### PR TITLE
Fall back to fs::copy on tempfile persist errors

### DIFF
--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -10,6 +10,7 @@ use tempfile::NamedTempFile;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use super::data_formats::symgen_yml::{IntFormat, SymGen};
+use super::util;
 
 /// Formats a given `input_file`, using to the given `int_format`.
 ///
@@ -28,7 +29,7 @@ pub fn format_file<P: AsRef<Path>>(
     // Write to a tempfile first, then replace the old one atomically.
     let f_new = NamedTempFile::new()?;
     contents.write(&f_new, int_format)?;
-    f_new.persist(input_file.as_ref())?;
+    util::persist_named_temp_file_safe(f_new, input_file.as_ref())?;
     Ok(())
 }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -12,6 +12,7 @@ use tempfile::NamedTempFile;
 
 use super::data_formats::symgen_yml::{IntFormat, LoadParams, SymGen, Symbol};
 use super::data_formats::{Generate, InFormat, OutFormat};
+use super::util;
 
 /// Forms the output file path from the base, version, and format.
 fn output_file_name(base: &Path, version: &str, format: &OutFormat) -> PathBuf {
@@ -45,7 +46,7 @@ fn generate_symbols<P: AsRef<Path>>(
             if let Some(parent) = output_file.parent() {
                 fs::create_dir_all(parent)?;
             }
-            f_gen.persist(output_file)?;
+            util::persist_named_temp_file_safe(f_gen, output_file)?;
         }
     }
     Ok(())
@@ -154,7 +155,7 @@ where
 
     let output_file = NamedTempFile::new()?;
     contents.write(&output_file, int_format)?;
-    output_file.persist(symgen_file)?;
+    util::persist_named_temp_file_safe(output_file, symgen_file)?;
     Ok(unmerged_symbols)
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,9 @@
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
+use std::fs;
+use std::path::Path;
+
+use tempfile::{NamedTempFile, PersistError};
 
 /// Encapsulates a collection of similar errors for different files.
 #[derive(Debug)]
@@ -18,4 +22,33 @@ impl Display for MultiFileError {
         }
         Ok(())
     }
+}
+
+/// Persist the temporary file at the target path.
+///
+/// This wraps `NamedTempFile::persist()` with fallback to manual copying.
+/// On some systems, the normal `persist()` might not always work. For example, on Unix
+/// systems `persist()` ultimately relies on `std::fs::rename()`:
+/// https://github.com/Stebalien/tempfile/blob/66aa57f7d3a38234fcd393077366b61d36171e42/src/file/imp/unix.rs#L131
+/// which will fail if the tempfile and target path are not on the same filesystem:
+/// https://doc.rust-lang.org/std/fs/fn.rename.html. Since `/tmp` (the normal return value of
+/// `std::env::temp_dir()` on Linux) can sometimes be mounted on a separate filesystem, this is
+/// a fairly common case.
+///
+/// If the normal `persist()` method fails, try manually copying the tempfile to the destination.
+/// Unlike `std::fs::rename()`, `std::fs::copy()` works even across filesystems.
+pub fn persist_named_temp_file_safe<P: AsRef<Path>>(
+    file: NamedTempFile,
+    new_path: P,
+) -> Result<(), PersistError> {
+    if let Err(e) = file.persist(&new_path) {
+        let file = NamedTempFile::from(e); // Grab the file handle again
+        if let Err(io_err) = fs::copy(file.path(), new_path) {
+            return Err(PersistError {
+                error: io_err,
+                file,
+            });
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
On Unix systems where the temp directory is mounted on a different
filesystem from the target path (which is the case for /tmp on some
systems), NamedTempFile::persist() will fail. Fall back to fs::copy() to
handle such failures.