### PR TITLE
Relicense symbols and C headers under GPLv3-MIT dual license

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,5 @@ This repository is an attempt to implement the first sharing method (machine-rea
 ### No$GBA with symbol names
 ![No$GBA with symbol names](docs/images/top-readme-nocash.png)
 
+## Licensing
+The overall `pmdsky-debug` project is licensed under [GPLv3](LICENSE.txt). However, the [symbols](symbols) and [C headers](headers) are additionally licensed under MIT; see the separate `LICENSE.txt` files in each directory. If you are exclusively using the symbols and/or C headers, you may choose to use them under either GPLv3 or MIT. If you are using `pmdsky-debug` as a submodule for your own project purely for the symbols and/or C headers, the dual license likewise applies, provided the symbols and/or C headers are the _only_ part of `pmdsky-debug` being used.

--- a/headers/LICENSE.txt
+++ b/headers/LICENSE.txt
@@ -1,0 +1,23 @@
+NOTE: The following license applies only to the files within this directory.
+
+MIT License
+
+Copyright (c) 2022 UsernameFodder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/headers/README.md
+++ b/headers/README.md
@@ -14,6 +14,7 @@
     - [Use meaningful types](#use-meaningful-types)
     - [Follow style conventions](#follow-style-conventions)
   - [Local development environment](#local-development-environment)
+  - [Licensing](#licensing)
 
 The C headers in this directory contain _type information_, including struct definitions, enum definitions, and function signatures. They also contain _documentation_ in the form of comments. They don't contain "code" in the sense of executable instructions (that would be in the realm of a decompilation project).
 
@@ -240,3 +241,6 @@ Naming conventions are as follows:
 - Either [`clang`](https://clang.llvm.org/) or [`gcc`](https://gcc.gnu.org/) will allow you to run compiler checks (syntax and size assertions) via `make` or `make headers`.
 - [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html) (often comes included when you install [`clang`](https://clang.llvm.org/)) will allow you to run the formatter via `make format` (it also requires the `find` and `xargs` Unix utilities). With `clang-format` version 10+ you can also run the formatter in check mode via `make format-check`.
 - [Python 3](https://www.python.org/) (invokable with the `python3` command) with [PyYAML](https://pyyaml.org/) installed (`pip3 install pyyaml`) will allow you to run synchronization checks between functions defined in the C headers and those defined in the corresponding [symbol](../symbols) files, via `make symbol-check`.
+
+## Licensing
+The `pmdsky-debug` C headers are dual-licensed under [GNU GPLv3](../LICENSE.txt) or [MIT](LICENSE.txt). If you are using the C headers in your own project, you may choose to use them under either license.

--- a/symbols/LICENSE.txt
+++ b/symbols/LICENSE.txt
@@ -1,0 +1,23 @@
+NOTE: The following license applies only to the files within this directory.
+
+MIT License
+
+Copyright (c) 2022 UsernameFodder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/symbols/README.md
+++ b/symbols/README.md
@@ -8,6 +8,7 @@
     - [Use address lists for duplicated symbols](#use-address-lists-for-duplicated-symbols)
     - [Follow style conventions](#follow-style-conventions)
   - [Local development environment](#local-development-environment)
+  - [Licensing](#licensing)
 
 A "symbol" is a name for a specific offset within a binary. Having descriptive symbol names often dramatically improves the readability of assembly instructions and decompiled code. This directory contains catalogs of symbols within the _Explorers of Sky_ binaries. They use the human-and-machine-readable [YAML](https://en.wikipedia.org/wiki/YAML) format, so they can be used both as documentation and for import into various tools.
 
@@ -119,3 +120,6 @@ Refer to the [`resymgen` README](../docs/resymgen.md#usage) for a general overvi
 - Bulk-merge symbols from a CSV file into the symbol tables: `resymgen merge -x -f csv -v <version> -i <CSV file> <YAML symbol file>`
     - The exact CSV format can be exported directly from a Ghidra project from the symbol table (in the code browser: Window > Symbol Table), and is documented in the [`resymgen` library docs](https://docs.rs/resymgen/latest/resymgen/data_formats/ghidra_csv/index.html).
     - If a CSV file contains addresses outside of the range of the block within the YAML file, they will be skipped, which allows you to run this command multiple times to append to multiple YAML files from a single CSV file.
+
+## Licensing
+The `pmdsky-debug` symbol tables are dual-licensed under [GNU GPLv3](../LICENSE.txt) or [MIT](LICENSE.txt). If you are using the symbol tables in your own project, you may choose to use them under either license.


### PR DESCRIPTION
Projects like tech-ticks' c-of-time use the symbol tables and C headers
to generate actual ROM patches. However, the current GPLv3 licensing of
the symbols/headers are problematic for the distribution of these
patches, since they are inherently tied to the closed-source EoS ROMs
and thus incompatible with GPL.

Release the symbols and C headers under a dual GPLv3-MIT license to make
it easier for people to create and distribute patches derived from them.
Patch creators may choose to use the symbols and headers under the MIT
license.

Note that this commit does NOT change the license of the overall
pmdsky-debug repository, which is and remains GPLv3.