### PR TITLE
Document the WTE format and its applications

### DIFF
--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -45,6 +45,10 @@ int GetMoveCritChance(struct move* move);
 bool IsRecoilMove(enum move_id move_id);
 bool IsPunchMove(enum move_id move_id);
 enum move_category GetMoveCategory(enum move_id move_id);
+void LoadWteFromRom(struct wte_handle* handle, char* path, uint32_t flags);
+void LoadWteFromFileDirectory(struct wte_handle* handle, uint16_t pack_file_id, uint16_t file_index,
+                              uint32_t malloc_flags);
+void UnloadWte(struct wte_handle* handle);
 void HandleSir0Translation(uint8_t** dst, uint8_t* src);
 void HandleSir0TranslationVeneer(uint8_t** dst, uint8_t* src);
 int GetLanguage(void);

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -78,16 +78,16 @@ struct wte_texture_params {
     enum texture_format format : 3;
     bool flip_x : 1;
     bool flip_y : 1;
-    uint8_t unusedD;
+    uint8_t unusedD : 3;
 };
 ASSERT_SIZE(struct wte_texture_params, 2);
 
 struct wte_header {
-    char signature[4]; // 0x0: Signature bytes (must be "\x57\x54\x45\x00")
-    void* texture; // 0x4
-    uint32_t texture_size; // 0x8
+    char signature[4];                // 0x0: Signature bytes (must be "\x57\x54\x45\x00")
+    void* texture;                    // 0x4
+    uint32_t texture_size;            // 0x8
     struct wte_texture_params params; // 0xC
-    uint16_t _padding_0xe; 
+    uint16_t _padding_0xe;
     /*  These bounds are NOT used by the game, but they prove useful to extract the texture out
         of the file. The offsets are redundant and should be zero
 
@@ -96,8 +96,8 @@ struct wte_header {
         needs to be a power of 2 in the range of 8..1024. The actual texture can have a lower
         height, but not a lower width, as the width is required to properly read the image */
     struct rect16_xywh texture_bounds; // 0x10
-    struct rgb* palette; // 0x18
-    uint16_t color_amt; // 0x1C: How many colors are stored in the palette
+    struct rgb* palette;               // 0x18
+    uint16_t color_amt;                // 0x1C: How many colors are stored in the palette
     uint16_t _padding_0x1e;
 };
 ASSERT_SIZE(struct wte_header, 32);

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -82,7 +82,7 @@ struct wte_header {
     struct wte_texture_params params;
     /*  These bounds are NOT used by the game, but they prove useful to extract the texture out
         of the file. The offsets are redundant and should be zero
-        
+
         The width specified here should always be the same as the one specified in the texture
         params, but the height may be lower. The reason is that just like the width, the height
         needs to be a power of 2 in the range of 8..1024. The actual texture can have a lower

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -22,13 +22,11 @@ struct rect16_xywh {
 ASSERT_SIZE(struct rect16_xywh, 8);
 
 // The fact the 4th byte is never used hints to the fact the struct is packed
-#pragma pack(push, 4)
 struct rgb {
-    int8_t r;
-    int8_t g;
-    int8_t b;
+    int32_t r : 8;
+    int32_t g : 8;
+    int32_t b : 8;
 };
-#pragma pack(pop)
 ASSERT_SIZE(struct rgb, 4);
 
 // A structure that represents a file stream for file I/O.
@@ -57,12 +55,12 @@ ASSERT_SIZE(struct file_stream, 72);
 // Struct used to load, store and unload WTE files
 struct wte_handle {
     void* content; // Pointer to the heap-allocated WTE data. Only stored for freeing the data
-    wte_header* header;
+    struct wte_header* header;
 };
 ASSERT_SIZE(struct wte_handle, 8);
 
 // These arguments are almost directly passed to the TEXIMAGE_PARAM register, just rearranged
-// For more information see 
+// For more information see:
 // https://problemkaputt.de/gbatek.htm#ds3dtextureattributes
 struct wte_texture_params {
     uint8_t texture_smult : 3;
@@ -80,16 +78,16 @@ struct wte_header {
     char signature[4]; // Signature bytes (must be "\x57\x54\x45\x00")
     void* texture;
     uint32_t texture_size;
-    wte_texture_params params;
-    /*  These bounds are NOT used by the game, but they prove useful to extract the texture out of the file. 
-        The offsets are redundant and should be 0
+    struct wte_texture_params params;
+    /*  These bounds are NOT used by the game, but they prove useful to extract the texture out
+        of the file. The offsets are redundant and should be zero
         
-        The width specified here should always be the same as the one specified in the texture params, 
-        but the height may be lower. The reason is that just like the width, the height needs to be a 
-        power of 2 in the range of 8..1024. The actual texture can have a lower height, but not a lower 
-        width, as the width is required to properly read and display the image */ 
-    rect16_xywh texture_bounds;
-    rgb* palette;
+        The width specified here should always be the same as the one specified in the texture
+        params, but the height may be lower. The reason is that just like the width, the height 
+        needs to be a power of 2 in the range of 8..1024. The actual texture can have a lower
+        height, but not a lower width, as the width is required to properly read the image */
+    struct rect16_xywh texture_bounds;
+    struct rgb* palette;
     uint16_t color_amt; // How many colors are stored in the palette
 };
 #pragma pack(pop)

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -22,12 +22,13 @@ struct rect16_xywh {
 ASSERT_SIZE(struct rect16_xywh, 8);
 
 // The fact the 4th byte is never used hints to the fact the struct is packed
-struct rgb {
-    int32_t r : 8;
-    int32_t g : 8;
-    int32_t b : 8;
+struct rgbx {
+    uint8_t r;
+    uint8_t b;
+    uint8_t g;
+    uint8_t x;
 };
-ASSERT_SIZE(struct rgb, 4);
+ASSERT_SIZE(struct rgbx, 4);
 
 // A structure that represents a file stream for file I/O.
 struct file_stream {
@@ -83,16 +84,15 @@ struct wte_header {
         of the file. The offsets are redundant and should be zero
         
         The width specified here should always be the same as the one specified in the texture
-        params, but the height may be lower. The reason is that just like the width, the height 
+        params, but the height may be lower. The reason is that just like the width, the height
         needs to be a power of 2 in the range of 8..1024. The actual texture can have a lower
         height, but not a lower width, as the width is required to properly read the image */
     struct rect16_xywh texture_bounds;
-    struct rgb* palette;
+    struct rgbx* palette;
     uint16_t color_amt; // How many colors are stored in the palette
 };
 #pragma pack(pop)
 ASSERT_SIZE(struct wte_header, 32);
-    
 
 // These flags are shared with the function to display text inside message boxes
 // So they might need a rename once more information is found

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -13,6 +13,24 @@ struct iovec {
 };
 ASSERT_SIZE(struct iovec, 8);
 
+struct rect16_xywh {
+    int16_t x;
+    int16_t y;
+    int16_t w;
+    int16_t h;
+};
+ASSERT_SIZE(struct rect16_xywh, 8);
+
+// The fact the 4th byte is never used hints to the fact the struct is packed
+#pragma pack(push, 4)
+struct rgb {
+    int8_t r;
+    int8_t g;
+    int8_t b;
+};
+#pragma pack(pop)
+ASSERT_SIZE(struct rgb, 4);
+
 // A structure that represents a file stream for file I/O.
 struct file_stream {
     undefined4 field_0x0;
@@ -35,6 +53,48 @@ struct file_stream {
     undefined4 field_0x44;
 };
 ASSERT_SIZE(struct file_stream, 72);
+
+// Struct used to load, store and unload WTE files
+struct wte_handle {
+    void* content; // Pointer to the heap-allocated WTE data. Only stored for freeing the data
+    wte_header* header;
+};
+ASSERT_SIZE(struct wte_handle, 8);
+
+// These arguments are almost directly passed to the TEXIMAGE_PARAM register, just rearranged
+// For more information see 
+// https://problemkaputt.de/gbatek.htm#ds3dtextureattributes
+struct wte_texture_params {
+    uint8_t texture_smult : 3;
+    uint8_t texture_tmult : 3;
+    uint8_t unused6 : 2;
+    enum texture_format format : 3;
+    bool flip_x : 1;
+    bool flip_y : 1;
+};
+ASSERT_SIZE(struct wte_texture_params, 2);
+
+// To accurately describe the structure of the header we need to enable packing
+#pragma pack(push, 4)
+struct wte_header {
+    char signature[4]; // Signature bytes (must be "\x57\x54\x45\x00")
+    void* texture;
+    uint32_t texture_size;
+    wte_texture_params params;
+    /*  These bounds are NOT used by the game, but they prove useful to extract the texture out of the file. 
+        The offsets are redundant and should be 0
+        
+        The width specified here should always be the same as the one specified in the texture params, 
+        but the height may be lower. The reason is that just like the width, the height needs to be a 
+        power of 2 in the range of 8..1024. The actual texture can have a lower height, but not a lower 
+        width, as the width is required to properly read and display the image */ 
+    rect16_xywh texture_bounds;
+    rgb* palette;
+    uint16_t color_amt; // How many colors are stored in the palette
+};
+#pragma pack(pop)
+ASSERT_SIZE(struct wte_header, 32);
+    
 
 // These flags are shared with the function to display text inside message boxes
 // So they might need a rename once more information is found

--- a/headers/types/common/enums.h
+++ b/headers/types/common/enums.h
@@ -44,6 +44,18 @@ enum overlay_group_id {
     OGROUP_OVERLAY_33 = 36,
 };
 
+// https://problemkaputt.de/gbatek.htm#ds3dtextureformats
+enum texture_format {
+    TEXFORMAT_NONE = 0,
+    TEXFORMAT_A3I5 = 1,
+    TEXFORMAT_4COLOR = 2,
+    TEXFORMAT_16COLOR = 3,
+    TEXFORMAT_256COLOR = 4,
+    TEXFORMAT_COMPRESSED = 5,
+    TEXFORMAT_A5I3 = 6,
+    TEXFORMAT_DIRECT = 7,
+}
+
 // Monster ID. Add 600 to get secondary genders.
 enum monster_id {
     MONSTER_NONE = 0,

--- a/headers/types/common/enums.h
+++ b/headers/types/common/enums.h
@@ -54,7 +54,7 @@ enum texture_format {
     TEXFORMAT_COMPRESSED = 5,
     TEXFORMAT_A5I3 = 6,
     TEXFORMAT_DIRECT = 7,
-}
+};
 
 // Monster ID. Add 600 to get secondary genders.
 enum monster_id {

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -386,6 +386,32 @@ arm9:
         
         r0: move ID
         return: move category enum
+    - name: LoadWteFromRom
+      address:
+        NA: 0x201DE4C
+      description: |-
+        Loads a SIR0-wrapped WTE file from ROM, and returns a handle to it
+
+        r0: [output] pointer to wte handle
+        r1: file path string
+        r2: load file flags
+    - name: LoadWteFromFileDirectory
+      address:
+        NA: 0x201DEC4
+      description: |-
+        Loads a SIR0-wrapped WTE file from a file directory, and returns a handle to it
+        
+        r0: [output] pointer to wte handle
+        r1: file directory id
+        r2: file index
+        r3: malloc flags
+    - name: UnloadWte
+      address:
+        NA: 0x201DF18
+      description: |-
+        Frees the buffer used to store the WTE data in the handle, and sets both pointers to null
+        
+        r0: pointer to wte handle
     - name: HandleSir0Translation
       address:
         NA: 0x201F4B4

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -391,7 +391,7 @@ arm9:
         NA: 0x201DE4C
       description: |-
         Loads a SIR0-wrapped WTE file from ROM, and returns a handle to it
-
+        
         r0: [output] pointer to wte handle
         r1: file path string
         r2: load file flags


### PR DESCRIPTION
The end goal should be to hopefully have a fully documented API of where and how the format is used, which considering how small it is, should be rather feasible. It might be so simple in fact that it could serve as a subject for a tutorial / guide! But that's to be discussed and resolved later