### PR TITLE
Don't pack structs by default

### DIFF
--- a/.github/workflows/check-headers.yml
+++ b/.github/workflows/check-headers.yml
@@ -19,7 +19,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Compile
-        run: make -C headers
+        run: make -C headers headers-aligned
+  implicit-padding-check:
+    runs-on: ubuntu-latest
+    needs: compile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Compile with implicit packing
+        run: make -C headers headers-packed
   format-check:
     runs-on: ubuntu-latest
     steps:

--- a/headers/Makefile
+++ b/headers/Makefile
@@ -9,10 +9,23 @@ else
 $(error C compiler not found)
 endif
 
+# Compile headers
+# Structs constrained by ASSERT_SIZE can only compile under both natural
+# alignment and packing if there is no implicit padding between members.
 .PHONY: headers
-headers:
+headers: headers-aligned headers-packed
+
+# Compile headers with natural struct member alignment by default
+.PHONY: headers-aligned
+headers-aligned:
 # -mno-ms-bitfields is needed for some Windows builds, e.g., MinGW's gcc/clang
 	$(CC) -m32 -fsyntax-only -mno-ms-bitfields pmdsky.h
+
+# Compile headers with implicit packing by default
+.PHONY: headers-packed
+headers-packed:
+# -mno-ms-bitfields is needed for some Windows builds, e.g., MinGW's gcc/clang
+	$(CC) -m32 -fsyntax-only -mno-ms-bitfields -DIMPLICIT_STRUCT_PACKING pmdsky.h
 
 .PHONY: format
 format:

--- a/headers/pmdsky.h
+++ b/headers/pmdsky.h
@@ -49,8 +49,29 @@ typedef uint16_t undefined2;
 typedef uint32_t undefined4;
 typedef undefined1 undefined;
 
-// All structs are assumed to be packed. If padding is desired, it must be defined explicitly
+#ifdef IMPLICIT_STRUCT_PACKING
+// In implicit packing mode, all structs are packed by default.
+// If padding is desired, it must be defined explicitly.
 #pragma pack(1)
