### PR TITLE
Make VersionDep value lookups more robust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resymgen"
 description = "Generates symbol tables for reverse engineering applications from a YAML specification"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["UsernameFodder <usernamefodder@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/UsernameFodder/pmdsky-debug"

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -391,7 +391,7 @@ fn check_no_function_overlap(symgen: &SymGen) -> Result<(), String> {
                 *extents = Some([(vers, vec![(ext, name)])].into());
             }
             Some(exts) => {
-                exts.entry(vers)
+                exts.entry_native(vers)
                     .and_modify(|e| e.push((ext, name)))
                     .or_insert_with(|| vec![(ext, name)]);
             }
@@ -816,8 +816,15 @@ mod tests {
             .next()
             .expect("symgen does not have two functions")
             .clone();
-        let addr = overlapping.address.get_mut(block.version("v1")).unwrap();
-        *addr = function.address.get(block.version("v1")).unwrap().clone();
+        let addr = overlapping
+            .address
+            .get_mut_native(block.version("v1"))
+            .unwrap();
+        *addr = function
+            .address
+            .get_native(block.version("v1"))
+            .unwrap()
+            .clone();
         block.functions = [function, overlapping].into();
         assert!(check_no_function_overlap(&symgen).is_err());
     }

--- a/src/data_formats/symgen_yml/bounds.rs
+++ b/src/data_formats/symgen_yml/bounds.rs
@@ -197,6 +197,57 @@ mod tests {
     }
 
     #[test]
+    fn test_by_version_bounds_and_extents_different_ordinals() {
+        let cases: [(VersionDep<_>, VersionDep<_>, bool); 3] = [
+            (
+                [
+                    (("v1", 0).into(), (0, Some(100))),
+                    (("v2", 0).into(), (0, Some(100))),
+                ]
+                .into(),
+                [
+                    (("v1", 1).into(), (0.into(), Some(100))),
+                    (("v2", 2).into(), (0.into(), Some(100))),
+                ]
+                .into(),
+                true,
+            ),
+            (
+                [
+                    (("v1", 0).into(), (0, Some(100))),
+                    (("v2", 0).into(), (0, Some(100))),
+                ]
+                .into(),
+                [
+                    (("v1", 1).into(), (0.into(), Some(150))),
+                    (("v2", 2).into(), (0.into(), Some(100))),
+                ]
+                .into(),
+                false,
+            ),
+            (
+                [(("v2", 0).into(), (0, Some(100)))].into(),
+                [
+                    (("v1", 1).into(), (0.into(), Some(150))),
+                    (("v2", 2).into(), (0.into(), Some(100))),
+                ]
+                .into(),
+                true,
+            ),
+        ];
+        for case in cases {
+            assert_eq!(
+                symbol_extents_in_bounds(
+                    &MaybeVersionDep::ByVersion(case.0.into()),
+                    &MaybeVersionDep::ByVersion(case.1.into())
+                )
+                .is_none(),
+                case.2
+            );
+        }
+    }
+
+    #[test]
     fn test_by_version_bounds_with_common_extents() {
         let cases: [(VersionDep<_>, _, bool); 3] = [
             (

--- a/src/data_formats/symgen_yml/merge.rs
+++ b/src/data_formats/symgen_yml/merge.rs
@@ -174,10 +174,12 @@ where
         for (v, x) in other.iter() {
             match versions_by_name.get(v.name()) {
                 // This version key already exists (by name), so try to merge the inner value
-                Some(vers) => MergeConflict::wrap(self.get_mut(vers).unwrap().merge(x), v.name())?,
+                Some(vers) => {
+                    MergeConflict::wrap(self.get_mut_native(vers).unwrap().merge(x), v.name())?
+                }
                 None => {
                     // This version key is new, so insert it
-                    self.insert(v.clone(), x.clone());
+                    self.insert_native(v.clone(), x.clone());
                     versions_by_name.insert(v.name().to_owned(), v.clone());
                 }
             }

--- a/src/data_formats/symgen_yml/symgen.rs
+++ b/src/data_formats/symgen_yml/symgen.rs
@@ -46,7 +46,7 @@ pub struct Symbol {
 }
 
 /// Combines possibly version-dependent `addrs` and `opt_len` into a single `MaybeVersionDep`
-/// with the data (addr, opt_len).
+/// with the data (addr, opt_len). Assumes `addrs` and `opt_len` have the same `Version` key space.
 fn zip_addr_len<T>(
     addrs: &MaybeVersionDep<T>,
     opt_len: Option<&MaybeVersionDep<Uint>>,
@@ -59,7 +59,7 @@ where
             let version_dep = match opt_len {
                 Some(len) => addr
                     .iter()
-                    .map(|(v, a)| (v.clone(), (a.clone(), len.get(Some(v)).copied())))
+                    .map(|(v, a)| (v.clone(), (a.clone(), len.get_native(Some(v)).copied())))
                     .collect(),
                 None => addr
                     .iter()


### PR DESCRIPTION
Fixes #38.

VersionDeps map Versions to values, where a Version is an ordinal-string
pair. Within a Block, the ordinal for Version keys is determined by the
version list in the Block's metadata and makes it possible to sort
version keys according to the Block's global version list.

The problem is that intuitively, a version will often be conceptualized
as a vanilla string, without the ordinal (which is largely an
implementation detail). This leads to unexpected results when attempting
a lookup in a VersionDep or MaybeVersionDep with a Version key that
matches one of the native keys by string value, but not by ordinal (with
the end result being an unexpected return value of None). This is
especially error-prone when working with glue code between a SymGen and
foreign symbols (like with the `merge` command), which caused a bug in
bounds checking for versions with ordinals greater than 0 (i.e., not the
first version in the list).

Rename the old VersionDep/MaybeVersionDep key-lookup functions to
include a "_native" suffix that highlights the expectation that keys are
in the native key space, with proper names AND ordinals.

Reimplement the vanilla key-lookup functions (without "_native") to
actually iterate over a VersionDep/MaybeVersionDep's keys to find a
native key that matches by name, but not necessarily by ordinal. This
turns lookups into an O(n) operation as opposed to O(1) (which is why
the "_native" functions are still useful), but is much more intuitive
for general-purpose key lookups, where the argument may not necessarily
come from the native key space. This fixes the aforementioned
bounds-checking bug.