### PR TITLE
Add addresses for JP arm9/overlay11 binaries

### DIFF
--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -6,6 +6,7 @@ arm9:
   address:
     NA: 0x2000000
     EU: 0x2000000
+    JP: 0x2000000
   length:
     NA: 0xB73F8
     EU: 0xB7D38

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -6,6 +6,7 @@ overlay11:
   address:
     NA: 0x22DC240
     EU: 0x22DCB80
+    JP: 0x22DD8E0
   length:
     NA: 0x48C40
     EU: 0x48E40


### PR DESCRIPTION
Taken from skytemple-files/pmd2data.xml. The binary lengths are
currently unknown.