### PR TITLE
Add remaining EU symbols

### DIFF
--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -289,6 +289,7 @@ overlay11:
     - name: OVERLAY11_OVERLAY_LOAD_TABLE
       address:
         NA: 0x232306C
+        EU: 0x2323B9C
       description: |-
         The overlays that can be loaded while this one is loaded.
         

--- a/symbols/overlay13.yml
+++ b/symbols/overlay13.yml
@@ -31,18 +31,24 @@ overlay13:
     - name: STARTERS_STRINGS
       address:
         NA: 0x238C14C
+        EU: 0x238CC8C
       length:
         NA: 0x60
+        EU: 0x60
     - name: QUIZ_QUESTION_STRINGS
       address:
         NA: 0x238C1AC
+        EU: 0x238CCEC
       length:
         NA: 0x84
+        EU: 0x84
     - name: QUIZ_ANSWER_STRINGS
       address:
         NA: 0x238C230
+        EU: 0x238CD70
       length:
         NA: 0x160
+        EU: 0x160
     - name: UNKNOWN_MENU_1
       address:
         NA: 0x238CECC

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -45,8 +45,10 @@ arm9:
     - name: MOVE_DATA_TABLE
       address:
         NA: 0x22113CC
+        EU: 0x2211D0C
       length:
         NA: 0x38C6
+        EU: 0x38C6
       description: |-
         The move data table loaded directly from /BALANCE/waza_p.bin. See struct move_data_table in the C headers.
         
@@ -58,15 +60,20 @@ arm9:
         NA:
           - 0x22A354C
           - 0x22A359C
-          - 0x22B99C4
+        EU:
+          - 0x22A3E8C
+          - 0x22A3EDC
       length:
         NA: 0x4
-      description: "Starts and 0 when the game is first launched, and continuously ticks up (presumably once per frame) while the game is running."
+        EU: 0x4
+      description: "Starts at 0 when the game is first launched, and continuously ticks up once per frame while the game is running."
     - name: BAG_ITEMS
       address:
         NA: 0x22A3824
+        EU: 0x22A4164
       length:
         NA: 0x12C
+        EU: 0x12C
       description: |-
         Array of item structs within the player's bag.
         
@@ -76,14 +83,18 @@ arm9:
     - name: BAG_ITEMS_PTR
       address:
         NA: 0x22A3BA8
+        EU: 0x22A44E8
       length:
         NA: 0x4
+        EU: 0x4
       description: Pointer to BAG_ITEMS.
     - name: STORAGE_ITEMS
       address:
         NA: 0x22A3BAE
+        EU: 0x22A44EE
       length:
         NA: 0x7D0
+        EU: 0x7D0
       description: |-
         Array of item IDs in the player's item storage.
         
@@ -93,8 +104,10 @@ arm9:
     - name: STORAGE_ITEM_QUANTITIES
       address:
         NA: 0x22A437E
+        EU: 0x22A4CBE
       length:
         NA: 0x7D0
+        EU: 0x7D0
       description: |-
         Array of 1000 2-byte (unsigned) quantities corresponding to the item IDs in STORAGE_ITEMS.
         
@@ -102,14 +115,18 @@ arm9:
     - name: KECLEON_SHOP_ITEMS_PTR
       address:
         NA: 0x22A4B50
+        EU: 0x22A5490
       length:
         NA: 0x4
+        EU: 0x4
       description: Pointer to KECLEON_SHOP_ITEMS.
     - name: KECLEON_SHOP_ITEMS
       address:
         NA: 0x22A4B54
+        EU: 0x22A5494
       length:
         NA: 0x20
+        EU: 0x20
       description: |-
         Array of up to 8 items in the Kecleon Shop of the form {struct item_id_16 id, uint16_t quantity}.
         
@@ -117,20 +134,26 @@ arm9:
     - name: UNUSED_KECLEON_SHOP_ITEMS
       address:
         NA: 0x22A4B74
+        EU: 0x22A54B4
       length:
         NA: 0x20
+        EU: 0x20
       description: "Seems to be another array like KECLEON_SHOP_ITEMS, but don't actually appear to be used by the Kecleon Shop."
     - name: KECLEON_WARES_ITEMS_PTR
       address:
         NA: 0x22A4B94
+        EU: 0x22A54D4
       length:
         NA: 0x4
+        EU: 0x4
       description: Pointer to KECLEON_WARES_ITEMS.
     - name: KECLEON_WARES_ITEMS
       address:
         NA: 0x22A4B98
+        EU: 0x22A54D8
       length:
         NA: 0x10
+        EU: 0x10
       description: |-
         Array of up to 4 items in Kecleon Wares of the form {struct item_id_16 id, uint16_t quantity}.
         
@@ -138,26 +161,34 @@ arm9:
     - name: UNUSED_KECLEON_WARES_ITEMS
       address:
         NA: 0x22A4BA8
+        EU: 0x22A54E8
       length:
         NA: 0x10
+        EU: 0x10
       description: "Seems to be another array like KECLEON_WARES_ITEMS, but don't actually appear to be used by Kecleon Wares."
     - name: MONEY_CARRIED
       address:
         NA: 0x22A4BB8
+        EU: 0x22A54F8
       length:
         NA: 0x4
+        EU: 0x4
       description: The amount of money the player is currently carrying.
     - name: MONEY_STORED
       address:
         NA: 0x22A4BC4
+        EU: 0x22A5504
       length:
         NA: 0x4
