### PR TITLE
Add minimum instruction count constraint to symbols_vfill.py

### DIFF
--- a/tools/arm5find.py
+++ b/tools/arm5find.py
@@ -14,7 +14,7 @@ python3 arm5find.py -a 0x1390 0x28c </path/to/arm9_NA.bin> </path/to/arm9_EU.bin
 python3 arm5find.py -d 0x77330 0x14 </path/to/overlay29_NA.bin> </path/to/overlay29_EU.bin>
 
 You can include more than one `-a`/`-d` inputs to search for multiple segments
-at once. You can also incluce more than one target file to search multiple
+at once. You can also include more than one target file to search multiple
 files at once.
 """
 

--- a/tools/symbols_vfill.py
+++ b/tools/symbols_vfill.py
@@ -6,8 +6,10 @@ addresses in the pmdsky-debug symbol tables, for addresses that are known in
 some game versions (e.g., NA, EU) but not in others.
 
 When run, the program will modify the YAML symbol tables in-place (unless
-dry-run mode is enabled), allowing inspection of filled addresses with
-`git diff` (or similar).
+dry-run mode is enabled). It is recommended that you commit any symbol table
+changes that you are working on BEFORE running `symbols_vfill.py`. This will
+allow you to inspect filled addresses with `git diff` (or similar), and will
+also prevent you from losing your changes if something somehow goes wrong.
 
 This program is conservative in the symbol addresses it fills in, and tries
 hard to avoid adding incorrect addresses caused by spurious matches between


### PR DESCRIPTION
Impose that adaptive length matches must match at least 4 instructions by default in order to further limit false positives. Add an option to configure this constraint.

Testing against symbols in #47 reveals that single matches might be found even with really short lengths (3 instructions). In the case of `EuFaintCheck`, a false positive match is found in the NA version. A minimum length of 4 instructions seems like a reasonable default for adaptive lengths.