### PR TITLE
Support 64-bit integers in resymgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resymgen"
 description = "Generates symbol tables for reverse engineering applications from a YAML specification"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["UsernameFodder <usernamefodder@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/UsernameFodder/pmdsky-debug"

--- a/docs/resymgen.md
+++ b/docs/resymgen.md
@@ -111,9 +111,9 @@ other:
 ```
 
 ### Currently supported output formats (`gen`)
-- SYM format
 - Ghidra-compatible symbol table (imported via the `ImportSymbolsScript.py` script)
 - JSON
+- No$GBA SYM format
 
 ### Currently supported input formats (`merge`)
 - `resymgen` YAML

--- a/src/data_formats/sym.rs
+++ b/src/data_formats/sym.rs
@@ -26,6 +26,9 @@ fn serialize_as_hex8<S>(x: &Uint, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
+    // If x is larger than u32::MAX, it'll just be printed with as many characters as needed.
+    // SYM only supports 32-bit numbers by virtue of requiring 8-character hex offsets,
+    // so there isn't really a well defined way to handle this case ¯\_(ツ)_/¯.
     s.serialize_str(&format!("{:08X}", x))
 }
 
@@ -117,6 +120,35 @@ mod tests {
         assert_eq!(
             f.generate_str(&symgen, "v2").expect("generate failed"),
             "02002000 fn1\n02003000 fn2\n02004000 SOME_DATA\n"
+        );
+    }
+
+    #[test]
+    fn test_generate_64bit() {
+        let symgen = SymGen::read(
+            r"
+            main:
+              address: 0x2000000
+              length: 0x10000000000
+              functions:
+                - name: fn1
+                  address: 0x100000000
+                - name: fn2
+                  address: 0x2000000
+                - name: fn3
+                  address: 0xFFFFFFFFFF
+              data: []
+            "
+            .as_bytes(),
+        )
+        .expect("Read failed");
+
+        let f = SymFormatter {};
+        // The format makes no official specification on how 64-bit numbers should behave,
+        // but resymgen should still deal with them in a consistent manner.
+        assert_eq!(
+            f.generate_str(&symgen, "").expect("generate failed"),
+            "100000000 fn1\n02000000 fn2\nFFFFFFFFFF fn3\n"
         );
     }
 }

--- a/src/data_formats/sym.rs
+++ b/src/data_formats/sym.rs
@@ -6,9 +6,9 @@
 //!
 //! # Example
 //! ```csv
-//! 2000000 main
-//! 2400000 function1
-//! 2FFFFFF SOME_DATA
+//! 02000000 main
+//! 02400000 function1
+//! 02FFFFFF SOME_DATA
 //! ```
 
 use std::error::Error;

--- a/src/data_formats/symgen_yml/types.rs
+++ b/src/data_formats/symgen_yml/types.rs
@@ -9,9 +9,9 @@ use std::slice;
 
 use serde::{Deserialize, Serialize};
 
-/// Unsigned integer type for addresses and lengths. This should match the system register size
-/// of the binary being reverse engineered.
-pub type Uint = u32;
+/// Unsigned integer type for addresses and lengths. This should be at least as large as the
+/// system register size of the binary being reverse engineered.
+pub type Uint = u64;
 /// Map from [`String`]s to sort indexes.
 pub type OrderMap = Option<HashMap<String, u64>>;
 


### PR DESCRIPTION
There's no reason why resymgen shouldn't support 64-bit binaries, and as
a somewhat general-purpose tool it's arguably expected that it should.
Change Uint to u64 to allow this, and add a few tests to make sure
things still work with numbers larger-than-32-bit numbers.
    
Users working with 32-bit binaries should not be meaningfully affected
by this increase in maximum value, since specifying both the address and
length for each symbol block is already required, and should constrain
symbol addresses and lengths to 32-bit integers via the in-bounds
symbols check resymgen provides, even when the underlying Uint type is
u64.