+#endif
+
+// A wrapper struct for an enum stored as an 8-bit integer.
+// For some `enum foo_id`, ENUM_8_BIT(foo_id) will define `struct foo_id_8`.
+// This should only be used within `#pragma pack(push, 1)`.
+#define ENUM_8_BIT(tag)                                                                            \
+    struct tag##_8 {                                                                               \
+        enum tag val : 8;                                                                          \
+    };                                                                                             \
+    ASSERT_SIZE(struct tag##_8, 1)
+
+// A wrapper struct for an enum stored as a 16-bit integer.
+// For some `enum foo_id`, ENUM_16_BIT(foo_id) will define `struct foo_id_16`.
+// This should only be used within `#pragma pack(push, 2)`.
+#define ENUM_16_BIT(tag)                                                                           \
+    struct tag##_16 {                                                                              \
+        enum tag val : 16;                                                                         \
+    };                                                                                             \
+    ASSERT_SIZE(struct tag##_16, 2)
 
 // Now include the actual type definitions and function signatures
 #include "types/types.h"

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -123,7 +123,7 @@ ASSERT_SIZE(struct mem_arena_getters, 8);
 // This seems to be a simple structure used with utility functions related to managing items in
 // the player's bag and storage.
 struct owned_item {
-    enum item_id id : 16;
+    struct item_id_16 id;
     uint16_t amount; // Probably? This is a guess
 };
 ASSERT_SIZE(struct owned_item, 4);
@@ -186,6 +186,7 @@ ASSERT_SIZE(struct wte_handle, 8);
 // These arguments are almost directly passed to the TEXIMAGE_PARAM register, just rearranged
 // For more information see:
 // https://problemkaputt.de/gbatek.htm#ds3dtextureattributes
+#pragma pack(push, 2)
 struct wte_texture_params {
     uint8_t texture_smult : 3;
     uint8_t texture_tmult : 3;
@@ -196,6 +197,7 @@ struct wte_texture_params {
     uint8_t unusedD : 3;
 };
 ASSERT_SIZE(struct wte_texture_params, 2);
+#pragma pack(pop)
 
 struct wte_header {
     char signature[4];                // 0x0: Signature bytes (must be "\x57\x54\x45\x00")
@@ -238,11 +240,6 @@ struct preprocessor_args {
 };
 ASSERT_SIZE(struct preprocessor_args, 80);
 
-struct type_matchup_16 {
-    enum type_matchup val : 16;
-};
-ASSERT_SIZE(struct type_matchup_16, 2);
-
 // Type matchup table, not including TYPE_NEUTRAL.
 // Note that Ghost's immunities seem to be hard-coded elsewhere. In this table, both Normal and
 // Fighting are encoded as neutral against Ghost.
@@ -257,19 +254,21 @@ ASSERT_SIZE(struct type_matchup_table, 648);
 
 // In the move data, the target and range are encoded together in the first byte of a single
 // two-byte field. The target is the lower half, and the range is the upper half.
+#pragma pack(push, 2)
 struct move_target_and_range {
-    enum move_target : 4;
-    enum move_range : 4;
-    enum healing_move_type : 4;
+    enum move_target target : 4;
+    enum move_range range : 4;
+    enum healing_move_type type : 4;
     uint16_t unused : 4; // At least I'm pretty sure this is unused...
 };
 ASSERT_SIZE(struct move_target_and_range, 2);
+#pragma pack(pop)
 
 // Data for a single move
 struct move_data {
     uint16_t base_power;                          // 0x0
-    enum type_id type : 8;                        // 0x2
-    enum move_category category : 8;              // 0x3
+    struct type_id_8 type;                        // 0x2
+    struct move_category_8 category;              // 0x3
     struct move_target_and_range target_range;    // 0x4
     struct move_target_and_range ai_target_range; // 0x6: Target/range as seen by the AI
     uint8_t pp;                                   // 0x8
@@ -290,7 +289,7 @@ struct move_data {
     bool usable_while_taunted; // 0x14
     // 0x15: Index in the string files of the range string to be displayed in the move info screen
     uint8_t range_string_idx;
-    enum move_id id : 16; // 0x16
+    struct move_id_16 id; // 0x16
     // 0x18: Index in the string files of the message string to be displayed in the dungeon message
     // log when a move is used. E.g., the default (0) is "[User] used [move]!"
     uint16_t message_string_idx;

--- a/headers/types/common/enums.h
+++ b/headers/types/common/enums.h
@@ -674,6 +674,11 @@ enum monster_id {
     MONSTER_RESERVE_45 = 599,
 };
 
+// This is usually stored as a 16-bit integer
+#pragma pack(push, 2)
+ENUM_16_BIT(monster_id);
+#pragma pack(pop)
+
 // Item ID
 enum item_id {
     ITEM_NOTHING = 0,
@@ -2078,6 +2083,11 @@ enum item_id {
     ITEM_UNNAMED_0x577 = 1399,
 };
 
+// This is usually stored as a 16-bit integer
+#pragma pack(push, 2)
+ENUM_16_BIT(item_id);
+#pragma pack(pop)
+
 // Type ID
 enum type_id {
     TYPE_NONE = 0,
@@ -2101,12 +2111,22 @@ enum type_id {
     TYPE_NEUTRAL = 18,
 };
 
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(type_id);
+#pragma pack(pop)
+
 enum type_matchup {
     MATCHUP_IMMUNE = 0,
     MATCHUP_NOT_VERY_EFFECTIVE = 1,
     MATCHUP_NEUTRAL = 2,
     MATCHUP_SUPER_EFFECTIVE = 3,
 };
+
+// This is usually stored as a 16-bit integer
+#pragma pack(push, 2)
+ENUM_16_BIT(type_matchup);
+#pragma pack(pop)
 
 // Move ID
 enum move_id {
@@ -2671,6 +2691,11 @@ enum move_id {
     MOVE_TAG_0x22E = 558,
 };
 
+// This is usually stored as a 16-bit integer
+#pragma pack(push, 2)
+ENUM_16_BIT(move_id);
+#pragma pack(pop)
+
 // Move category
 enum move_category {
     CATEGORY_PHYSICAL = 0,
@@ -2678,6 +2703,11 @@ enum move_category {
     CATEGORY_STATUS = 2,
     CATEGORY_NONE = 3, // this is a guess
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(move_category);
+#pragma pack(pop)
 
 // Move range.
 // In the move data, this is the upper 4 bits of the joint Range + Target bitfield
@@ -2849,6 +2879,11 @@ enum ability_id {
     ABILITY_STORM_DRAIN = 122,
     ABILITY_LEAF_GUARD = 123,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(ability_id);
+#pragma pack(pop)
 
 // Dungeon ID.
 // Each "section" of what we would normally consider "one dungeon" has its own ID. Many of the
@@ -3112,6 +3147,16 @@ enum dungeon_id {
     DUNGEON_DUMMY_0xFF = 255,
 };
 
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(dungeon_id);
+#pragma pack(pop)
+
+// This is occasionally stored as a 16-bit integer
+#pragma pack(push, 2)
+ENUM_16_BIT(dungeon_id);
+#pragma pack(pop)
+
 // Dungeon group ID.
 // This is more in line with what we would think of as a "whole dungeon".
 // A single dungeon group might encompass multiple dungeon IDs.
@@ -3217,6 +3262,11 @@ enum dungeon_group_id {
     DGROUP_DUMMY_0x62 = 98,
     DGROUP_DUMMY_0x63 = 99,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(dungeon_group_id);
+#pragma pack(pop)
 
 // Music/song IDs. Some background SFX are also stored as "songs".
 enum music_id {
@@ -3425,6 +3475,11 @@ enum music_id {
     MUSIC_TEAM_CHARMS_THEME_ALTERNATE_2_UNUSED = 202,
     MUSIC_NONE_0x3E7 = 999,
 };
+
+// This is usually stored as a 16-bit integer
+#pragma pack(push, 2)
+ENUM_16_BIT(music_id);
+#pragma pack(pop)
 
 // IQ skill ID. These are usually encoded as bitvectors.
 enum iq_skill_id {

--- a/headers/types/dungeon_mode/dungeon.h
+++ b/headers/types/dungeon_mode/dungeon.h
@@ -1873,9 +1873,9 @@ struct dungeon {
     undefined field_0x745;
     undefined field_0x746;
     undefined field_0x747;
-    enum dungeon_id id : 8;             // 0x748
+    struct dungeon_id_8 id;             // 0x748
     uint8_t floor;                      // 0x749: Current floor number
-    enum dungeon_group_id group_id : 8; // 0x74A: Same for different segments of a dungeon
+    struct dungeon_group_id_8 group_id; // 0x74A: Same for different segments of a dungeon
     undefined field_0x74b;
     undefined field_0x74c;
     undefined field_0x74d;
@@ -1932,7 +1932,7 @@ struct dungeon {
     undefined field_0x795;
     undefined field_0x796;
     undefined field_0x797;
-    enum dungeon_objective dungeon_objective : 8; // 0x798: Objective of the current dungeon
+    struct dungeon_objective_8 dungeon_objective; // 0x798: Objective of the current dungeon
     undefined field_0x799;
     undefined field_0x79a;
     uint8_t rescue_attempts_left; // 0x79B: Number of times you can be rescued in this dungeon
@@ -4472,10 +4472,10 @@ struct dungeon {
     undefined field_0xcd35;
     undefined field_0xcd36;
     undefined field_0xcd37;
-    enum weather_id weather : 8; // 0xCD38: current weather
+    struct weather_id_8 weather; // 0xCD38: current weather
     // 0xCD39: Default weather on the floor that will be reverted to if the current weather is
     // artificial and ends
-    enum weather_id natural_weather : 8;
+    struct weather_id_8 natural_weather;
     // 0xCD3A: Turns left for each weather type in enum weather_id (except WEATHER_RANDOM). If
     // multiple of these are nonzero, the one with the highest number of turns left is chosen.
     // Ties are broken in enum order
@@ -22476,8 +22476,8 @@ struct dungeon {
     undefined field_0x1a250;
     bool is_turning; // 0x1A251: Player is pressing Y to turn on the spot
     // Derived from internal direction in leader info block
-    enum direction_id leader_target_direction : 8;        // 0x1A252
-    enum direction_id leader_target_direction_mirror : 8; // 0x1A253
+    struct direction_id_8 leader_target_direction;        // 0x1A252
+    struct direction_id_8 leader_target_direction_mirror; // 0x1A253
     undefined field_0x1a254;
     undefined field_0x1a255;
     undefined field_0x1a256;
@@ -98113,7 +98113,7 @@ struct dungeon {
     undefined field_0x2c9e7;
     // 0x2C9E8: ID of an item guaranteed to spawn on the floor, if applicable
     // (e.g., certain mission types)
-    enum item_id guaranteed_item_id : 16;
+    struct item_id_16 guaranteed_item_id;
     undefined field_0x2c9ea;
     undefined field_0x2c9eb;
     undefined field_0x2c9ec;

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -27,13 +27,13 @@ struct item {
     // 0x2: Only for stackable items. Will be 0 if unapplicable. For Poké, this is an "amount code"
     // rather than the literal amount
     uint16_t quantity;
-    enum item_id id : 16; // 0x4
+    struct item_id_16 id; // 0x4
 };
 ASSERT_SIZE(struct item, 6);
 
 // Trap info
 struct trap {
-    enum trap_id id : 8;
+    struct trap_id_8 id;
     // If 0 or 2, the trap will activate only when a team member steps on it. If 1, the trap will
     // activate only when an enemy steps on it. Naturally, this seems to be 0 for traps and 2 for
     // Wonder Tiles
@@ -69,7 +69,7 @@ struct move {
     bool f_exclusive_item_pp_boost : 1; // A PP-boosting exclusive item is in effect
     uint16_t flags3_unk10 : 6;
 
-    enum move_id id : 16; // 0x4
+    struct move_id_16 id; // 0x4
     uint8_t pp;           // 0x6: Current PP
     uint8_t ginseng;      // 0x7: Ginseng boost
 };
@@ -97,6 +97,7 @@ ASSERT_SIZE(struct monster_stat_modifiers, 32);
 // Many fields are indexes that select from a group of status conditions. These fields are named
 // by the FIRST status in the list (when the index is 1, since 0 usually means no status). For other
 // statuses in the group, see the subsequent enum values in enum status_id after the first status.
+#pragma pack(push, 1)
 struct statuses {
     bool roost;
     uint8_t field_0x1; // Set by Roost to 0x2
@@ -117,7 +118,7 @@ struct statuses {
     undefined field_0x10;
     undefined field_0x11;
     undefined field_0x12;
-    enum monster_behavior monster_behavior : 8; // 0x13
+    struct monster_behavior_8 monster_behavior; // 0x13
     uint8_t sleep;                              // 0x14: STATUS_SLEEP if 1
     uint8_t sleep_turns; // 0x15: Turns left for the status in statuses::sleep
     uint8_t burn;        // 0x16: STATUS_BURN if 1
@@ -216,6 +217,7 @@ struct statuses {
     uint8_t stockpile_stage;        // 0x75: Goes from 0-3. STATUS_STOCKPILING if nonzero
 };
 ASSERT_SIZE(struct statuses, 118);
+#pragma pack(pop)
 
 // Monster info
 struct monster {
@@ -227,13 +229,13 @@ struct monster {
     uint16_t flags_unk10 : 5;
     bool f_swapping_places_petrified_ally : 1; // Swapping places with a petrified ally
 
-    enum monster_id id : 16;          // 0x2:
-    enum monster_id apparent_id : 16; // 0x4: What's outwardly displayed if Transformed
+    struct monster_id_16 id;          // 0x2:
+    struct monster_id_16 apparent_id; // 0x4: What's outwardly displayed if Transformed
     bool is_not_team_member; // 0x6: true for enemies and allied NPCs that aren't on the team
     bool is_team_leader;     // 0x7
     // 0x8: An ally is an NPC that isn't a normal team member, e.g. for story boss battles
     bool is_ally;
-    enum shopkeeper_mode shopkeeper : 8; // 0x9
+    struct shopkeeper_mode_8 shopkeeper; // 0x9
     uint8_t level;                       // 0xA
     undefined field_0xb;
     int16_t team_index;  // 0xC: In order by team lineup
@@ -254,12 +256,12 @@ struct monster {
     int exp;                                      // 0x20: Total Exp. Points
     struct monster_stat_modifiers stat_modifiers; // 0x24
     int16_t hidden_power_base_power;              // 0x44
-    enum type_id hidden_power_type : 8;           // 0x46
+    struct type_id_8 hidden_power_type;           // 0x46
     undefined field_0x47;
-    enum dungeon_id joined_at : 8; // 0x48: Also used as a unique identifier for special monsters
+    struct dungeon_id_8 joined_at; // 0x48: Also used as a unique identifier for special monsters
     undefined field_0x49;
     uint16_t action_id;              // 0x4A: Changes as you do things
-    enum direction_id direction : 8; // 0x4C: Current direction the monster is facing
+    struct direction_id_8 direction; // 0x4C: Current direction the monster is facing
     undefined field_0x4d;
     // 0x4E: Metadata for some action_id values.
     // E.g., this is the bag item index when using an item
@@ -278,10 +280,10 @@ struct monster {
     undefined field_0x5b;
     undefined field_0x5c;
     undefined field_0x5d;
-    enum type_id type1 : 8;       // 0x5E
-    enum type_id type2 : 8;       // 0x5F
-    enum ability_id ability1 : 8; // 0x60
-    enum ability_id ability2 : 8; // 0x61
+    struct type_id_8 type1;       // 0x5E
+    struct type_id_8 type2;       // 0x5F
+    struct ability_id_8 ability1; // 0x60
+    struct ability_id_8 ability2; // 0x61
     struct item held_item;        // 0x62
     uint16_t held_item_id;        // 0x68: Appears to be a mirror of held_item.id
     // Previous position data is used by the AI
@@ -291,7 +293,7 @@ struct monster {
     struct position prev_pos4; // 0x76: Position 4 turns ago
     undefined field_0x7a;
     undefined field_0x7b;
-    enum ai_objective ai_objective : 8; // 0x7C
+    struct ai_objective_8 ai_objective; // 0x7C
     bool ai_not_next_to_target;         // 0x7D: This NPC monster is not next to its current target
     bool ai_targeting_enemy;            // 0x7E: This NPC monster is targeting an enemy monster
     bool ai_turning_around;             // 0x7F: This NPC monster has decided to turn around
@@ -310,7 +312,7 @@ struct monster {
     // 0x9C: First 9 bytes contain bitfield data; the rest is presumably padding.
     // Bitvector. See enum iq_skill_id for the meaning of each bit.
     uint32_t iq_skill_flags[3];
-    enum tactic_id tactic : 8; // 0xA8
+    struct tactic_id_8 tactic; // 0xA8
     struct statuses statuses;  // 0xA9
     undefined field_0x11f;
     undefined field_0x120;
@@ -546,7 +548,7 @@ ASSERT_SIZE(struct monster, 576);
 
 // Generic entity data
 struct entity {
-    enum entity_type type : 32; // 0x0
+    enum entity_type type;      // 0x0
     struct position pos;        // 0x4
     struct position prev_pos;   // 0x8
     int pixel_x_shifted;        // 0xC: pixel_x << 8
@@ -664,7 +666,7 @@ struct entity {
     undefined field_0xa1;
     undefined field_0xa2;
     undefined field_0xa3;
-    enum direction_id graphical_direction_mirror1 : 8; // 0xA4
+    struct direction_id_8 graphical_direction_mirror1; // 0xA4
     undefined field_0xa5;
     undefined field_0xa6;
     undefined field_0xa7;
@@ -676,8 +678,8 @@ struct entity {
     undefined field_0xad;
     uint8_t anim_id;                           // 0xAE: Maybe?
     uint8_t anim_id_mirror;                    // 0xAF
-    enum direction_id graphical_direction : 8; // 0xB0: Direction a monster's sprite is facing
-    enum direction_id graphical_direction_mirror0 : 8; // 0xB1
+    struct direction_id_8 graphical_direction; // 0xB0: Direction a monster's sprite is facing
+    struct direction_id_8 graphical_direction_mirror0; // 0xB1
     undefined field_0xb2;
     undefined field_0xb3;
     void* info; // 0xB4: Points to info struct for monster/item/trap
@@ -791,7 +793,7 @@ struct dungeon_generation_info {
     uint8_t monster_house_room;
     undefined field_0x6;
     undefined field_0x7;
-    enum hidden_stairs_type hidden_stairs_type : 32; // 0x8
+    enum hidden_stairs_type hidden_stairs_type; // 0x8
     undefined field_0xc;
     undefined field_0xd;
     undefined field_0xe;
@@ -802,7 +804,7 @@ struct dungeon_generation_info {
     uint16_t music_table_idx;
     undefined field_0x14;
     undefined field_0x15;
-    enum fixed_room_id fixed_room_id : 8; // 0x16
+    struct fixed_room_id_8 fixed_room_id; // 0x16
     undefined field_0x17;
     undefined field_0x18;
     undefined field_0x19;
@@ -863,7 +865,7 @@ struct floor_generation_status {
     bool has_kecleon_shop;                // 0x3: This floor has a Kecleon Shop
     bool has_chasms_as_secondary_terrain; // 0x4: Secondary terrain type is SECONDARY_TERRAIN_CHASM
     bool is_invalid;                      // 0x5: Set when floor generation fails
-    enum floor_size floor_size : 8;       // 0x6
+    struct floor_size_8 floor_size;       // 0x6
     bool has_maze;                        // 0x7: This floor has a maze room
     bool no_enemy_spawns;                 // 0x8: No enemies should spawn on this floor
     undefined field_0x9;
@@ -887,8 +889,8 @@ struct floor_generation_status {
     uint16_t kecleon_shop_middle_y; // 0x22
     // 0x24: The number of tiles that can be reached from the stairs, assuming normal mobility
     int n_tiles_reachable_from_stairs;
-    enum floor_layout layout : 32;                   // 0x28
-    enum hidden_stairs_type hidden_stairs_type : 32; // 0x2C
+    enum floor_layout layout;                   // 0x28
+    enum hidden_stairs_type hidden_stairs_type; // 0x2C
     // The limits of the Kecleon Shop, if applicable
     int kecleon_shop_min_x; // 0x30
     int kecleon_shop_min_y; // 0x34
@@ -905,20 +907,15 @@ struct spawn_position {
 };
 ASSERT_SIZE(struct spawn_position, 2);
 
-struct monster_id_16 {
-    enum monster_id id : 16;
-};
-ASSERT_SIZE(struct monster_id_16, 2);
-
 // Dungeon floor properties
 struct floor_properties {
-    enum floor_layout layout : 8; // 0x0
+    struct floor_layout_8 layout; // 0x0
     int8_t n_rooms;               // 0x1: Number of rooms to be generated
     uint8_t tileset;              // 0x2
     // 0x3: Indexes into the music ID table in overlay 10 to determine the floor's music track.
     // See the relevant descriptions in the overlay 10 symbols for more information.
     uint8_t music_table_idx;
-    enum weather_id weather : 8; // 0x4
+    struct weather_id_8 weather; // 0x4
     // 0x5: Controls how many connections will be made between grid cells
     uint8_t floor_connectivity;
     uint8_t enemy_density;              // 0x6: Controls how many enemies will be spawned
@@ -942,13 +939,13 @@ struct floor_properties {
     uint8_t item_density; // 0xF: Controls how many items will be spawned
     uint8_t trap_density; // 0x10: Controls how many traps will be spawned
     uint8_t floor_number; // 0x11: The current floor number within the overall dungeon
-    enum fixed_room_id fixed_room_id : 8; // 0x12
+    struct fixed_room_id_8 fixed_room_id; // 0x12
     uint8_t extra_hallways;               // 0x13: Number of extra hallways to generate
     uint8_t buried_item_density; // 0x14: Controls how many buried items (in walls) will be spawned
     // 0x15: Controls how much secondary terrain (water, lava, and this actually applies to chasms
     // too) will be spawned
     uint8_t secondary_terrain_density;
-    enum darkness_level darkness_level : 8; // 0x16
+    struct darkness_level_8 darkness_level; // 0x16
     uint8_t max_money_amount_div_5;         // 0x17: 1/5 the maximum amount for Poké spawns
     undefined field_0x18;
     // 0x19: Chance that a Monster House will be an itemless one
@@ -966,16 +963,16 @@ ASSERT_SIZE(struct floor_properties, 32);
 // Info about a mission destination floor
 struct mission_destination_info {
     bool is_destination_floor;  // 0x0: Whether or not the current floor is a mission destination
-    enum mission_type type : 8; // 0x1:
+    struct mission_type_8 type; // 0x1:
     // 0x2: The meaning of this field depends on the type field; see union mission_subtype.
     uint8_t subtype;
     undefined field_0x3;
     // 0x4: Item to retrieve, if this is an item-retrieval mission
-    enum item_id item_to_retrieve : 16;
-    enum item_id item_to_deliver : 16;     // 0x6: Item to deliver to the client, if relevant
-    enum item_id special_target_item : 16; // 0x8: For Sealed Chamber and Treasure Memo missions
-    enum monster_id client : 16;           // 0xA: The client on the mission listing
-    enum monster_id rescue_target : 16;    // 0xC: The monster to be rescued
+    struct item_id_16 item_to_retrieve;
+    struct item_id_16 item_to_deliver;     // 0x6: Item to deliver to the client, if relevant
+    struct item_id_16 special_target_item; // 0x8: For Sealed Chamber and Treasure Memo missions
+    struct monster_id_16 client;           // 0xA: The client on the mission listing
+    struct monster_id_16 rescue_target;    // 0xC: The monster to be rescued
     // 0xE: Usually just the target to defeat. If an outlaw has minions, the monster IDs will be
     // listed in subsequent entries. Note that there can be multiple minions of the same species,
     // which is not reflected here.
@@ -984,7 +981,7 @@ struct mission_destination_info {
     undefined field_0x15;
     // 0x16: Fixed room ID of the destination floor, if relevant
     // (e.g., Chambers, Challenge Letters, etc.)
-    enum fixed_room_id fixed_room_id : 8;
+    struct fixed_room_id_8 fixed_room_id;
     undefined field_0x17;
     undefined field_0x18;
     undefined field_0x19;
@@ -1035,7 +1032,7 @@ ASSERT_SIZE(struct dungeon_restriction, 12);
 
 // Entry in the fixed room item spawn table
 struct fixed_room_item_spawn_entry {
-    enum item_id id : 16;
+    struct item_id_16 id;
     undefined field_0x2;
     undefined field_0x3;
     undefined field_0x4;
@@ -1047,9 +1044,9 @@ ASSERT_SIZE(struct fixed_room_item_spawn_entry, 8);
 
 // Entry in the fixed room monster spawn table
 struct fixed_room_monster_spawn_entry {
-    enum monster_id id : 16;
+    struct monster_id_16 id;
     uint8_t stat_table_idx; // Index into the fixed room monster spawn stats table
-    enum monster_behavior behavior : 8;
+    struct monster_behavior_8 behavior;
 };
 ASSERT_SIZE(struct fixed_room_monster_spawn_entry, 4);
 
@@ -1070,7 +1067,7 @@ ASSERT_SIZE(struct fixed_room_monster_spawn_stats_entry, 12);
 // Entry in the fixed room properties table
 struct fixed_room_properties_entry {
     // 0x0: If MUSIC_NONE_0x0, the music will be taken from the mappa file for the floor
-    enum music_id music : 16;
+    struct music_id_16 music;
     undefined field_0x2;
     undefined field_0x3;
     bool illuminated; // 0x4: Floor will be fully illuminated (darkness level DARKNESS_BRIGHT)
@@ -1090,7 +1087,7 @@ ASSERT_SIZE(struct fixed_room_properties_entry, 12);
 
 // Entry in the fixed room tile spawn table.
 struct fixed_room_tile_spawn_entry {
-    enum trap_id id : 8; // 0x0
+    struct trap_id_8 id; // 0x0
     uint8_t flags;       // 0x1: Copied into trap::flags
     uint8_t room;        // 0x2: Room ID, or 0xFF for hallways
     // 0x3: flags3: 1-byte bitfield
@@ -1109,11 +1106,6 @@ struct fixed_room_entity_spawn_entry {
 };
 ASSERT_SIZE(struct fixed_room_entity_spawn_entry, 12);
 
-struct move_id_16 {
-    enum move_id : 16;
-};
-ASSERT_SIZE(struct move_id_16, 2);
-
 // Data for guest monsters that join you during certain story dungeons.
 // These all directly correspond to fields in struct monster.
 struct guest_monster {
@@ -1121,8 +1113,8 @@ struct guest_monster {
     undefined field_0x1;
     undefined field_0x2;
     undefined field_0x3;
-    enum monster_id id : 16;       // 0x4
-    enum dungeon_id joined_at : 8; // 0x6
+    struct monster_id_16 id;       // 0x4
+    struct dungeon_id_8 joined_at; // 0x6
     undefined field_0x7;
     struct move_id_16 moves[4]; // 0x8
     int16_t max_hp;             // 0x10

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -16,6 +16,11 @@ enum direction_id {
     DIR_CURRENT = 8, // Current direction of an entity. Used as a special value in some functions
 };
 
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(direction_id);
+#pragma pack(pop)
+
 // Terrain type for a tile
 enum terrain_type {
     TERRAIN_WALL = 0,
@@ -30,6 +35,11 @@ enum secondary_terrain_type {
     SECONDARY_TERRAIN_LAVA = 1,
     SECONDARY_TERRAIN_CHASM = 2,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(secondary_terrain_type);
+#pragma pack(pop)
 
 // Mobility types for monsters
 enum mobility_type {
@@ -81,6 +91,11 @@ enum trap_id {
     TRAP_RANDOM_TRAP = 23,
     TRAP_GRUDGE_TRAP = 24,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(trap_id);
+#pragma pack(pop)
 
 // The type of hidden stairs (i.e. where it leads), if present
 enum hidden_stairs_type {
@@ -223,6 +238,11 @@ enum tactic_id {
     TACTIC_GET_AWAY_FROM_HERE = 10,
 };
 
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(tactic_id);
+#pragma pack(pop)
+
 // Modes related to shopkeeper behavior
 enum shopkeeper_mode {
     SHOPKEEPER_MODE_NORMAL = 0,
@@ -230,6 +250,11 @@ enum shopkeeper_mode {
     SHOPKEEPER_MODE_ATTACK_ENEMIES = 2,
     SHOPKEEPER_MODE_ATTACK_TEAM = 3,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(shopkeeper_mode);
+#pragma pack(pop)
 
 // Behavior type of NPC monsters
 enum monster_behavior {
@@ -257,6 +282,11 @@ enum monster_behavior {
     BEHAVIOR_WANDERING_ENEMY_0x15 = 21,
 };
 
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(monster_behavior);
+#pragma pack(pop)
+
 // AI objective that controls how an AI acts in the moment.
 // These were probably taken from Rescue Team; need to confirm validity in Explorers.
 enum ai_objective {
@@ -269,6 +299,11 @@ enum ai_objective {
     AI_STAND_STILL = 6,
     AI_TAKE_ITEM = 7,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(ai_objective);
+#pragma pack(pop)
 
 // Exclusive effect ID. These are usually encoded as bitvectors.
 // Some of these are unused in-game but still labeled if easy to infer.
@@ -414,6 +449,11 @@ enum darkness_level {
     DARKNESS_DARK = 2,
 };
 
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(darkness_level);
+#pragma pack(pop)
+
 // Weather ID
 enum weather_id {
     WEATHER_CLEAR = 0,
@@ -426,6 +466,11 @@ enum weather_id {
     WEATHER_SNOW = 7,
     WEATHER_RANDOM = 8,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(weather_id);
+#pragma pack(pop)
 
 // Dungeon floor type
 enum floor_type {
@@ -440,6 +485,11 @@ enum dungeon_objective {
     OBJECTIVE_NORMAL = 1,
     OBJECTIVE_RESCUE = 2, // Rescuing another player
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(dungeon_objective);
+#pragma pack(pop)
 
 // Mission type on a floor
 enum mission_type {
@@ -457,6 +507,11 @@ enum mission_type {
     MISSION_CHALLENGE_REQUEST = 11,
     MISSION_TREASURE_MEMO = 12,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(mission_type);
+#pragma pack(pop)
 
 // Mission subtype for MISSION_EXPLORE_WITH_CLIENT
 enum mission_subtype_explore {
@@ -766,12 +821,22 @@ enum fixed_room_id {
     FIXED_UNUSED_0xFF = 255,
 };
 
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(fixed_room_id);
+#pragma pack(pop)
+
 // Floor layout size during floor generation
 enum floor_size {
     FLOOR_SIZE_LARGE = 0,
     FLOOR_SIZE_SMALL = 1,
     FLOOR_SIZE_MEDIUM = 2,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(floor_size);
+#pragma pack(pop)
 
 // Floor layout type during floor generation
 enum floor_layout {
@@ -792,5 +857,10 @@ enum floor_layout {
     LAYOUT_UNUSED_0xE = 14,
     LAYOUT_UNUSED_0xF = 15,
 };
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(floor_layout);
+#pragma pack(pop)
 
 #endif

--- a/headers/types/ground_mode/enums.h
+++ b/headers/types/ground_mode/enums.h
@@ -1312,6 +1312,11 @@ enum common_routine_id {
     ROUTINE_MAP_TEST = 700,
 };
 
+// This is usually stored as a 16-bit integer
+#pragma pack(push, 2)
+ENUM_16_BIT(common_routine_id);
+#pragma pack(pop)
+
 // Script entity IDs. While a few script entities differ between versions, the IDs are the same.
 enum script_entity_id {
     ENTITY_PLAYER = 0,

--- a/headers/types/ground_mode/ground_mode.h
+++ b/headers/types/ground_mode/ground_mode.h
@@ -77,7 +77,7 @@ ASSERT_SIZE(struct script_opcode_table, 3064);
 
 // Common routines used within the unionall.ssb script (the master script).
 struct common_routine {
-    enum common_routine_id id : 16;
+    struct common_routine_id_16 id;
     int16_t field_0x2;
     char* name; // Routine name as a null-terminated string
 };

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -1438,7 +1438,7 @@ arm9:
       description: |-
         Null-terminated list of all the recoil moves, as 2-byte move IDs.
         
-        type: {enum move_id:16}[11]
+        type: struct move_id_16[11]
     - name: PUNCH_MOVE_LIST
       address:
         NA: 0x2098D8A
@@ -1447,7 +1447,7 @@ arm9:
       description: |-
         Null-terminated list of all the punch moves, as 2-byte move IDs.
         
-        type: {enum move_id:16}[16]
+        type: struct move_id_16[16]
     - name: SCRIPT_VARS_LOCALS
       address:
         NA: 0x209CECC
@@ -1615,7 +1615,7 @@ arm9:
         
         This is an array of 200 bytes. Each byte is an enum corresponding to one dungeon.
         
-        type: {enum secondary_terrain_type:8}[200]
+        type: struct secondary_terrain_type_8[200]
     - name: SENTRY_MINIGAME_DATA
       address:
         NA: 0x20A1BB0
@@ -1864,7 +1864,7 @@ arm9:
       description: |-
         The default monster ID for the hero (0x4: Charmander)
         
-        type: enum monster_id:16
+        type: struct monster_id_16
     - name: DEFAULT_PARTNER_ID
       address:
         NA: 0x20AFEFE
@@ -1875,7 +1875,7 @@ arm9:
       description: |-
         The default monster ID for the partner (0x1: Bulbasaur)
         
-        type: enum monster_id:16
+        type: struct monster_id_16
     - name: GAME_MODE
       address:
         NA: 0x20AFF70

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -32,7 +32,7 @@ overlay10:
       description: |-
         The first dungeon that can have extra traps spawn in Monster Houses, Dark Hill
         
-        type: enum dungeon_id:8
+        type: struct dungeon_id_8
     - name: BAD_POISON_DAMAGE_COOLDOWN
       address:
         NA: 0x22C4414
@@ -302,7 +302,7 @@ overlay10:
         
         This is a table with 30 rows, each with 4 2-byte music IDs. Each row contains the possible music IDs for a given group, from which the music track will be selected randomly.
         
-        type: {enum music_id:16}[30][4]
+        type: struct music_id_16[30][4]
     - name: MALE_ACCURACY_STAGE_MULTIPLIERS
       address:
         NA: 0x22C540C
@@ -339,7 +339,7 @@ overlay10:
         
         This is an array of 170 2-byte music IDs, and is indexed into by the music value in the floor properties struct for a given floor. Music IDs with the highest bit set (0x8000) are indexes into the RANDOM_MUSIC_ID_TABLE.
         
-        type: {enum music_id:16}[170] (or not a music ID if the highest bit is set)
+        type: struct music_id_16[170] (or not a music ID if the highest bit is set)
     - name: TYPE_MATCHUP_TABLE
       address:
         NA: 0x22C56B0

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -238,7 +238,7 @@ overlay11:
       description: |-
         Table of dungeon IDs corresponding to entries in RECRUITMENT_TABLE_SPECIES.
         
-        type: {enum dungeon_id:16}[22]
+        type: struct dungeon_id_16[22]
     - name: RECRUITMENT_TABLE_LEVELS
       address:
         NA: 0x23208AC
@@ -262,7 +262,7 @@ overlay11:
         
         Interestingly, this includes both Heatran genders. It also includes Darkrai for some reason?
         
-        type: {enum monster_id:16}[22]
+        type: struct monster_id_16[22]
     - name: LEVEL_TILEMAP_LIST
       address:
         NA: 0x2320D2C

--- a/symbols/overlay13.yml
+++ b/symbols/overlay13.yml
@@ -19,7 +19,7 @@ overlay13:
       length:
         NA: 0x2A
         EU: 0x2A
-      description: "type: {enum monster_id:16}[21]"
+      description: "type: struct monster_id_16[21]"
     - name: STARTERS_HERO_IDS
       address:
         NA: 0x238C0B8
@@ -27,7 +27,7 @@ overlay13:
       length:
         NA: 0x40
         EU: 0x40
-      description: "type: {enum monster_id:16}[32]"
+      description: "type: struct monster_id_16[32]"
     - name: STARTERS_STRINGS
       address:
         NA: 0x238C14C

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -2318,7 +2318,7 @@ overlay29:
         
         Overrides are used to substitute different fixed room data for things like revisits to story dungeons.
         
-        type: {enum fixed_room_id:8}[256]
+        type: struct fixed_room_id_8[256]
     - name: FIXED_ROOM_MONSTER_SPAWN_TABLE
       address:
         NA: 0x234FF14

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -89,7 +89,7 @@ arm9:
         
         For stackable items, the quantities are stored elsewhere, in STORAGE_ITEM_QUANTITIES.
         
-        type: {enum item_id:16}[1000]
+        type: struct item_id_16[1000]
     - name: STORAGE_ITEM_QUANTITIES
       address:
         NA: 0x22A437E
@@ -111,7 +111,7 @@ arm9:
       length:
         NA: 0x20
       description: |-
-        Array of up to 8 items in the Kecleon Shop of the form {enum item_id:16, uint16_t quantity}.
+        Array of up to 8 items in the Kecleon Shop of the form {struct item_id_16 id, uint16_t quantity}.
         
         If there are fewer than 8 items, the array is expected to be null-terminated.
     - name: UNUSED_KECLEON_SHOP_ITEMS
@@ -132,7 +132,7 @@ arm9:
       length:
         NA: 0x10
       description: |-
-        Array of up to 4 items in Kecleon Wares of the form {enum item_id:16, uint16_t quantity}.
+        Array of up to 4 items in Kecleon Wares of the form {struct item_id_16 id, uint16_t quantity}.
         
         If there are fewer than 4 items, the array is expected to be null-terminated.
     - name: UNUSED_KECLEON_WARES_ITEMS
@@ -201,7 +201,7 @@ arm9:
         
         Controls the text and map location during the "map cutscene" just before entering a dungeon, as well as the actual dungeon loaded afterwards.
         
-        type: enum dungeon_id:8
+        type: struct dungeon_id_8
     - name: PENDING_STARTING_FLOOR
       address:
         NA: 0x22AB4FD
@@ -241,7 +241,7 @@ arm9:
         
         This is presumably part of a larger struct, together with other nearby data.
         
-        type: enum monster_id:16
+        type: struct monster_id_16
     - name: HERO_NICKNAME
       address:
         NA: 0x22ABE1A
@@ -263,7 +263,7 @@ arm9:
         
         This is presumably part of a larger struct, together with other nearby data.
         
-        type: enum monster_id:16
+        type: struct monster_id_16
     - name: LEADER_IQ_SKILLS
       address:
         NA: 0x22B5198


### PR DESCRIPTION
The `#pragma pack` directive is the only way to pack structs that
Ghidra's C parser supports, but it prevents compilers from assuming
struct alignment, which causes them to emit a lot of boilerplate code
that can be safely run even with unaligned structs. This is horribly
inefficient for writing patches using the C headers.

Most of the C structs don't actually require packing. Change structs to
be naturally aligned by default, but also keep a build target that
switches back to the old implicit packing behavior. By compiling in both
modes simultaneously, the clarity benefits of forbidding implicit struct
padding is preserved (as long as structs are accompanied by an
ASSERT_SIZE), while giving compilers more reasonable alignment
guarantees in most cases.

As part of this migration, replace all 8-bit and 16-bit enum bitfields
with proper wrapper structs. This should improve decompiler output in
Ghidra (which still doesn't support bitfields), and also allow enum
types to be more readily applied to globals. The convenience macros
ENUM_8_BIT and ENUM_16_BIT are added to help standardize these wrapper
structs and make them easier to define.