### PR TITLE
Add some fields for file_stream, update FileSeek desc.

### DIFF
--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -156,9 +156,9 @@ struct file_stream {
     undefined4 field_0x18;
     undefined4 field_0x1c;
     undefined4 field_0x20;
-    undefined4 field_0x24;
-    undefined4 field_0x28;
-    undefined4 field_0x2c;
+    void* start_address;
+    void* end_address;
+    void* current_address;
     undefined4 field_0x30;
     undefined4 field_0x34;
     undefined4 field_0x38;

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -552,7 +552,7 @@ arm9:
         This function has the a similar API to the fseek(3) library function from C, including using the same codes for the `whence` parameter:
         - SEEK_SET=0
         - SEEK_CUR=1
-        - SEEK_END=2 (maybe not implemented?).
+        - SEEK_END=2.
         
         r0: file_stream pointer
         r1: offset


### PR DESCRIPTION
- Clarified what `0x24` - `0x2c` are in the `file_stream` struct
- Updated the FileSeek description to no longer mark seeking from the end as unimplemented, since it seems to be implemented.