### PR TITLE
Fix GetTypeMatchup's third parameter

### DIFF
--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -40,7 +40,7 @@ bool DefenderAbilityIsActive(struct entity* attacker, struct entity* defender,
                              enum ability_id ability_id, bool attacker_ability_enabled);
 bool ExclusiveItemEffectIsActive(struct entity* entity, enum exclusive_item_effect_id effect_id);
 enum type_matchup GetTypeMatchup(struct entity* attacker, struct entity* defender,
-                                 enum type_id target_type, enum type_id attack_type);
+                                 int target_type_idx, enum type_id attack_type);
 void CalcDamage(struct entity* attacker, struct entity* defender, enum type_id attack_type,
                 int attack_power, int crit_chance, undefined4* damage_out, int damage_mult_fp,
                 enum move_id move_id, int param_9);

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -411,7 +411,7 @@ overlay29:
         
         r0: attacker pointer
         r1: defender pointer
-        r2: target type
+        r2: target type index (0 the target's first type, 1 for the target's second type)
         r3: attack type
         return: enum type_matchup
     - name: CalcDamage


### PR DESCRIPTION
This parameter should be an index into the target's types, not the type
ID itself.