+        EU: 0x4
       description: The amount of money the player currently has stored in the Duskull Bank.
     - name: LAST_NEW_MOVE
       address:
         NA: 0x22AAE4C
+        EU: 0x22AB78C
       length:
         NA: 0x8
+        EU: 0x8
       description: |-
         Move struct of the last new move introduced when learning a new move. Persists even after the move selection is made in the menu.
         
@@ -178,8 +209,10 @@ arm9:
     - name: BAG_LEVEL
       address:
         NA: 0x22AB15C
+        EU: 0x22ABA9C
       length:
         NA: 0x1
+        EU: 0x1
       description: "The player's bag level, which determines the bag capacity. This indexes directly into the BAG_CAPACITY_TABLE in the ARM9 binary."
     - name: DEBUG_SPECIAL_EPISODE_NUMBER
       address:
@@ -199,8 +232,10 @@ arm9:
     - name: PENDING_DUNGEON_ID
       address:
         NA: 0x22AB4FC
+        EU: 0x22ABE3C
       length:
         NA: 0x1
+        EU: 0x1
       description: |-
         The ID of the selected dungeon when setting off from the overworld.
         
@@ -210,26 +245,34 @@ arm9:
     - name: PENDING_STARTING_FLOOR
       address:
         NA: 0x22AB4FD
+        EU: 0x22ABE3D
       length:
         NA: 0x1
+        EU: 0x1
       description: The floor number to start from in the dungeon specified by PENDING_DUNGEON_ID.
     - name: PLAY_TIME_SECONDS
       address:
         NA: 0x22AB694
+        EU: 0x22ABFD4
       length:
         NA: 0x4
+        EU: 0x4
       description: "The player's total play time in seconds."
     - name: PLAY_TIME_FRAME_COUNTER
       address:
         NA: 0x22AB698
+        EU: 0x22ABFD8
       length:
         NA: 0x1
+        EU: 0x1
       description: "Counts from 0-59 in a loop, with the play time being incremented by 1 second with each rollover."
     - name: TEAM_NAME
       address:
         NA: 0x22AB918
+        EU: 0x22AC258
       length:
         NA: 0xC
+        EU: 0xC
       description: |-
         The team name.
         
@@ -239,8 +282,10 @@ arm9:
     - name: HERO_SPECIES_ID
       address:
         NA: 0x22ABDE4
+        EU: 0x22AC724
       length:
         NA: 0x2
+        EU: 0x2
       description: |-
         The hero's species ID.
         
@@ -250,8 +295,10 @@ arm9:
     - name: HERO_NICKNAME
       address:
         NA: 0x22ABE1A
+        EU: 0x22AC75A
       length:
         NA: 0xA
+        EU: 0xA
       description: |-
         The hero's nickname.
         
@@ -261,8 +308,10 @@ arm9:
     - name: PARTNER_SPECIES_ID
       address:
         NA: 0x22ABE28
+        EU: 0x22AC768
       length:
         NA: 0x2
+        EU: 0x2
       description: |-
         The partner's species ID.
         
@@ -272,8 +321,10 @@ arm9:
     - name: LEADER_IQ_SKILLS
       address:
         NA: 0x22B5198
+        EU: 0x22B5AD8
       length:
         NA: 0xC
+        EU: 0xC
       description: |-
         Unlocked IQ skills of the current leader, available for selection from the IQ skills menu.
         
@@ -283,8 +334,10 @@ arm9:
     - name: LEADER_NICKNAME
       address:
         NA: 0x22B51AA
+        EU: 0x22B5AEA
       length:
         NA: 0xA
+        EU: 0xA
       description: |-
         The current leader's nickname.
         
@@ -294,25 +347,39 @@ arm9:
     - name: PARTY_MEMBER_2_IQ_SKILLS
       address:
         NA: 0x22B5200
+        EU: 0x22B5B40
       length:
         NA: 0xC
+        EU: 0xC
       description: |-
         Unlocked IQ skills of the second party member, available for selection from the IQ skills menu.
         
         One bit per skill (1 if unlocked). Same format as the IQ skills bitvector on the monster info struct.
         
         This is presumably part of a larger struct, together with other nearby data.
+    - name: FRAMES_SINCE_LAUNCH_TIMES_THREE
+      address:
+        NA: 0x22B99C4
+        EU: 0x22BA304
+      length:
+        NA: 0x4
+        EU: 0x4
+      description: "Starts at 0 when the game is first launched, and ticks up by 3 per frame while the game is running."
     - name: TURNING_ON_THE_SPOT_FLAG
       address:
         NA: 0x237C9A6
+        EU: 0x237D5A6
       length:
         NA: 0x1
+        EU: 0x1
       description: "[Runtime] Flag for whether the player is turning on the spot (pressing Y)."
     - name: FLOOR_GENERATION_STATUS
       address:
         NA: 0x237CFBC
+        EU: 0x237DBBC
       length:
         NA: 0x40
+        EU: 0x40
       description: |-
         [Runtime] Status data related to generation of the current floor in a dungeon.
         


### PR DESCRIPTION
No more missing EU symbols!

I also decided to split `FRAMES_SINCE_LAUNCH` in ram.yml into two different symbols because one of three counters is faster, it counts up by 3 every frame, but I don't know what it's used for, so I just called it `FRAMES_SINCE_LAUNCH_TIMES_THREE`. Feel free to suggest a better name if you have any ideas