### PR TITLE
Use reverse chronological order for symbol versions

### DIFF
--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -41,6 +41,7 @@ enum forced_loss_reason GetForcedLossReason(void);
 void ResetDamageDesc(undefined4* damage_desc);
 uint16_t GetSpriteIndex(enum monster_id monster_id);
 bool FloorNumberIsEven(void);
+void EuFaintCheck(bool non_team_member_fainted, bool set_unk_byte);
 void HandleFaint(struct entity* fainted_entity, int faint_reason, struct entity* killer);
 enum monster_id GetKecleonIdToSpawnByFloor(void);
 void TryActivateSlowStart(void);
@@ -209,6 +210,7 @@ bool IsSecretBazaar(void);
 bool IsSecretRoom(void);
 struct minimap_display_data* GetMinimapData(void);
 void SetMinimapDataE447(uint8_t value);
+uint8_t GetMinimapDataE447(void);
 void SetMinimapDataE448(uint8_t value);
 bool IsSecretFloor(void);
 void LoadFixedRoomDataVeneer(void);
@@ -320,7 +322,5 @@ void DisplayMessage(undefined4 param_1, int message_id, bool wait_for_input);
 void DisplayMessage2(undefined4 param_1, int message_id, bool wait_for_input);
 void DisplayMessageInternal(int message_id, bool wait_for_input, undefined4 param_3,
                             undefined4 param_4, undefined4 param_5, undefined4 param_6);
-void EuFaintCheck(bool non_team_member_fainted, bool set_unk_byte);
-uint8_t GetMinimapDataE447(void);
 
 #endif

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -1,15 +1,15 @@
 arm9:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2000000
     EU: 0x2000000
+    NA: 0x2000000
     JP: 0x2000000
   length:
-    NA: 0xB73F8
     EU: 0xB7D38
+    NA: 0xB73F8
     JP: 0xB8CB8
   description: |-
     The main ARM9 binary.
@@ -18,8 +18,8 @@ arm9:
   functions:
     - name: InitMemAllocTable
       address:
-        NA: 0x2000DE0
         EU: 0x2000DE0
+        NA: 0x2000DE0
         JP: 0x2000DE0
       description: |-
         Initializes MEMORY_ALLOCATION_TABLE.
@@ -29,8 +29,8 @@ arm9:
         No params.
     - name: SetMemAllocatorParams
       address:
-        NA: 0x2000E70
         EU: 0x2000E70
+        NA: 0x2000E70
         JP: 0x2000E70
       description: |-
         Sets global parameters for the memory allocator.
@@ -43,8 +43,8 @@ arm9:
         r1: GetFreeArena function pointer (GetFreeArenaDefault is used if null)
     - name: GetAllocArenaDefault
       address:
-        NA: 0x2000EC0
         EU: 0x2000EC0
+        NA: 0x2000EC0
         JP: 0x2000EC0
       description: |-
         The default function for retrieving the arena for memory allocations. This function always just returns the initial arena pointer.
@@ -54,8 +54,8 @@ arm9:
         return: memory arena pointer, or null
     - name: GetFreeArenaDefault
       address:
-        NA: 0x2000EC4
         EU: 0x2000EC4
+        NA: 0x2000EC4
         JP: 0x2000EC4
       description: |-
         The default function for retrieving the arena for memory freeing. This function always just returns the initial arena pointer.
@@ -65,8 +65,8 @@ arm9:
         return: memory arena pointer, or null
     - name: InitMemArena
       address:
-        NA: 0x2000EC8
         EU: 0x2000EC8
+        NA: 0x2000EC8
         JP: 0x2000EC8
       description: |-
         Initializes a new memory arena with the given specifications, and records it in the global MEMORY_ALLOCATION_TABLE.
@@ -77,8 +77,8 @@ arm9:
         r3: maximum number of blocks that the arena can hold
     - name: MemAllocFlagsToBlockType
       address:
-        NA: 0x2000F44
         EU: 0x2000F44
+        NA: 0x2000F44
         JP: 0x2000F44
       description: |-
         Converts the internal alloc flags bitfield (struct mem_block field 0x4) to the block type bitfield (struct mem_block field 0x0).
@@ -87,8 +87,8 @@ arm9:
         return: block type flags
     - name: FindAvailableMemBlock
       address:
-        NA: 0x2000F88
         EU: 0x2000F88
+        NA: 0x2000F88
         JP: 0x2000F88
       description: |-
         Searches through the given memory arena for a block with enough free space.
@@ -101,8 +101,8 @@ arm9:
         return: index of the located block in the arena's block array, or -1 if nothing is available
     - name: SplitMemBlock
       address:
-        NA: 0x2001070
         EU: 0x2001070
+        NA: 0x2001070
         JP: 0x2001070
       description: |-
         Given a memory block at a given index, splits off another memory block of the specified size from the end.
@@ -117,8 +117,8 @@ arm9:
         return: the newly split-off memory block
     - name: MemAlloc
       address:
-        NA: 0x2001170
         EU: 0x2001170
+        NA: 0x2001170
         JP: 0x2001170
       description: |-
         Allocates some memory on the heap, returning a pointer to the starting address.
@@ -132,8 +132,8 @@ arm9:
         return: pointer
     - name: MemFree
       address:
-        NA: 0x2001188
         EU: 0x2001188
+        NA: 0x2001188
         JP: 0x2001188
       description: |-
         Frees heap-allocated memory.
@@ -143,8 +143,8 @@ arm9:
         r0: pointer
     - name: MemArenaAlloc
       address:
-        NA: 0x200119C
         EU: 0x200119C
+        NA: 0x200119C
         JP: 0x200119C
       description: |-
         Allocates some memory on the heap and creates a new global memory arena with it.
@@ -158,8 +158,8 @@ arm9:
         return: memory arena pointer
     - name: CreateMemArena
       address:
-        NA: 0x2001280
         EU: 0x2001280
+        NA: 0x2001280
         JP: 0x2001280
       description: |-
         Creates a new memory arena within a given block of memory.
@@ -171,8 +171,8 @@ arm9:
         return: memory arena pointer
     - name: MemLocateSet
       address:
-        NA: 0x2001390
         EU: 0x2001390
+        NA: 0x2001390
         JP: 0x2001390
       description: |-
         The implementation for MemAlloc.
@@ -189,8 +189,8 @@ arm9:
         return: pointer to allocated memory
     - name: MemLocateUnset
       address:
-        NA: 0x2001638
         EU: 0x2001638
+        NA: 0x2001638
         JP: 0x2001638
       description: |-
         The implementation for MemFree.
@@ -201,8 +201,8 @@ arm9:
         r1: pointer to free
     - name: RoundUpDiv256
       address:
-        NA: 0x2001894
         EU: 0x2001894
+        NA: 0x2001894
         JP: 0x2001894
       description: |-
         Divide a number by 256 and round up to the nearest integer.
@@ -211,8 +211,8 @@ arm9:
         return: number // 256
     - name: MultiplyByFixedPoint
       address:
-        NA: 0x2001A54
         EU: 0x2001A54
+        NA: 0x2001A54
         JP: 0x2001A54
       description: |-
         Multiply a signed integer x by a signed binary fixed-point multiplier (8 fraction bits).
@@ -222,8 +222,8 @@ arm9:
         return: x * multiplier
     - name: UMultiplyByFixedPoint
       address:
-        NA: 0x2001B0C
         EU: 0x2001B0C
+        NA: 0x2001B0C
         JP: 0x2001B0C
       description: |-
         Multiplies an unsigned integer x by an unsigned binary fixed-point multiplier (8 fraction bits).
@@ -233,21 +233,21 @@ arm9:
         return: x * multiplier
     - name: GetRngSeed
       address:
-        NA: 0x200222C
         EU: 0x200222C
+        NA: 0x200222C
       description: Get the current value of PRNG_SEQUENCE_NUM.
     - name: SetRngSeed
       address:
-        NA: 0x200223C
         EU: 0x200223C
+        NA: 0x200223C
       description: |-
         Seed PRNG_SEQUENCE_NUM to a given value.
         
         r0: seed
     - name: Rand16Bit
       address:
-        NA: 0x200224C
         EU: 0x200224C
+        NA: 0x200224C
         JP: 0x200224C
       description: |-
         Computes a pseudorandom 16-bit integer using the general-purpose PRNG.
@@ -261,8 +261,8 @@ arm9:
         return: pseudorandom int on the interval [0, 65535]
     - name: RandInt
       address:
-        NA: 0x2002274
         EU: 0x2002274
+        NA: 0x2002274
         JP: 0x2002274
       description: |-
         Compute a pseudorandom integer under a given maximum value using the general-purpose PRNG.
@@ -273,8 +273,8 @@ arm9:
         return: pseudorandom integer on the interval [0, high - 1]
     - name: RandRange
       address:
-        NA: 0x200228C
         EU: 0x200228C
+        NA: 0x200228C
         JP: 0x200228C
       description: |-
         Compute a pseudorandom value between two integers using the general-purpose PRNG.
@@ -286,8 +286,8 @@ arm9:
         return: pseudorandom integer on the interval [x, y - 1]
     - name: Rand32Bit
       address:
-        NA: 0x20022AC
         EU: 0x20022AC
+        NA: 0x20022AC
         JP: 0x20022AC
       description: |-
         Computes a random 32-bit integer using the general-purpose PRNG. The upper and lower 16 bits are each generated with a separate call to Rand16Bit (so this function advances the PRNG twice).
@@ -295,8 +295,8 @@ arm9:
         return: pseudorandom int on the interval [0, 4294967295]
     - name: RandIntSafe
       address:
-        NA: 0x20022F8
         EU: 0x20022F8
+        NA: 0x20022F8
         JP: 0x20022F8
       description: |-
         Same as RandInt, except explicitly masking out the upper 16 bits of the output from Rand16Bit (which should be zero anyway).
@@ -305,8 +305,8 @@ arm9:
         return: pseudorandom integer on the interval [0, high - 1]
     - name: RandRangeSafe
       address:
-        NA: 0x2002318
         EU: 0x2002318
+        NA: 0x2002318
         JP: 0x2002318
       description: |-
         Like RandRange, except reordering the inputs as needed, and explicitly masking out the upper 16 bits of the output from Rand16Bit (which should be zero anyway).
@@ -316,8 +316,8 @@ arm9:
         return: pseudorandom integer on the interval [min(x, y), max(x, y) - 1]
     - name: WaitForever
       address:
-        NA: 0x2002438
         EU: 0x2002438
+        NA: 0x2002438
         JP: 0x2002438
       description: |-
         Sets some program state and calls WaitForInterrupt in an infinite loop.
@@ -327,8 +327,8 @@ arm9:
         No params.
     - name: InitMemAllocTableVeneer
       address:
-        NA: 0x200321C
         EU: 0x200321C
+        NA: 0x200321C
         JP: 0x200321C
       description: |-
         Likely a linker-generated veneer for InitMemAllocTable.
@@ -338,8 +338,8 @@ arm9:
         No params.
     - name: MemZero
       address:
-        NA: 0x2003250
         EU: 0x2003250
+        NA: 0x2003250
         JP: 0x2003250
       description: |-
         Zeroes a buffer.
@@ -348,8 +348,8 @@ arm9:
         r1: len
     - name: MemcpySimple
       address:
-        NA: 0x20032E4
         EU: 0x20032E4
+        NA: 0x20032E4
         JP: 0x20032E4
       description: |-
         A simple implementation of the memcpy(3) C library function.
@@ -363,8 +363,8 @@ arm9:
         r2: n
     - name: TaskProcBoot
       address:
-        NA: 0x2003328
         EU: 0x2003328
+        NA: 0x2003328
         JP: 0x2003328
       description: |-
         Probably related to booting the game?
@@ -374,8 +374,8 @@ arm9:
         No params.
     - name: EnableAllInterrupts
       address:
-        NA: 0x2003608
         EU: 0x2003608
+        NA: 0x2003608
         JP: 0x2003608
       description: |-
         Sets the Interrupt Master Enable (IME) register to 1, which enables all CPU interrupts (if enabled in the Interrupt Enable (IE) register).
@@ -385,8 +385,8 @@ arm9:
         return: old value in the IME register
     - name: GetTime
       address:
-        NA: 0x20037B4
         EU: 0x20037B4
+        NA: 0x20037B4
         JP: 0x20037B4
       description: |-
         Seems to get the current (system?) time as an IEEE 754 floating-point number.
@@ -394,8 +394,8 @@ arm9:
         return: current time (maybe in seconds?)
     - name: DisableAllInterrupts
       address:
-        NA: 0x2003824
         EU: 0x2003824
+        NA: 0x2003824
         JP: 0x2003824
       description: |-
         Sets the Interrupt Master Enable (IME) register to 0, which disables all CPU interrupts (even if enabled in the Interrupt Enable (IE) register).
@@ -405,8 +405,8 @@ arm9:
         return: old value in the IME register
     - name: SoundResume
       address:
-        NA: 0x2003CC4
         EU: 0x2003CC4
+        NA: 0x2003CC4
         JP: 0x2003CC4
       description: |-
         Probably resumes the sound player if paused?
@@ -414,8 +414,8 @@ arm9:
         This function prints the debug string "sound resume".
     - name: CardPullOutWithStatus
       address:
-        NA: 0x2003D2C
         EU: 0x2003D2C
+        NA: 0x2003D2C
         JP: 0x2003D2C
       description: |-
         Probably aborts the program with some status code? It seems to serve a similar purpose to the exit(3) function.
@@ -425,8 +425,8 @@ arm9:
         r0: status code
     - name: CardPullOut
       address:
-        NA: 0x2003D70
         EU: 0x2003D70
+        NA: 0x2003D70
         JP: 0x2003D70
       description: |-
         Sets some global flag that probably triggers system exit?
@@ -436,8 +436,8 @@ arm9:
         No params.
     - name: CardBackupError
       address:
-        NA: 0x2003D94
         EU: 0x2003D94
+        NA: 0x2003D94
         JP: 0x2003D94
       description: |-
         Sets some global flag that maybe indicates a save error?
@@ -447,8 +447,8 @@ arm9:
         No params.
     - name: HaltProcessDisp
       address:
-        NA: 0x2003DB8
         EU: 0x2003DB8
+        NA: 0x2003DB8
         JP: 0x2003DB8
       description: |-
         Maybe halts the process display?
@@ -458,8 +458,8 @@ arm9:
         r0: status code
     - name: OverlayIsLoaded
       address:
-        NA: 0x2003ED0
         EU: 0x2003ED0
+        NA: 0x2003ED0
         JP: 0x2003ED0
       description: |-
         Checks if an overlay with a certain group ID is currently loaded.
@@ -470,8 +470,8 @@ arm9:
         return: bool
     - name: LoadOverlay
       address:
-        NA: 0x20040AC
         EU: 0x20040AC
+        NA: 0x20040AC
         JP: 0x20040AC
       description: |-
         Loads an overlay from ROM by its group ID.
@@ -481,8 +481,8 @@ arm9:
         r0: group ID of the overlay to load
     - name: UnloadOverlay
       address:
-        NA: 0x2004868
         EU: 0x2004868
+        NA: 0x2004868
         JP: 0x2004868
       description: |-
         Unloads an overlay from ROM by its group ID.
@@ -493,10 +493,10 @@ arm9:
         others: ?
     - name: EuclideanNorm
       address:
-        NA:
+        EU:
           - 0x2005050
           - 0x20050B0
-        EU:
+        NA:
           - 0x2005050
           - 0x20050B0
       description: |-
@@ -506,8 +506,8 @@ arm9:
         return: sqrt(x*x + y*y)
     - name: ClampComponentAbs
       address:
-        NA: 0x2005110
         EU: 0x2005110
+        NA: 0x2005110
         JP: 0x2005110
       description: |-
         Clamps the absolute values in a two-component integer array.
@@ -518,8 +518,8 @@ arm9:
         r1: max absolute value
     - name: KeyWaitInit
       address:
-        NA: 0x2006DA4
         EU: 0x2006DA4
+        NA: 0x2006DA4
         JP: 0x2006DA4
       description: |-
         Implements (most of?) SPECIAL_PROC_KEY_WAIT_INIT (see ScriptSpecialProcessCall).
@@ -527,8 +527,8 @@ arm9:
         No params.
     - name: DataTransferInit
       address:
-        NA: 0x2008168
         EU: 0x2008168
+        NA: 0x2008168
         JP: 0x2008168
       description: |-
         Initializes data transfer mode to get data from the ROM cartridge.
@@ -536,8 +536,8 @@ arm9:
         No params.
     - name: DataTransferStop
       address:
-        NA: 0x2008194
         EU: 0x2008194
+        NA: 0x2008194
         JP: 0x2008194
       description: |-
         Finalizes data transfer from the ROM cartridge.
@@ -547,8 +547,8 @@ arm9:
         No params.
     - name: FileInitVeneer
       address:
-        NA: 0x2008204
         EU: 0x2008204
+        NA: 0x2008204
       description: |-
         Likely a linker-generated veneer for FileInit.
         
@@ -557,8 +557,8 @@ arm9:
         r0: file_stream pointer
     - name: FileOpen
       address:
-        NA: 0x2008210
         EU: 0x2008210
+        NA: 0x2008210
         JP: 0x2008210
       description: |-
         Opens a file from the ROM file system at the given path, sort of like C's fopen(3) library function.
@@ -567,8 +567,8 @@ arm9:
         r1: file path string
     - name: FileGetSize
       address:
-        NA: 0x2008244
         EU: 0x2008244
+        NA: 0x2008244
         JP: 0x2008244
       description: |-
         Gets the size of an open file.
@@ -577,8 +577,8 @@ arm9:
         return: file size
     - name: FileRead
       address:
-        NA: 0x2008254
         EU: 0x2008254
+        NA: 0x2008254
         JP: 0x2008254
       description: |-
         Reads the contents of a file into the given buffer, and moves the file cursor accordingly.
@@ -591,8 +591,8 @@ arm9:
         return: number of bytes read
     - name: FileSeek
       address:
-        NA: 0x20082A8
         EU: 0x20082A8
+        NA: 0x20082A8
         JP: 0x20082A8
       description: |-
         Sets a file stream's position indicator.
@@ -607,8 +607,8 @@ arm9:
         r2: whence
     - name: FileClose
       address:
-        NA: 0x20082C4
         EU: 0x20082C4
+        NA: 0x20082C4
         JP: 0x20082C4
       description: |-
         Closes a file.
@@ -620,8 +620,8 @@ arm9:
         r0: file_stream pointer
     - name: LoadFileFromRom
       address:
-        NA: 0x2008C3C
         EU: 0x2008C3C
+        NA: 0x2008C3C
         JP: 0x2008C3C
       description: |-
         Loads a file from ROM by filepath into a heap-allocated buffer.
@@ -631,20 +631,20 @@ arm9:
         r2: flags
     - name: GetDebugFlag1
       address:
-        NA: 0x200C110
         EU: 0x200C198
+        NA: 0x200C110
         JP: 0x200C110
       description: Just returns 0 in the final binary.
     - name: SetDebugFlag1
       address:
-        NA: 0x200C118
         EU: 0x200C1A0
+        NA: 0x200C118
         JP: 0x200C118
       description: A no-op in the final binary.
     - name: AppendProgPos
       address:
-        NA: 0x200C120
         EU: 0x200C1A8
+        NA: 0x200C120
         JP: 0x200C120
       description: |-
         Write a base message into a string and append the file name and line number to the end in the format "file = '%s'  line = %5d\n".
@@ -657,8 +657,8 @@ arm9:
         return: number of characters printed, excluding the null-terminator
     - name: DebugPrintTrace
       address:
-        NA: 0x200C16C
         EU: 0x200C1F4
+        NA: 0x200C16C
         JP: 0x200C16C
       description: |-
         Would log a printf format string tagged with the file name and line number in the debug binary.
@@ -671,10 +671,10 @@ arm9:
         r1: program position info (can be null)
     - name: DebugPrint0
       address:
+        EU: 0x200C284
         NA:
           - 0x200C1C8
           - 0x200C1FC
-        EU: 0x200C284
       description: |-
         Would log a printf format string in the debug binary.
         
@@ -684,20 +684,20 @@ arm9:
         ...: variadic
     - name: GetDebugFlag2
       address:
-        NA: 0x200C234
         EU: 0x200C2BC
+        NA: 0x200C234
         JP: 0x200C234
       description: Just returns 0 in the final binary.
     - name: SetDebugFlag2
       address:
-        NA: 0x200C23C
         EU: 0x200C2C4
+        NA: 0x200C23C
         JP: 0x200C23C
       description: A no-op in the final binary.
     - name: DebugPrint
       address:
-        NA: 0x200C240
         EU: 0x200C2C8
+        NA: 0x200C240
         JP: 0x200C240
       description: |-
         Would log a printf format string in the debug binary. A no-op in the final binary.
@@ -707,8 +707,8 @@ arm9:
         ...: variadic
     - name: FatalError
       address:
-        NA: 0x200C25C
         EU: 0x200C2E4
+        NA: 0x200C25C
         JP: 0x200C25C
       description: |-
         Logs some debug messages, then hangs the process.
@@ -720,8 +720,8 @@ arm9:
         ...: variadic
     - name: IsAuraBow
       address:
-        NA: 0x200CC14
         EU: 0x200CC9C
+        NA: 0x200CC14
         JP: 0x200CC14
       description: |-
         Checks if an item is one of the aura bows received at the start of the game.
@@ -730,21 +730,6 @@ arm9:
         return: bool
     - name: SprintfStatic
       address:
-        NA:
-          - 0x200D634
-          - 0x200E990
-          - 0x2013758
-          - 0x20176E4
-          - 0x2017A40
-          - 0x2023590
-          - 0x202378C
-          - 0x2037F30
-          - 0x2039438
-          - 0x203CFA4
-          - 0x2042A84
-          - 0x2052418
-          - 0x2054A60
-          - 0x20609E8
         EU:
           - 0x200D6BC
           - 0x200E808
@@ -762,6 +747,21 @@ arm9:
           - 0x2052750
           - 0x2054DDC
           - 0x2060D64
+        NA:
+          - 0x200D634
+          - 0x200E990
+          - 0x2013758
+          - 0x20176E4
+          - 0x2017A40
+          - 0x2023590
+          - 0x202378C
+          - 0x2037F30
+          - 0x2039438
+          - 0x203CFA4
+          - 0x2042A84
+          - 0x2052418
+          - 0x2054A60
+          - 0x20609E8
       description: |-
         Functionally the same as Sprintf, just defined statically in many different places.
         
@@ -773,8 +773,8 @@ arm9:
         return: number of characters printed, excluding the null-terminator
     - name: SetMoneyCarried
       address:
-        NA: 0x200ED1C
         EU: 0x200EDC4
+        NA: 0x200ED1C
         JP: 0x200ED4C
       description: |-
         Sets the amount of money the player is carrying, clamping the value to the range [0, MAX_MONEY_CARRIED].
@@ -782,8 +782,8 @@ arm9:
         r0: new value
     - name: IsBagFull
       address:
-        NA: 0x200EDC0
         EU: 0x200EE68
+        NA: 0x200EDC0
         JP: 0x200EDF0
       description: |-
         Implements SPECIAL_PROC_IS_BAG_FULL (see ScriptSpecialProcessCall).
@@ -791,8 +791,8 @@ arm9:
         return: bool
     - name: CountItemTypeInBag
       address:
-        NA: 0x200EE88
         EU: 0x200EF30
+        NA: 0x200EE88
         JP: 0x200EEB8
       description: |-
         Implements SPECIAL_PROC_COUNT_ITEM_TYPE_IN_BAG (see ScriptSpecialProcessCall).
@@ -801,8 +801,8 @@ arm9:
         return: number of items of the specified ID in the bag
     - name: AddItemToBag
       address:
-        NA: 0x200F84C
         EU: 0x200F8F4
+        NA: 0x200F84C
         JP: 0x200F81C
       description: |-
         Implements SPECIAL_PROC_ADD_ITEM_TO_BAG (see ScriptSpecialProcessCall).
@@ -811,8 +811,8 @@ arm9:
         return: bool
     - name: ScriptSpecialProcess0x39
       address:
-        NA: 0x200FD54
         EU: 0x200FDFC
+        NA: 0x200FD54
         JP: 0x200FD24
       description: |-
         Implements SPECIAL_PROC_0x39 (see ScriptSpecialProcessCall).
@@ -820,8 +820,8 @@ arm9:
         return: bool
     - name: CountItemTypeInStorage
       address:
-        NA: 0x200FEE4
         EU: 0x200FF8C
+        NA: 0x200FEE4
         JP: 0x200FEB4
       description: |-
         Implements SPECIAL_PROC_COUNT_ITEM_TYPE_IN_STORAGE (see ScriptSpecialProcessCall).
@@ -830,8 +830,8 @@ arm9:
         return: number of items of the specified ID in storage
     - name: RemoveItemsTypeInStorage
       address:
-        NA: 0x20101E4
         EU: 0x201028C
+        NA: 0x20101E4
         JP: 0x20101B4
       description: |-
         Probably? Implements SPECIAL_PROC_0x2A (see ScriptSpecialProcessCall).
@@ -840,8 +840,8 @@ arm9:
         return: bool
     - name: AddItemToStorage
       address:
-        NA: 0x201031C
         EU: 0x20103C4
+        NA: 0x201031C
         JP: 0x20102EC
       description: |-
         Implements SPECIAL_PROC_ADD_ITEM_TO_STORAGE (see ScriptSpecialProcessCall).
@@ -850,8 +850,8 @@ arm9:
         return: bool
     - name: SetMoneyStored
       address:
-        NA: 0x2010724
         EU: 0x20107CC
+        NA: 0x2010724
         JP: 0x20106F4
       description: |-
         Sets the amount of money the player has stored in the Duskull Bank, clamping the value to the range [0, MAX_MONEY_STORED].
@@ -859,8 +859,8 @@ arm9:
         r0: new value
     - name: GetExclusiveItemOffset
       address:
-        NA: 0x2010E40
         EU: 0x2010EE8
+        NA: 0x2010E40
         JP: 0x2010E10
       description: |-
         Gets the exclusive item offset, which is the item ID relative to that of the first exclusive item, the Prism Ruff.
@@ -869,8 +869,8 @@ arm9:
         return: offset
     - name: ApplyExclusiveItemStatBoosts
       address:
-        NA: 0x2010E64
         EU: 0x2010F0C
+        NA: 0x2010E64
         JP: 0x2010E34
       description: |-
         Applies stat boosts from an exclusive item.
@@ -882,8 +882,8 @@ arm9:
         stack[0]: pointer to special defense stat to modify
     - name: SetExclusiveItemEffect
       address:
-        NA: 0x2010F80
         EU: 0x2011028
+        NA: 0x2010F80
         JP: 0x2010F50
       description: |-
         Sets the bit for an exclusive item effect.
@@ -892,8 +892,8 @@ arm9:
         r1: exclusive item effect ID
     - name: ExclusiveItemEffectFlagTest
       address:
-        NA: 0x2010FA4
         EU: 0x201104C
+        NA: 0x2010FA4
         JP: 0x2010F74
       description: |-
         Tests the exclusive item bitvector for a specific exclusive item effect.
@@ -903,8 +903,8 @@ arm9:
         return: bool
     - name: GetMoveTargetAndRange
       address:
-        NA: 0x2013840
         EU: 0x20138E8
+        NA: 0x2013840
         JP: 0x2013810
       description: |-
         Gets the move target-and-range field. See struct move_target_and_range in the C headers.
@@ -914,8 +914,8 @@ arm9:
         return: move target and range
     - name: GetMoveType
       address:
-        NA: 0x2013864
         EU: 0x201390C
+        NA: 0x2013864
       description: |-
         Gets the type of a move
         
@@ -923,8 +923,8 @@ arm9:
         return: Type of the move
     - name: GetMoveBasePower
       address:
-        NA: 0x20139CC
         EU: 0x2013A74
+        NA: 0x20139CC
         JP: 0x201399C
       description: |-
         Gets the base power of a move from the move data table.
@@ -933,8 +933,8 @@ arm9:
         return: base power
     - name: GetMoveAccuracyOrAiChance
       address:
-        NA: 0x2013A0C
         EU: 0x2013AB4
+        NA: 0x2013A0C
       description: |-
         Gets one of the two accuracy values of a move or its ai_condition_random_chance field.
         
@@ -943,8 +943,8 @@ arm9:
         return: Move's accuracy1, accuracy2 or ai_condition_random_chance
     - name: GetMaxPp
       address:
-        NA: 0x2013A50
         EU: 0x2013AF8
+        NA: 0x2013A50
         JP: 0x2013A20
       description: |-
         Gets the maximum PP for a given move.
@@ -953,8 +953,8 @@ arm9:
         return: max PP for the given move, capped at 99
     - name: GetMoveCritChance
       address:
-        NA: 0x2013B10
         EU: 0x2013BB8
+        NA: 0x2013B10
         JP: 0x2013AE0
       description: |-
         Gets the critical hit chance of a move.
@@ -963,8 +963,8 @@ arm9:
         return: base power
     - name: IsRecoilMove
       address:
-        NA: 0x2013E14
         EU: 0x2013EBC
+        NA: 0x2013E14
       description: |-
         Checks if the given move is a recoil move (affected by Reckless).
         
@@ -972,8 +972,8 @@ arm9:
         return: bool
     - name: IsPunchMove
       address:
-        NA: 0x2014D18
         EU: 0x2014DC0
+        NA: 0x2014D18
       description: |-
         Checks if the given move is a punch move (affected by Iron Fist).
         
@@ -981,8 +981,8 @@ arm9:
         return: bool
     - name: GetMoveCategory
       address:
-        NA: 0x20151C8
         EU: 0x2015270
+        NA: 0x20151C8
         JP: 0x2015198
       description: |-
         Gets a move's category (physical, special, status).
@@ -991,8 +991,8 @@ arm9:
         return: move category enum
     - name: LoadWteFromRom
       address:
-        NA: 0x201DE4C
         EU: 0x201DEE8
+        NA: 0x201DE4C
         JP: 0x201DEA4
       description: |-
         Loads a SIR0-wrapped WTE file from ROM, and returns a handle to it
@@ -1002,8 +1002,8 @@ arm9:
         r2: load file flags
     - name: LoadWteFromFileDirectory
       address:
-        NA: 0x201DEC4
         EU: 0x201DF60
+        NA: 0x201DEC4
         JP: 0x201DF1C
       description: |-
         Loads a SIR0-wrapped WTE file from a file directory, and returns a handle to it
@@ -1014,8 +1014,8 @@ arm9:
         r3: malloc flags
     - name: UnloadWte
       address:
-        NA: 0x201DF18
         EU: 0x201DFB4
+        NA: 0x201DF18
         JP: 0x201DF70
       description: |-
         Frees the buffer used to store the WTE data in the handle, and sets both pointers to null
@@ -1023,8 +1023,8 @@ arm9:
         r0: pointer to wte handle
     - name: HandleSir0Translation
       address:
-        NA: 0x201F4B4
         EU: 0x201F550
+        NA: 0x201F4B4
         JP: 0x201F50C
       description: |-
         Translates the offsets in a SIR0 file into NDS memory addresses, changes the magic number to SirO (opened), and returns a pointer to the first pointer specified in the SIR0 header (beginning of the data).
@@ -1033,8 +1033,8 @@ arm9:
         r1: pointer to source file buffer
     - name: HandleSir0TranslationVeneer
       address:
-        NA: 0x201F58C
         EU: 0x201F628
+        NA: 0x201F58C
       description: |-
         Likely a linker-generated veneer for HandleSir0Translation.
         
@@ -1044,8 +1044,8 @@ arm9:
         r1: pointer to source file buffer
     - name: GetLanguageType
       address:
-        NA: 0x20205A0
         EU: 0x2020688
+        NA: 0x20205A0
         JP: 0x20205F8
       description: |-
         Gets the language type.
@@ -1055,8 +1055,8 @@ arm9:
         return: language type
     - name: GetLanguage
       address:
-        NA: 0x20205B0
         EU: 0x20206B0
+        NA: 0x20205B0
         JP: 0x2020608
       description: |-
         Gets the single-byte language ID of the current program.
@@ -1066,8 +1066,8 @@ arm9:
         return: language ID
     - name: PreprocessString
       address:
-        NA: 0x20223F0
         EU: 0x20225EC
+        NA: 0x20223F0
         JP: 0x2022440
       description: |-
         An enhanced sprintf, which recognizes certain tags and replaces them with appropiate game values.
@@ -1083,8 +1083,8 @@ arm9:
         stack[0]: pointer to preprocessor args
     - name: StrcpySimple
       address:
-        NA: 0x2025100
         EU: 0x20253CC
+        NA: 0x2025100
         JP: 0x2025150
       description: |-
         A simple implementation of the strcpy(3) C library function.
@@ -1095,8 +1095,8 @@ arm9:
         r1: src
     - name: StrncpySimple
       address:
-        NA: 0x202511C
         EU: 0x20253E8
+        NA: 0x202511C
         JP: 0x202516C
       description: |-
         A simple implementation of the strncpy(3) C library function.
@@ -1108,8 +1108,8 @@ arm9:
         r2: n
     - name: StringFromMessageId
       address:
-        NA: 0x20258C4
         EU: 0x2025B90
+        NA: 0x20258C4
         JP: 0x20258A4
       description: |-
         Gets the string corresponding to a given message ID.
@@ -1118,8 +1118,8 @@ arm9:
         return: string from the string files with the given message ID
     - name: SetScreenWindowsColor
       address:
-        NA: 0x2027A68
         EU: 0x2027D5C
+        NA: 0x2027A68
         JP: 0x2027DC8
       description: |-
         Sets the palette of the frames of windows in the specified screen
@@ -1128,8 +1128,8 @@ arm9:
         r1: is upper screen
     - name: SetBothScreensWindowsColor
       address:
-        NA: 0x2027A80
         EU: 0x2027D74
+        NA: 0x2027A80
         JP: 0x2027DE0
       description: |-
         Sets the palette of the frames of windows in both screens
@@ -1137,24 +1137,24 @@ arm9:
         r0: palette index
     - name: GetNotifyNote
       address:
-        NA: 0x20484A0
         EU: 0x20487BC
+        NA: 0x20484A0
       description: |-
         Returns the current value of NOTIFY_NOTE.
         
         return: bool
     - name: SetNotifyNote
       address:
-        NA: 0x20484B0
         EU: 0x20487CC
+        NA: 0x20484B0
       description: |-
         Sets NOTIFY_NOTE to the given value.
         
         r0: bool
     - name: InitMainTeamAfterQuiz
       address:
-        NA: 0x20487C4
         EU: 0x2048AE0
+        NA: 0x20487C4
         JP: 0x2048B30
       description: |-
         Implements SPECIAL_PROC_INIT_MAIN_TEAM_AFTER_QUIZ (see ScriptSpecialProcessCall).
@@ -1162,8 +1162,8 @@ arm9:
         No params.
     - name: ScriptSpecialProcess0x3
       address:
-        NA: 0x2048A0C
         EU: 0x2048D28
+        NA: 0x2048A0C
         JP: 0x2048D78
       description: |-
         Implements SPECIAL_PROC_0x3 (see ScriptSpecialProcessCall).
@@ -1171,8 +1171,8 @@ arm9:
         No params.
     - name: ScriptSpecialProcess0x4
       address:
-        NA: 0x2048A84
         EU: 0x2048DA0
+        NA: 0x2048A84
         JP: 0x2048DF0
       description: |-
         Implements SPECIAL_PROC_0x4 (see ScriptSpecialProcessCall).
@@ -1180,8 +1180,8 @@ arm9:
         No params.
     - name: NoteSaveBase
       address:
-        NA: 0x2048F84
         EU: 0x20492A0
+        NA: 0x2048F84
         JP: 0x20492F0
       description: |-
         Probably related to saving or quicksaving?
@@ -1193,8 +1193,8 @@ arm9:
         return: status code
     - name: NoteLoadBase
       address:
-        NA: 0x2049370
         EU: 0x20496A8
+        NA: 0x2049370
         JP: 0x20496DC
       description: |-
         Probably related to loading a save file or quicksave?
@@ -1204,16 +1204,16 @@ arm9:
         return: status code
     - name: GetGameMode
       address:
-        NA: 0x204AFC0
         EU: 0x204B2F8
+        NA: 0x204AFC0
       description: |-
         Gets the value of GAME_MODE.
         
         return: game mode
     - name: InitScriptVariableValues
       address:
-        NA: 0x204B04C
         EU: 0x204B384
+        NA: 0x204B04C
         JP: 0x204B3B4
       description: |-
         Initialize the script variable values table (SCRIPT_VARS_VALUES).
@@ -1223,16 +1223,16 @@ arm9:
         No params.
     - name: InitEventFlagScriptVars
       address:
-        NA: 0x204B304
         EU: 0x204B63C
+        NA: 0x204B304
       description: |-
         Initializes an assortment of event flag script variables (see the code for an exhaustive list).
         
         No params.
     - name: ZinitScriptVariable
       address:
-        NA: 0x204B434
         EU: 0x204B76C
+        NA: 0x204B434
         JP: 0x204B794
       description: |-
         Zero-initialize the values of the given script variable.
@@ -1241,8 +1241,8 @@ arm9:
         r1: script variable ID
     - name: LoadScriptVariableRaw
       address:
-        NA: 0x204B49C
         EU: 0x204B7D4
+        NA: 0x204B49C
         JP: 0x204B7FC
       description: |-
         Loads a script variable descriptor for a given ID.
@@ -1252,8 +1252,8 @@ arm9:
         r2: script variable ID
     - name: LoadScriptVariableValue
       address:
-        NA: 0x204B4EC
         EU: 0x204B824
+        NA: 0x204B4EC
         JP: 0x204B84C
       description: |-
         Loads the value of a script variable.
@@ -1263,8 +1263,8 @@ arm9:
         return: value
     - name: LoadScriptVariableValueAtIndex
       address:
-        NA: 0x204B678
         EU: 0x204B9B0
+        NA: 0x204B678
         JP: 0x204B9D8
       description: |-
         Loads the value of a script variable at some index (for script variables that are arrays).
@@ -1275,8 +1275,8 @@ arm9:
         return: value
     - name: SaveScriptVariableValue
       address:
-        NA: 0x204B820
         EU: 0x204BB58
+        NA: 0x204B820
         JP: 0x204BB80
       description: |-
         Saves the given value to a script variable.
@@ -1286,8 +1286,8 @@ arm9:
         r2: value to save
     - name: SaveScriptVariableValueAtIndex
       address:
-        NA: 0x204B988
         EU: 0x204BCC0
+        NA: 0x204B988
         JP: 0x204BCE8
       description: |-
         Saves the given value to a script variable at some index (for script variables that are arrays).
@@ -1298,8 +1298,8 @@ arm9:
         r3: value to save
     - name: LoadScriptVariableValueSum
       address:
-        NA: 0x204BB00
         EU: 0x204BE38
+        NA: 0x204BB00
         JP: 0x204BE60
       description: |-
         Loads the sum of all values of a given script variable (for script variables that are arrays).
@@ -1309,8 +1309,8 @@ arm9:
         return: sum of values
     - name: LoadScriptVariableValueBytes
       address:
-        NA: 0x204BB64
         EU: 0x204BE9C
+        NA: 0x204BB64
         JP: 0x204BEC4
       description: |-
         Loads some number of bytes from the value of a given script variable.
@@ -1320,8 +1320,8 @@ arm9:
         r2: number of bytes to load
     - name: SaveScriptVariableValueBytes
       address:
-        NA: 0x204BBCC
         EU: 0x204BF04
+        NA: 0x204BBCC
         JP: 0x204BF2C
       description: |-
         Saves some number of bytes to the given script variable.
@@ -1331,8 +1331,8 @@ arm9:
         r2: number of bytes
     - name: ScriptVariablesEqual
       address:
-        NA: 0x204BC18
         EU: 0x204BF50
+        NA: 0x204BC18
         JP: 0x204BF78
       description: |-
         Checks if two script variables have equal values. For arrays, compares elementwise for the length of the first variable.
@@ -1343,8 +1343,8 @@ arm9:
         return: true if values are equal, false otherwise
     - name: EventFlagBackup
       address:
-        NA: 0x204C1E4
         EU: 0x204C51C
+        NA: 0x204C1E4
         JP: 0x204C544
       description: |-
         Saves event flag script variables (see the code for an exhaustive list) to their respective BACKUP script variables, but only in certain game modes.
@@ -1354,8 +1354,8 @@ arm9:
         No params.
     - name: DumpScriptVariableValues
       address:
-        NA: 0x204C408
         EU: 0x204C740
+        NA: 0x204C408
         JP: 0x204C768
       description: |-
         Runs EventFlagBackup, then copies the script variable values table (SCRIPT_VARS_VALUES) to the given pointer.
@@ -1364,8 +1364,8 @@ arm9:
         return: always 1
     - name: RestoreScriptVariableValues
       address:
-        NA: 0x204C430
         EU: 0x204C768
+        NA: 0x204C430
         JP: 0x204C790
       description: |-
         Restores the script variable values table (SCRIPT_VARS_VALUES) with the given data. The source data is assumed to be exactly 1024 bytes in length.
@@ -1374,8 +1374,8 @@ arm9:
         return: whether the restored value for VAR_VERSION is equal to its default value
     - name: InitScenarioScriptVars
       address:
-        NA: 0x204C488
         EU: 0x204C7C0
+        NA: 0x204C488
         JP: 0x204C7E8
       description: |-
         Initializes most of the SCENARIO_* script variables (except SCENARIO_TALK_BIT_FLAG for some reason). Also initializes the PLAY_OLD_GAME variable.
@@ -1383,8 +1383,8 @@ arm9:
         No params.
     - name: SetScenarioScriptVar
       address:
-        NA: 0x204C618
         EU: 0x204C950
+        NA: 0x204C618
         JP: 0x204C978
       description: |-
         Sets the given SCENARIO_* script variable with a given pair of values [val0, val1].
@@ -1396,8 +1396,8 @@ arm9:
         r2: val1
     - name: GetSpecialEpisodeType
       address:
-        NA: 0x204C8EC
         EU: 0x204CC24
+        NA: 0x204C8EC
         JP: 0x204CC4C
       description: |-
         Gets the special episode type from the SPECIAL_EPISODE_TYPE script variable.
@@ -1405,8 +1405,8 @@ arm9:
         return: special episode type
     - name: ScenarioFlagBackup
       address:
-        NA: 0x204CCB8
         EU: 0x204CFF0
+        NA: 0x204CCB8
         JP: 0x204D018
       description: |-
         Saves scenario flag script variables (SCENARIO_SELECT, SCENARIO_MAIN_BIT_FLAG) to their respective BACKUP script variables, but only in certain game modes.
@@ -1416,8 +1416,8 @@ arm9:
         No params.
     - name: InitWorldMapScriptVars
       address:
-        NA: 0x204CD88
         EU: 0x204D0C0
+        NA: 0x204CD88
         JP: 0x204D0E8
       description: |-
         Initializes the WORLD_MAP_* script variable values (IDs 0x55-0x57).
@@ -1425,8 +1425,8 @@ arm9:
         No params.
     - name: InitDungeonListScriptVars
       address:
-        NA: 0x204CE90
         EU: 0x204D1C8
+        NA: 0x204CE90
         JP: 0x204D1F0
       description: |-
         Initializes the DUNGEON_*_LIST script variable values (IDs 0x4f-0x54).
@@ -1434,16 +1434,16 @@ arm9:
         No params.
     - name: SetDungeonTipShown
       address:
-        NA: 0x204D250
         EU: 0x204D588
+        NA: 0x204D250
       description: |-
         Marks a dungeon tip as already shown to the player
         
         r0: Dungeon tip ID
     - name: GetDungeonTipShown
       address:
-        NA: 0x204D290
         EU: 0x204D5C8
+        NA: 0x204D290
       description: |-
         Checks if a dungeon tip has already been shown before or not.
         
@@ -1451,8 +1451,8 @@ arm9:
         return: True if the tip has been shown before, false otherwise.
     - name: MonsterSpawnsEnabled
       address:
-        NA: 0x204D360
         EU: 0x204D698
+        NA: 0x204D360
         JP: 0x204D6C0
       description: |-
         Always returns true.
@@ -1463,8 +1463,8 @@ arm9:
         return: bool (always true)
     - name: SetAdventureLogStructLocation
       address:
-        NA: 0x204FA24
         EU: 0x204FD5C
+        NA: 0x204FA24
         JP: 0x204FD70
       description: |-
         Sets the location of the adventure log struct in memory.
@@ -1474,8 +1474,8 @@ arm9:
         No params.
     - name: SetAdventureLogDungeonFloor
       address:
-        NA: 0x204FA3C
         EU: 0x204FD74
+        NA: 0x204FA3C
         JP: 0x204FD88
       description: |-
         Sets the current dungeon floor pair.
@@ -1483,8 +1483,8 @@ arm9:
         r0: struct dungeon_floor_pair
     - name: GetAdventureLogDungeonFloor
       address:
-        NA: 0x204FA5C
         EU: 0x204FD94
+        NA: 0x204FA5C
         JP: 0x204FDA8
       description: |-
         Gets the current dungeon floor pair.
@@ -1492,8 +1492,8 @@ arm9:
         return: struct dungeon_floor_pair
     - name: ClearAdventureLogStruct
       address:
-        NA: 0x204FA70
         EU: 0x204FDA8
+        NA: 0x204FA70
         JP: 0x204FDBC
       description: |-
         Clears the adventure log structure.
@@ -1501,8 +1501,8 @@ arm9:
         No params.
     - name: SetAdventureLogCompleted
       address:
-        NA: 0x204FB9C
         EU: 0x204FED4
+        NA: 0x204FB9C
         JP: 0x204FEE8
       description: |-
         Marks one of the adventure log entry as completed.
@@ -1510,8 +1510,8 @@ arm9:
         r0: entry ID
     - name: IsAdventureLogNotEmpty
       address:
-        NA: 0x204FBC4
         EU: 0x204FEFC
+        NA: 0x204FBC4
         JP: 0x204FF10
       description: |-
         Checks if at least one of the adventure log entry is completed.
@@ -1519,8 +1519,8 @@ arm9:
         return: bool
     - name: GetAdventureLogCompleted
       address:
-        NA: 0x204FBFC
         EU: 0x204FF34
+        NA: 0x204FBFC
         JP: 0x204FF48
       description: |-
         Checks if one adventure log entry is completed.
@@ -1529,8 +1529,8 @@ arm9:
         return: bool
     - name: IncrementNbDungeonsCleared
       address:
-        NA: 0x204FC28
         EU: 0x204FF60
+        NA: 0x204FC28
         JP: 0x204FF74
       description: |-
         Increments by 1 the number of dungeons cleared.
@@ -1540,8 +1540,8 @@ arm9:
         No params.
     - name: GetNbDungeonsCleared
       address:
-        NA: 0x204FC6C
         EU: 0x204FFA4
+        NA: 0x204FC6C
         JP: 0x204FFB8
       description: |-
         Gets the number of dungeons cleared.
@@ -1549,8 +1549,8 @@ arm9:
         return: the number of dungeons cleared
     - name: IncrementNbFriendRescues
       address:
-        NA: 0x204FC80
         EU: 0x204FFB8
+        NA: 0x204FC80
         JP: 0x204FFCC
       description: |-
         Increments by 1 the number of successful friend rescues.
@@ -1558,8 +1558,8 @@ arm9:
         No params.
     - name: GetNbFriendRescues
       address:
-        NA: 0x204FCC8
         EU: 0x2050000
+        NA: 0x204FCC8
         JP: 0x2050014
       description: |-
         Gets the number of successful friend rescues.
@@ -1567,8 +1567,8 @@ arm9:
         return: the number of successful friend rescues
     - name: IncrementNbEvolutions
       address:
-        NA: 0x204FCDC
         EU: 0x2050014
+        NA: 0x204FCDC
         JP: 0x2050028
       description: |-
         Increments by 1 the number of evolutions.
@@ -1576,8 +1576,8 @@ arm9:
         No params.
     - name: GetNbEvolutions
       address:
-        NA: 0x204FD24
         EU: 0x205005C
+        NA: 0x204FD24
         JP: 0x2050070
       description: |-
         Gets the number of evolutions.
@@ -1585,8 +1585,8 @@ arm9:
         return: the number of evolutions
     - name: IncrementNbSteals
       address:
-        NA: 0x204FD38
         EU: 0x2050070
+        NA: 0x204FD38
         JP: 0x2050084
       description: |-
         Leftover from Time & Darkness. Does not do anything.
@@ -1596,8 +1596,8 @@ arm9:
         No params.
     - name: IncrementNbEggsHatched
       address:
-        NA: 0x204FD3C
         EU: 0x2050074
+        NA: 0x204FD3C
         JP: 0x2050088
       description: |-
         Increments by 1 the number of eggs hatched.
@@ -1605,8 +1605,8 @@ arm9:
         No params.
     - name: GetNbEggsHatched
       address:
-        NA: 0x204FD78
         EU: 0x20500B0
+        NA: 0x204FD78
         JP: 0x20500C4
       description: |-
         Gets the number of eggs hatched.
@@ -1614,8 +1614,8 @@ arm9:
         return: the number of eggs hatched
     - name: GetNbPokemonJoined
       address:
-        NA: 0x204FD8C
         EU: 0x20500C4
+        NA: 0x204FD8C
         JP: 0x20500D8
       description: |-
         Gets the number of different pokémon that joined.
@@ -1623,8 +1623,8 @@ arm9:
         return: the number of different pokémon that joined
     - name: GetNbMovesLearned
       address:
-        NA: 0x204FDA0
         EU: 0x20500D8
+        NA: 0x204FDA0
         JP: 0x20500EC
       description: |-
         Gets the number of different moves learned.
@@ -1632,8 +1632,8 @@ arm9:
         return: the number of different moves learned
     - name: SetVictoriesOnOneFloor
       address:
-        NA: 0x204FDB4
         EU: 0x20500EC
+        NA: 0x204FDB4
         JP: 0x2050100
       description: |-
         Sets the record of victories on one floor.
@@ -1641,8 +1641,8 @@ arm9:
         r0: the new record of victories
     - name: GetVictoriesOnOneFloor
       address:
-        NA: 0x204FDE8
         EU: 0x2050120
+        NA: 0x204FDE8
         JP: 0x2050134
       description: |-
         Gets the record of victories on one floor.
@@ -1650,8 +1650,8 @@ arm9:
         return: the record of victories
     - name: SetPokemonJoined
       address:
-        NA: 0x204FDFC
         EU: 0x2050134
+        NA: 0x204FDFC
         JP: 0x2050148
       description: |-
         Marks one pokémon as joined.
@@ -1659,8 +1659,8 @@ arm9:
         r0: monster ID
     - name: SetPokemonBattled
       address:
-        NA: 0x204FE58
         EU: 0x2050190
+        NA: 0x204FE58
         JP: 0x20501A4
       description: |-
         Marks one pokémon as battled.
@@ -1668,8 +1668,8 @@ arm9:
         r0: monster ID
     - name: GetNbPokemonBattled
       address:
-        NA: 0x204FEB4
         EU: 0x20501EC
+        NA: 0x204FEB4
         JP: 0x2050200
       description: |-
         Gets the number of different pokémon that battled against you.
@@ -1677,8 +1677,8 @@ arm9:
         return: the number of different pokémon that battled against you
     - name: IncrementNbBigTreasureWins
       address:
-        NA: 0x204FEC8
         EU: 0x2050200
+        NA: 0x204FEC8
         JP: 0x2050214
       description: |-
         Increments by 1 the number of big treasure wins.
@@ -1688,8 +1688,8 @@ arm9:
         No params.
     - name: SetNbBigTreasureWins
       address:
-        NA: 0x204FEE8
         EU: 0x2050220
+        NA: 0x204FEE8
         JP: 0x2050234
       description: |-
         Sets the number of big treasure wins.
@@ -1697,8 +1697,8 @@ arm9:
         r0: the new number of big treasure wins
     - name: GetNbBigTreasureWins
       address:
-        NA: 0x204FF20
         EU: 0x2050258
+        NA: 0x204FF20
         JP: 0x205026C
       description: |-
         Gets the number of big treasure wins.
@@ -1706,8 +1706,8 @@ arm9:
         return: the number of big treasure wins
     - name: SetNbRecycled
       address:
-        NA: 0x204FF34
         EU: 0x205026C
+        NA: 0x204FF34
         JP: 0x2050280
       description: |-
         Sets the number of items recycled.
@@ -1715,8 +1715,8 @@ arm9:
         r0: the new number of items recycled
     - name: GetNbRecycled
       address:
-        NA: 0x204FF6C
         EU: 0x20502A4
+        NA: 0x204FF6C
         JP: 0x20502B8
       description: |-
         Gets the number of items recycled.
@@ -1724,8 +1724,8 @@ arm9:
         return: the number of items recycled
     - name: IncrementNbSkyGiftsSent
       address:
-        NA: 0x204FF80
         EU: 0x20502B8
+        NA: 0x204FF80
         JP: 0x20502CC
       description: |-
         Increments by 1 the number of sky gifts sent.
@@ -1735,8 +1735,8 @@ arm9:
         No params.
     - name: SetNbSkyGiftsSent
       address:
-        NA: 0x204FFA0
         EU: 0x20502D8
+        NA: 0x204FFA0
         JP: 0x20502EC
       description: |-
         Sets the number of Sky Gifts sent.
@@ -1744,8 +1744,8 @@ arm9:
         return: the number of Sky Gifts sent
     - name: GetNbSkyGiftsSent
       address:
-        NA: 0x204FFD8
         EU: 0x2050310
+        NA: 0x204FFD8
         JP: 0x2050324
       description: |-
         Gets the number of Sky Gifts sent.
@@ -1753,8 +1753,8 @@ arm9:
         return: the number of Sky Gifts sent
     - name: ComputeSpecialCounters
       address:
-        NA: 0x204FFEC
         EU: 0x2050324
+        NA: 0x204FFEC
         JP: 0x2050338
       description: |-
         Computes the counters from the bit fields in the adventure log, as they are not updated automatically when bit fields are altered.
@@ -1764,8 +1764,8 @@ arm9:
         No params.
     - name: RecruitSpecialPokemonLog
       address:
-        NA: 0x2050244
         EU: 0x205057C
+        NA: 0x2050244
         JP: 0x2050590
       description: |-
         Marks a specified special pokémon as recruited in the adventure log.
@@ -1773,8 +1773,8 @@ arm9:
         r0: monster ID
     - name: IncrementNbFainted
       address:
-        NA: 0x20502B0
         EU: 0x20505E8
+        NA: 0x20502B0
         JP: 0x20505FC
       description: |-
         Increments by 1 the number of times you fainted.
@@ -1782,8 +1782,8 @@ arm9:
         No params.
     - name: GetNbFainted
       address:
-        NA: 0x20502EC
         EU: 0x2050624
+        NA: 0x20502EC
         JP: 0x2050638
       description: |-
         Gets the number of times you fainted.
@@ -1791,8 +1791,8 @@ arm9:
         return: the number of times you fainted
     - name: SetItemAcquired
       address:
-        NA: 0x2050300
         EU: 0x2050638
+        NA: 0x2050300
         JP: 0x205064C
       description: |-
         Marks one specific item as acquired.
@@ -1800,8 +1800,8 @@ arm9:
         r0: item ID
     - name: GetNbItemAcquired
       address:
-        NA: 0x20503CC
         EU: 0x2050704
+        NA: 0x20503CC
         JP: 0x2050718
       description: |-
         Gets the number of items acquired.
@@ -1809,8 +1809,8 @@ arm9:
         return: the number of items acquired
     - name: SetChallengeLetterCleared
       address:
-        NA: 0x2050420
         EU: 0x2050758
+        NA: 0x2050420
         JP: 0x205076C
       description: |-
         Sets a challenge letter as cleared.
@@ -1818,8 +1818,8 @@ arm9:
         r0: challenge ID
     - name: GetSentryDutyGamePoints
       address:
-        NA: 0x20504A4
         EU: 0x20507DC
+        NA: 0x20504A4
         JP: 0x20507F0
       description: |-
         Gets the points for the associated rank in the footprints minigame.
@@ -1828,8 +1828,8 @@ arm9:
         return: points
     - name: SetSentryDutyGamePoints
       address:
-        NA: 0x20504BC
         EU: 0x20507F4
+        NA: 0x20504BC
         JP: 0x2050808
       description: |-
         Sets a new record in the footprints minigame.
@@ -1838,8 +1838,8 @@ arm9:
         return: the rank (range 0-4, 1st to 5th; -1 if out of ranking)
     - name: SubFixedPoint
       address:
-        NA: 0x2050F10
         EU: 0x2051248
+        NA: 0x2050F10
         JP: 0x2051260
       description: |-
         Compute the subtraction of two decimal fixed-point numbers (16 fraction bits).
@@ -1851,8 +1851,8 @@ arm9:
         return: max(float - decrement, 0)
     - name: BinToDecFixedPoint
       address:
-        NA: 0x2051020
         EU: 0x2051358
+        NA: 0x2051020
         JP: 0x2051370
       description: |-
         Convert a binary fixed-point number (16 fraction bits) to the decimal fixed-point number (16 fraction bits) used for belly calculations. Thousandths are floored.
@@ -1863,8 +1863,8 @@ arm9:
         return: fractional number in decimal fixed-point format
     - name: CeilFixedPoint
       address:
-        NA: 0x2051064
         EU: 0x205139C
+        NA: 0x2051064
         JP: 0x20513B4
       description: |-
         Compute the ceiling of a decimal fixed-point number (16 fraction bits).
@@ -1875,8 +1875,8 @@ arm9:
         return: ceil(float)
     - name: DungeonGoesUp
       address:
-        NA: 0x2051288
         EU: 0x20515C0
+        NA: 0x2051288
         JP: 0x20515D8
       description: |-
         Returns whether the specified dungeon is considered as going upward or not
@@ -1885,8 +1885,8 @@ arm9:
         return: bool
     - name: JoinedAtRangeCheck
       address:
-        NA: 0x2051490
         EU: 0x20517C8
+        NA: 0x2051490
       description: |-
         Returns whether a certain joined_at field value is between dungeon_id::DUNGEON_JOINED_AT_BIDOOF and dungeon_id::DUNGEON_DUMMY_0xE3.
         
@@ -1894,8 +1894,8 @@ arm9:
         return: bool
     - name: ShouldCauseGameOverOnFaint
       address:
-        NA: 0x2051760
         EU: 0x2051A98
+        NA: 0x2051760
       description: |-
         Returns whether a game over should happen when a monster with the specified joined_at ID faints (as long as the other conditions are met). It might have a more generic meaning.
         
@@ -1903,8 +1903,8 @@ arm9:
         return: bool
     - name: GetMonsterGender
       address:
-        NA: 0x20527A8
         EU: 0x2052AE0
+        NA: 0x20527A8
       description: |-
         Returns the gender field of a monster given its ID.
         
@@ -1912,8 +1912,8 @@ arm9:
         return: monster gender
     - name: GetSpriteSize
       address:
-        NA: 0x20527E0
         EU: 0x2052B18
+        NA: 0x20527E0
       description: |-
         Returns the sprite size of the specified monster. If the size is between 1 and 6, 6 will be returned.
         
@@ -1921,8 +1921,8 @@ arm9:
         return: sprite size
     - name: GetSpriteFileSize
       address:
-        NA: 0x205281C
         EU: 0x2052B54
+        NA: 0x205281C
       description: |-
         Returns the sprite file size of the specified monster.
         
@@ -1930,8 +1930,8 @@ arm9:
         return: sprite file size
     - name: GetMonsterPreEvolution
       address:
-        NA: 0x20529A8
         EU: 0x2052CE0
+        NA: 0x20529A8
       description: |-
         Returns the pre-evolution id of a monster given its ID.
         
@@ -1939,8 +1939,8 @@ arm9:
         return: ID of the monster that evolves into the one specified in r0
     - name: GetEvolutions
       address:
-        NA: 0x2053E88
         EU: 0x2054204
+        NA: 0x2053E88
       description: |-
         Returns a list of all the possible evolutions for a given monster id.
         
@@ -1951,8 +1951,8 @@ arm9:
         return: Number of possible evolutions for the specified monster id
     - name: GetMonsterIdFromSpawnEntry
       address:
-        NA: 0x2054480
         EU: 0x20547FC
+        NA: 0x2054480
       description: |-
         Returns the monster ID of the specified monster spawn entry
         
@@ -1960,8 +1960,8 @@ arm9:
         return: monster_spawn_entry::id
     - name: GetMonsterLevelFromSpawnEntry
       address:
-        NA: 0x20544B8
         EU: 0x2054834
+        NA: 0x20544B8
         JP: 0x20547F0
       description: |-
         Returns the level of the specified monster spawn entry.
@@ -1970,8 +1970,8 @@ arm9:
         return: uint8_t
     - name: GetMonsterGenderVeneer
       address:
-        NA: 0x2054760
         EU: 0x2054ADC
+        NA: 0x2054760
       description: |-
         Likely a linker-generated veneer for GetMonsterGender.
         
@@ -1981,8 +1981,8 @@ arm9:
         return: monster gender
     - name: IsUnown
       address:
-        NA: 0x2054A88
         EU: 0x2054E04
+        NA: 0x2054A88
         JP: 0x2054DC0
       description: |-
         Checks if a monster ID is an Unown.
@@ -1991,8 +1991,8 @@ arm9:
         return: bool
     - name: IsShaymin
       address:
-        NA: 0x2054AA4
         EU: 0x2054E20
+        NA: 0x2054AA4
         JP: 0x2054DDC
       description: |-
         Checks if a monster ID is a Shaymin form.
@@ -2001,8 +2001,8 @@ arm9:
         return: bool
     - name: IsCastform
       address:
-        NA: 0x2054AD4
         EU: 0x2054E50
+        NA: 0x2054AD4
         JP: 0x2054E0C
       description: |-
         Checks if a monster ID is a Castform form.
@@ -2011,8 +2011,8 @@ arm9:
         return: bool
     - name: IsCherrim
       address:
-        NA: 0x2054B2C
         EU: 0x2054EA8
+        NA: 0x2054B2C
         JP: 0x2054E64
       description: |-
         Checks if a monster ID is a Cherrim form.
@@ -2021,8 +2021,8 @@ arm9:
         return: bool
     - name: IsDeoxys
       address:
-        NA: 0x2054B74
         EU: 0x2054EF0
+        NA: 0x2054B74
         JP: 0x2054EAC
       description: |-
         Checks if a monster ID is a Deoxys form.
@@ -2031,8 +2031,8 @@ arm9:
         return: bool
     - name: IsMonsterOnTeam
       address:
-        NA: 0x2055148
         EU: 0x20554C4
+        NA: 0x2055148
         JP: 0x2055480
       description: |-
         Checks if a given monster is on the exploration team (not necessarily the active party)?
@@ -2042,8 +2042,8 @@ arm9:
         return: bool
     - name: SetTeamSetupHeroAndPartnerOnly
       address:
-        NA: 0x20569CC
         EU: 0x2056D48
+        NA: 0x20569CC
         JP: 0x2056D68
       description: |-
         Implements SPECIAL_PROC_SET_TEAM_SETUP_HERO_AND_PARTNER_ONLY (see ScriptSpecialProcessCall).
@@ -2051,8 +2051,8 @@ arm9:
         No params.
     - name: SetTeamSetupHeroOnly
       address:
-        NA: 0x2056AB0
         EU: 0x2056E2C
+        NA: 0x2056AB0
         JP: 0x2056E48
       description: |-
         Implements SPECIAL_PROC_SET_TEAM_SETUP_HERO_ONLY (see ScriptSpecialProcessCall).
@@ -2060,8 +2060,8 @@ arm9:
         No params.
     - name: GetPartyMembers
       address:
-        NA: 0x2056C20
         EU: 0x2056F9C
+        NA: 0x2056C20
         JP: 0x2056FB4
       description: |-
         Appears to get the team's active party members. Implements most of SPECIAL_PROC_IS_TEAM_SETUP_SOLO (see ScriptSpecialProcessCall).
@@ -2070,8 +2070,8 @@ arm9:
         return: Number of party members
     - name: IqSkillFlagTest
       address:
-        NA: 0x2058F04
         EU: 0x2059280
+        NA: 0x2058F04
         JP: 0x2059200
       description: |-
         Tests whether an IQ skill with a given ID is active.
@@ -2081,8 +2081,8 @@ arm9:
         return: bool
     - name: GetSosMailCount
       address:
-        NA: 0x205B97C
         EU: 0x205BCF8
+        NA: 0x205B97C
         JP: 0x205BC7C
       description: |-
         Implements SPECIAL_PROC_GET_SOS_MAIL_COUNT (see ScriptSpecialProcessCall).
@@ -2092,8 +2092,8 @@ arm9:
         return: SOS mail count
     - name: DungeonRequestsDone
       address:
-        NA: 0x205EDA4
         EU: 0x205F120
+        NA: 0x205EDA4
         JP: 0x205F0A4
       description: |-
         Seems to return the number of missions completed.
@@ -2105,8 +2105,8 @@ arm9:
         return: number of missions completed
     - name: DungeonRequestsDoneWrapper
       address:
-        NA: 0x205EE10
         EU: 0x205F18C
+        NA: 0x205EE10
       description: |-
         Calls DungeonRequestsDone with the second argument set to false.
         
@@ -2114,8 +2114,8 @@ arm9:
         return: number of mission completed
     - name: AnyDungeonRequestsDone
       address:
-        NA: 0x205EE20
         EU: 0x205F19C
+        NA: 0x205EE20
         JP: 0x205F120
       description: |-
         Calls DungeonRequestsDone with the second argument set to true, and converts the integer output to a boolean.
@@ -2124,8 +2124,8 @@ arm9:
         return: bool: whether the number of missions completed is greater than 0
     - name: ScriptSpecialProcess0x3D
       address:
-        NA: 0x2065B50
         EU: 0x2065ECC
+        NA: 0x2065B50
         JP: 0x2065E38
       description: |-
         Implements SPECIAL_PROC_0x3D (see ScriptSpecialProcessCall).
@@ -2133,8 +2133,8 @@ arm9:
         No params.
     - name: ScriptSpecialProcess0x3E
       address:
-        NA: 0x2065B60
         EU: 0x2065EDC
+        NA: 0x2065B60
         JP: 0x2065E48
       description: |-
         Implements SPECIAL_PROC_0x3E (see ScriptSpecialProcessCall).
@@ -2142,8 +2142,8 @@ arm9:
         No params.
     - name: ScriptSpecialProcess0x17
       address:
-        NA: 0x2065C48
         EU: 0x2065FC4
+        NA: 0x2065C48
         JP: 0x2065F30
       description: |-
         Implements SPECIAL_PROC_0x17 (see ScriptSpecialProcessCall).
@@ -2151,8 +2151,8 @@ arm9:
         No params.
     - name: ItemAtTableIdx
       address:
-        NA: 0x2065CF8
         EU: 0x2066074
+        NA: 0x2065CF8
         JP: 0x2065FE0
       description: |-
         Gets info about the item at a given item table (not sure what this table is...) index.
@@ -2163,8 +2163,8 @@ arm9:
         r1: [output] pointer to an owned_item
     - name: WaitForInterrupt
       address:
-        NA: 0x207BC30
         EU: 0x207BFC8
+        NA: 0x207BC30
         JP: 0x207BF18
       description: |-
         Presumably blocks until the program receives an interrupt.
@@ -2174,8 +2174,8 @@ arm9:
         No params.
     - name: FileInit
       address:
-        NA: 0x207F3E4
         EU: 0x207F77C
+        NA: 0x207F3E4
         JP: 0x207F6CC
       description: |-
         Initializes a file_stream structure for file I/O.
@@ -2185,8 +2185,8 @@ arm9:
         r0: file_stream pointer
     - name: Abs
       address:
-        NA: 0x208655C
         EU: 0x20868F4
+        NA: 0x208655C
         JP: 0x2086844
       description: |-
         Takes the absolute value of an integer.
@@ -2195,8 +2195,8 @@ arm9:
         return: abs(x)
     - name: Mbtowc
       address:
-        NA: 0x20871BC
         EU: 0x2087554
+        NA: 0x20871BC
         JP: 0x20874A4
       description: |-
         The mbtowc(3) C library function.
@@ -2207,8 +2207,8 @@ arm9:
         return: number of consumed bytes, or -1 on failure
     - name: TryAssignByte
       address:
-        NA: 0x20871F4
         EU: 0x208758C
+        NA: 0x20871F4
         JP: 0x20874DC
       description: |-
         Assign a byte to the target of a pointer if the pointer is non-null.
@@ -2218,8 +2218,8 @@ arm9:
         return: true on success, false on failure
     - name: TryAssignByteWrapper
       address:
-        NA: 0x2087208
         EU: 0x20875A0
+        NA: 0x2087208
         JP: 0x20874F0
       description: |-
         Wrapper around TryAssignByte.
@@ -2231,8 +2231,8 @@ arm9:
         return: true on success, false on failure
     - name: Wcstombs
       address:
-        NA: 0x2087224
         EU: 0x20875BC
+        NA: 0x2087224
         JP: 0x208750C
       description: |-
         The wcstombs(3) C library function.
@@ -2243,8 +2243,8 @@ arm9:
         return: characters converted
     - name: Memcpy
       address:
-        NA: 0x208729C
         EU: 0x2087634
+        NA: 0x208729C
         JP: 0x2087584
       description: |-
         The memcpy(3) C library function.
@@ -2254,8 +2254,8 @@ arm9:
         r2: n
     - name: Memmove
       address:
-        NA: 0x20872BC
         EU: 0x2087654
+        NA: 0x20872BC
         JP: 0x20875A4
       description: |-
         The memmove(3) C library function.
@@ -2267,8 +2267,8 @@ arm9:
         r2: n
     - name: Memset
       address:
-        NA: 0x2087308
         EU: 0x20876A0
+        NA: 0x2087308
         JP: 0x20875F0
       description: |-
         The memset(3) C library function.
@@ -2281,8 +2281,8 @@ arm9:
         return: s
     - name: Memchr
       address:
-        NA: 0x208731C
         EU: 0x20876B4
+        NA: 0x208731C
         JP: 0x2087604
       description: |-
         The memchr(3) C library function.
@@ -2293,8 +2293,8 @@ arm9:
         return: pointer to first occurrence of c in s, or a null pointer if no match
     - name: Memcmp
       address:
-        NA: 0x2087348
         EU: 0x20876E0
+        NA: 0x2087348
         JP: 0x2087630
       description: |-
         The memcmp(3) C library function.
@@ -2305,8 +2305,8 @@ arm9:
         return: comparison value
     - name: MemsetInternal
       address:
-        NA: 0x2087388
         EU: 0x2087720
+        NA: 0x2087388
         JP: 0x2087670
       description: |-
         The actual memory-setting implementation for the memset(3) C library function.
@@ -2318,8 +2318,8 @@ arm9:
         r2: n
     - name: VsprintfInternalSlice
       address:
-        NA: 0x2088C74
         EU: 0x208900C
+        NA: 0x2088C74
         JP: 0x2088F5C
       description: |-
         This is what implements the bulk of VsprintfInternal.
@@ -2333,8 +2333,8 @@ arm9:
         return: number of characters printed, excluding the null-terminator
     - name: TryAppendToSlice
       address:
-        NA: 0x2089498
         EU: 0x2089830
+        NA: 0x2089498
         JP: 0x2089780
       description: |-
         Best-effort append the given data to a slice. If the slice's capacity is reached, any remaining data will be truncated.
@@ -2345,8 +2345,8 @@ arm9:
         return: true
     - name: VsprintfInternal
       address:
-        NA: 0x20894DC
         EU: 0x2089874
+        NA: 0x20894DC
         JP: 0x20897C4
       description: |-
         This is what implements Vsprintf. It's akin to __vsprintf_internal in the modern-day version of glibc (in fact, it's probably an older version of this).
@@ -2358,8 +2358,8 @@ arm9:
         return: number of characters printed, excluding the null-terminator
     - name: Vsprintf
       address:
-        NA: 0x2089544
         EU: 0x20898DC
+        NA: 0x2089544
         JP: 0x208982C
       description: |-
         The vsprintf(3) C library function.
@@ -2370,8 +2370,8 @@ arm9:
         return: number of characters printed, excluding the null-terminator
     - name: Snprintf
       address:
-        NA: 0x208955C
         EU: 0x20898F4
+        NA: 0x208955C
         JP: 0x2089844
       description: |-
         The snprintf(3) C library function.
@@ -2385,8 +2385,8 @@ arm9:
         return: number of characters printed, excluding the null-terminator
     - name: Sprintf
       address:
-        NA: 0x2089584
         EU: 0x208991C
+        NA: 0x2089584
         JP: 0x208986C
       description: |-
         The sprintf(3) C library function.
@@ -2399,8 +2399,8 @@ arm9:
         return: number of characters printed, excluding the null-terminator
     - name: Strlen
       address:
-        NA: 0x2089678
         EU: 0x2089A10
+        NA: 0x2089678
         JP: 0x2089960
       description: |-
         The strlen(3) C library function.
@@ -2409,8 +2409,8 @@ arm9:
         return: length of s
     - name: Strcpy
       address:
-        NA: 0x2089694
         EU: 0x2089A2C
+        NA: 0x2089694
         JP: 0x208997C
       description: |-
         The strcpy(3) C library function.
@@ -2421,8 +2421,8 @@ arm9:
         r1: src
     - name: Strncpy
       address:
-        NA: 0x208975C
         EU: 0x2089AF4
+        NA: 0x208975C
         JP: 0x2089A44
       description: |-
         The strncpy(3) C library function.
@@ -2432,8 +2432,8 @@ arm9:
         r2: n
     - name: Strcat
       address:
-        NA: 0x20897AC
         EU: 0x2089B44
+        NA: 0x20897AC
         JP: 0x2089A94
       description: |-
         The strcat(3) C library function.
@@ -2442,8 +2442,8 @@ arm9:
         r1: src
     - name: Strncat
       address:
-        NA: 0x20897DC
         EU: 0x2089B74
+        NA: 0x20897DC
         JP: 0x2089AC4
       description: |-
         The strncat(3) C library function.
@@ -2453,8 +2453,8 @@ arm9:
         r2: n
     - name: Strcmp
       address:
-        NA: 0x208982C
         EU: 0x2089BC4
+        NA: 0x208982C
         JP: 0x2089B14
       description: |-
         The strcmp(3) C library function.
@@ -2466,8 +2466,8 @@ arm9:
         return: comparison value
     - name: Strncmp
       address:
-        NA: 0x2089940
         EU: 0x2089CD8
+        NA: 0x2089940
         JP: 0x2089C28
       description: |-
         The strncmp(3) C library function.
@@ -2478,8 +2478,8 @@ arm9:
         return: comparison value
     - name: Strchr
       address:
-        NA: 0x2089974
         EU: 0x2089D0C
+        NA: 0x2089974
         JP: 0x2089C5C
       description: |-
         The strchr(3) C library function.
@@ -2489,8 +2489,8 @@ arm9:
         return: pointer to the located byte c, or null pointer if no match
     - name: Strcspn
       address:
-        NA: 0x20899B0
         EU: 0x2089D48
+        NA: 0x20899B0
         JP: 0x2089C98
       description: |-
         The strcspn(3) C library function.
@@ -2500,8 +2500,8 @@ arm9:
         return: offset of the first character in string within stopset
     - name: Strstr
       address:
-        NA: 0x2089A70
         EU: 0x2089E08
+        NA: 0x2089A70
         JP: 0x2089D58
       description: |-
         The strstr(3) C library function.
@@ -2511,8 +2511,8 @@ arm9:
         return: pointer into haystack where needle starts, or null pointer if no match
     - name: Wcslen
       address:
-        NA: 0x208B3E8
         EU: 0x208B780
+        NA: 0x208B3E8
         JP: 0x208B6D0
       description: |-
         The wcslen(3) C library function.
@@ -2521,8 +2521,8 @@ arm9:
         return: length of ws
     - name: AddFloat
       address:
-        NA: 0x208ECB8
         EU: 0x208F050
+        NA: 0x208ECB8
         JP: 0x208EFA0
       description: |-
         This appears to be the libgcc implementation of __addsf3 (not sure which gcc version), which implements the addition operator for IEEE 754 floating-point numbers.
@@ -2532,8 +2532,8 @@ arm9:
         return: a + b
     - name: DivideFloat
       address:
-        NA: 0x208F234
         EU: 0x208F5CC
+        NA: 0x208F234
         JP: 0x208F51C
       description: |-
         This appears to be the libgcc implementation of __divsf3 (not sure which gcc version), which implements the division operator for IEEE 754 floating-point numbers.
@@ -2543,8 +2543,8 @@ arm9:
         return: dividend / divisor
     - name: FloatToDouble
       address:
-        NA: 0x208F5EC
         EU: 0x208F984
+        NA: 0x208F5EC
         JP: 0x208F8D4
       description: |-
         This appears to be the libgcc implementation of __extendsfdf2 (not sure which gcc version), which implements the float to double cast operation for IEEE 754 floating-point numbers.
@@ -2553,8 +2553,8 @@ arm9:
         return: (double)float
     - name: FloatToInt
       address:
-        NA: 0x208F670
         EU: 0x208FA08
+        NA: 0x208F670
         JP: 0x208F958
       description: |-
         This appears to be the libgcc implementation of __fixsfsi (not sure which gcc version), which implements the float to int cast operation for IEEE 754 floating-point numbers. The output saturates if the input is out of the representable range for the int type.
@@ -2563,8 +2563,8 @@ arm9:
         return: (int)float
     - name: IntToFloat
       address:
-        NA: 0x208F6A4
         EU: 0x208FA3C
+        NA: 0x208F6A4
         JP: 0x208F98C
       description: |-
         This appears to be the libgcc implementation of __floatsisf (not sure which gcc version), which implements the int to float cast operation for IEEE 754 floating-point numbers.
@@ -2573,8 +2573,8 @@ arm9:
         return: (float)int
     - name: UIntToFloat
       address:
-        NA: 0x208F6EC
         EU: 0x208FA84
+        NA: 0x208F6EC
         JP: 0x208F9D4
       description: |-
         This appears to be the libgcc implementation of __floatunsisf (not sure which gcc version), which implements the unsigned int to float cast operation for IEEE 754 floating-point numbers.
@@ -2583,14 +2583,14 @@ arm9:
         return: (float)uint
     - name: MultiplyFloat
       address:
-        NA: 0x208F734
         EU: 0x208FACC
+        NA: 0x208F734
         JP: 0x208FA1C
       description: "This appears to be the libgcc implementation of __mulsf3 (not sure which gcc version), which implements the multiplication operator for IEEE 754 floating-point numbers."
     - name: Sqrtf
       address:
-        NA: 0x208F914
         EU: 0x208FCAC
+        NA: 0x208F914
         JP: 0x208FBFC
       description: |-
         The sqrtf(3) C library function.
@@ -2599,8 +2599,8 @@ arm9:
         return: sqrt(x)
     - name: SubtractFloat
       address:
-        NA: 0x208FA04
         EU: 0x208FD9C
+        NA: 0x208FA04
         JP: 0x208FCEC
       description: |-
         This appears to be the libgcc implementation of __subsf3 (not sure which gcc version), which implements the subtraction operator for IEEE 754 floating-point numbers.
@@ -2610,8 +2610,8 @@ arm9:
         return: a - b
     - name: DivideInt
       address:
-        NA: 0x208FEA4
         EU: 0x209023C
+        NA: 0x208FEA4
         JP: 0x209018C
       description: |-
         This appears to be the libgcc implementation of __divsi3 (not sure which gcc version), which implements the division operator for signed ints.
@@ -2621,8 +2621,8 @@ arm9:
         return: dividend / divisor
     - name: DivideUInt
       address:
-        NA: 0x20900B0
         EU: 0x2090448
+        NA: 0x20900B0
         JP: 0x2090398
       description: |-
         This appears to be the libgcc implementation of __udivsi3 (not sure which gcc version), which implements the division operator for unsigned ints.
@@ -2634,8 +2634,8 @@ arm9:
         return: dividend / divisor
     - name: DivideUIntNoZeroCheck
       address:
-        NA: 0x20900B8
         EU: 0x2090450
+        NA: 0x20900B8
         JP: 0x20903A0
       description: |-
         Subsidiary function to DivideUInt. Skips the initial check for divisor == 0.
@@ -2648,175 +2648,175 @@ arm9:
   data:
     - name: DEFAULT_MEMORY_ARENA_SIZE
       address:
-        NA: 0x2000E58
         EU: 0x2000E58
+        NA: 0x2000E58
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Length in bytes of the default memory allocation arena, 1991680."
     - name: AURA_BOW_ID_LAST
       address:
-        NA: 0x200CC34
         EU: 0x200CCBC
+        NA: 0x200CC34
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Highest item ID of the aura bows.
     - name: NUMBER_OF_ITEMS
       address:
-        NA: 0x200E860
         EU: 0x200E930
+        NA: 0x200E860
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Number of items in the game.
     - name: MAX_MONEY_CARRIED
       address:
-        NA: 0x200ED50
         EU: 0x200EDF8
+        NA: 0x200ED50
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Maximum amount of money the player can carry, 99999."
     - name: MAX_MONEY_STORED
       address:
-        NA: 0x2010750
         EU: 0x20107F8
+        NA: 0x2010750
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Maximum amount of money the player can store in the Duskull Bank, 9999999."
     - name: SCRIPT_VARS_VALUES_PTR
       address:
-        NA:
-          - 0x204B2F8
-          - 0x204B4E4
-          - 0x204C42C
-          - 0x204C484
         EU:
           - 0x204B630
           - 0x204B81C
           - 0x204C764
           - 0x204C7BC
+        NA:
+          - 0x204B2F8
+          - 0x204B4E4
+          - 0x204C42C
+          - 0x204C484
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Hard-coded pointer to SCRIPT_VARS_VALUES.
     - name: MONSTER_ID_LIMIT
       address:
-        NA: 0x205449C
         EU: 0x2054818
+        NA: 0x205449C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: One more than the maximum valid monster ID (0x483).
     - name: MAX_RECRUITABLE_TEAM_MEMBERS
       address:
-        NA:
-          - 0x2055238
-          - 0x205564C
         EU:
           - 0x20555B4
           - 0x20559C8
+        NA:
+          - 0x2055238
+          - 0x205564C
       description: "555, appears to be the maximum number of members recruited to an exploration team, at least for the purposes of some checks that need to iterate over all team members."
     - name: CART_REMOVED_IMG_DATA
       address:
-        NA: 0x2092AE8
         EU: 0x2092EE4
+        NA: 0x2092AE8
       length:
-        NA: 0x4000
         EU: 0x2000
+        NA: 0x4000
     - name: EXCLUSIVE_ITEM_STAT_BOOST_DATA
       address:
-        NA: 0x20980E8
         EU: 0x209852C
+        NA: 0x20980E8
       length:
-        NA: 0x3C
         EU: 0x3C
+        NA: 0x3C
       description: |-
         Contains stat boost effects for different exclusive item classes.
         
         Each 4-byte entry contains the boost data for (attack, special attack, defense, special defense), 1 byte each, for a specific exclusive item class, indexed according to the stat boost data index list.
     - name: EXCLUSIVE_ITEM_ATTACK_BOOSTS
       address:
-        NA: 0x20980E8
         EU: 0x209852C
+        NA: 0x20980E8
       length:
-        NA: 0x39
         EU: 0x39
+        NA: 0x39
       description: "EXCLUSIVE_ITEM_STAT_BOOST_DATA, offset by 0"
     - name: EXCLUSIVE_ITEM_SPECIAL_ATTACK_BOOSTS
       address:
-        NA: 0x20980E9
         EU: 0x209852D
+        NA: 0x20980E9
       length:
-        NA: 0x39
         EU: 0x39
+        NA: 0x39
       description: "EXCLUSIVE_ITEM_STAT_BOOST_DATA, offset by 1"
     - name: EXCLUSIVE_ITEM_DEFENSE_BOOSTS
       address:
-        NA: 0x20980EA
         EU: 0x209852E
+        NA: 0x20980EA
       length:
-        NA: 0x39
         EU: 0x39
+        NA: 0x39
       description: "EXCLUSIVE_ITEM_STAT_BOOST_DATA, offset by 2"
     - name: EXCLUSIVE_ITEM_SPECIAL_DEFENSE_BOOSTS
       address:
-        NA: 0x20980EB
         EU: 0x209852F
+        NA: 0x20980EB
       length:
-        NA: 0x39
         EU: 0x39
+        NA: 0x39
       description: "EXCLUSIVE_ITEM_STAT_BOOST_DATA, offset by 3"
     - name: EXCLUSIVE_ITEM_EFFECT_DATA
       address:
-        NA: 0x2098124
         EU: 0x2098568
+        NA: 0x2098124
       length:
-        NA: 0x778
         EU: 0x778
+        NA: 0x778
       description: |-
         Contains special effects for each exclusive item.
         
         Each entry is 2 bytes, with the first entry corresponding to the first exclusive item (Prism Ruff). The first byte is the exclusive item effect ID, and the second byte is an index into other data tables (related to the more generic stat boosting effects for specific monsters).
     - name: EXCLUSIVE_ITEM_STAT_BOOST_DATA_INDEXES
       address:
-        NA: 0x2098125
         EU: 0x2098569
+        NA: 0x2098125
       length:
-        NA: 0x777
         EU: 0x777
+        NA: 0x777
       description: "EXCLUSIVE_ITEM_EFFECT_DATA, offset by 1"
     - name: RECOIL_MOVE_LIST
       address:
-        NA: 0x2098D74
         EU: 0x20991B8
+        NA: 0x2098D74
       length:
-        NA: 0x16
         EU: 0x16
+        NA: 0x16
       description: |-
         Null-terminated list of all the recoil moves, as 2-byte move IDs.
         
         type: struct move_id_16[11]
     - name: PUNCH_MOVE_LIST
       address:
-        NA: 0x2098D8A
         EU: 0x20991CE
+        NA: 0x2098D8A
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
       description: |-
         Null-terminated list of all the punch moves, as 2-byte move IDs.
         
         type: struct move_id_16[16]
     - name: SCRIPT_VARS_LOCALS
       address:
-        NA: 0x209CECC
         EU: 0x209D450
+        NA: 0x209CECC
       length:
-        NA: 0x40
         EU: 0x40
+        NA: 0x40
       description: |-
         List of special "local" variables available to the script engine. There are 4 16-byte entries.
         
@@ -2825,12 +2825,12 @@ arm9:
         type: struct script_local_var_table
     - name: SCRIPT_VARS
       address:
-        NA: 0x209D870
         EU: 0x209DDF4
+        NA: 0x209D870
         JP: 0x209EC44
       length:
-        NA: 0x730
         EU: 0x730
+        NA: 0x730
         JP: 0x730
       description: |-
         List of predefined global variables that track game state, which are available to the script engine. There are 115 16-byte entries.
@@ -2840,11 +2840,11 @@ arm9:
         type: struct script_var_table
     - name: DUNGEON_DATA_LIST
       address:
-        NA: 0x209E3A0
         EU: 0x209E924
+        NA: 0x209E3A0
       length:
-        NA: 0x2D0
         EU: 0x2D0
+        NA: 0x2D0
       description: |-
         Data about every dungeon in the game.
         
@@ -2855,11 +2855,11 @@ arm9:
         type: struct dungeon_data_list_entry[180]
     - name: DUNGEON_RESTRICTIONS
       address:
-        NA: 0x20A0C64
         EU: 0x20A11E8
+        NA: 0x20A0C64
       length:
-        NA: 0xC00
         EU: 0xC00
+        NA: 0xC00
       description: |-
         Data related to dungeon restrictions for every dungeon in the game.
         
@@ -2870,128 +2870,128 @@ arm9:
         type: struct dungeon_restriction[256]
     - name: SPECIAL_BAND_STAT_BOOST
       address:
-        NA: 0x20A186C
         EU: 0x20A1DF0
+        NA: 0x20A186C
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Stat boost value for the Special Band.
     - name: MUNCH_BELT_STAT_BOOST
       address:
-        NA: 0x20A187C
         EU: 0x20A1E00
+        NA: 0x20A187C
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Stat boost value for the Munch Belt.
     - name: GUMMI_STAT_BOOST
       address:
-        NA: 0x20A1888
         EU: 0x20A1E0C
+        NA: 0x20A1888
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Stat boost value if a stat boost occurs when eating normal Gummis.
     - name: MIN_IQ_EXCLUSIVE_MOVE_USER
       address:
-        NA: 0x20A188C
         EU: 0x20A1E10
+        NA: 0x20A188C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
     - name: WONDER_GUMMI_IQ_GAIN
       address:
-        NA: 0x20A1890
         EU: 0x20A1E14
+        NA: 0x20A1890
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: IQ gain when ingesting wonder gummis.
     - name: AURA_BOW_STAT_BOOST
       address:
-        NA: 0x20A1898
         EU: 0x20A1E1C
+        NA: 0x20A1898
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Stat boost value for the aura bows.
     - name: MIN_IQ_ITEM_MASTER
       address:
-        NA: 0x20A18A4
         EU: 0x20A1E28
+        NA: 0x20A18A4
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
     - name: DEF_SCARF_STAT_BOOST
       address:
-        NA: 0x20A18A8
         EU: 0x20A1E2C
+        NA: 0x20A18A8
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Stat boost value for the Defense Scarf.
     - name: POWER_BAND_STAT_BOOST
       address:
-        NA: 0x20A18AC
         EU: 0x20A1E30
+        NA: 0x20A18AC
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Stat boost value for the Power Band.
     - name: WONDER_GUMMI_STAT_BOOST
       address:
-        NA: 0x20A18B0
         EU: 0x20A1E34
+        NA: 0x20A18B0
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Stat boost value if a stat boost occurs when eating Wonder Gummis.
     - name: ZINC_BAND_STAT_BOOST
       address:
-        NA: 0x20A18B4
         EU: 0x20A1E38
+        NA: 0x20A18B4
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Stat boost value for the Zinc Band.
     - name: TACTICS_UNLOCK_LEVEL_TABLE
       address:
-        NA: 0x20A1940
         EU: 0x20A1EC4
+        NA: 0x20A1940
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: OUTLAW_LEVEL_TABLE
       address:
-        NA: 0x20A1998
         EU: 0x20A1F1C
+        NA: 0x20A1998
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
       description: "Table of 2-byte outlaw levels for outlaw missions, indexed by mission rank."
     - name: OUTLAW_MINION_LEVEL_TABLE
       address:
-        NA: 0x20A19B8
         EU: 0x20A1F3C
+        NA: 0x20A19B8
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
       description: "Table of 2-byte outlaw minion levels for outlaw hideout missions, indexed by mission rank."
     - name: IQ_SKILL_RESTRICTIONS
       address:
-        NA: 0x20A1A5C
         EU: 0x20A1FE0
+        NA: 0x20A1A5C
       length:
-        NA: 0x8A
         EU: 0x8A
+        NA: 0x8A
       description: Table of 2-byte values for each IQ skill that represent a group. IQ skills in the same group can not be enabled at the same time.
     - name: SECONDARY_TERRAIN_TYPES
       address:
-        NA: 0x20A1AE8
         EU: 0x20A206C
+        NA: 0x20A1AE8
       length:
-        NA: 0xC8
         EU: 0xC8
+        NA: 0xC8
       description: |-
         The type of secondary terrain for each dungeon in the game.
         
@@ -3000,58 +3000,58 @@ arm9:
         type: struct secondary_terrain_type_8[200]
     - name: SENTRY_MINIGAME_DATA
       address:
-        NA: 0x20A1BB0
         EU: 0x20A2134
+        NA: 0x20A1BB0
     - name: IQ_SKILLS
       address:
-        NA: 0x20A1C7C
         EU: 0x20A2200
+        NA: 0x20A1C7C
       length:
-        NA: 0x114
         EU: 0x114
+        NA: 0x114
       description: Table of 4-byte values for each IQ skill that represent the required IQ value to unlock a skill.
     - name: IQ_GROUP_SKILLS
       address:
-        NA: 0x20A1D90
         EU: 0x20A2314
+        NA: 0x20A1D90
       length:
-        NA: 0x190
         EU: 0x190
+        NA: 0x190
     - name: IQ_GUMMI_GAIN_TABLE
       address:
-        NA: 0x20A22B0
         EU: 0x20A2834
+        NA: 0x20A22B0
       length:
-        NA: 0x288
         EU: 0x288
+        NA: 0x288
     - name: GUMMI_BELLY_RESTORE_TABLE
       address:
-        NA: 0x20A2538
         EU: 0x20A2ABC
+        NA: 0x20A2538
       length:
-        NA: 0x288
         EU: 0x288
+        NA: 0x288
     - name: BAG_CAPACITY_TABLE
       address:
-        NA: 0x20A27D4
         EU: 0x20A2D58
+        NA: 0x20A27D4
       length:
         NA: 0x20
       description: Array of 4-byte integers containing the bag capacity for each bag level.
     - name: SPECIAL_EPISODE_MAIN_CHARACTERS
       address:
-        NA: 0x20A27F4
         EU: 0x20A2D78
+        NA: 0x20A27F4
       length:
-        NA: 0xC8
         EU: 0xC8
+        NA: 0xC8
     - name: GUEST_MONSTER_DATA
       address:
-        NA: 0x20A28BC
         EU: 0x20A2E40
+        NA: 0x20A28BC
       length:
-        NA: 0x288
         EU: 0x288
+        NA: 0x288
       description: |-
         Data for guest monsters that join you during certain story dungeons.
         
@@ -3062,30 +3062,30 @@ arm9:
         type: struct guest_monster[18]
     - name: RANK_UP_TABLE
       address:
-        NA: 0x20A2B44
         EU: 0x20A30C8
+        NA: 0x20A2B44
       length:
-        NA: 0xD0
         EU: 0xD0
+        NA: 0xD0
     - name: MONSTER_SPRITE_DATA
       address:
-        NA: 0x20A2D08
         EU: 0x20A332C
+        NA: 0x20A2D08
       length:
-        NA: 0x4B0
         EU: 0x4B0
+        NA: 0x4B0
     - name: MISSION_DUNGEON_UNLOCK_TABLE
       address:
-        NA: 0x20A3CAC
         EU: 0x20A42AC
+        NA: 0x20A3CAC
     - name: EVENTS
       address:
-        NA: 0x20A5488
         EU: 0x20A5BD8
+        NA: 0x20A5488
         JP: 0x20A6894
       length:
-        NA: 0x1434
         EU: 0x1584
+        NA: 0x1434
         JP: 0x1470
       description: |-
         Table of levels for the script engine, in which scenes can take place. There are a version-dependent number of 12-byte entries.
@@ -3093,12 +3093,12 @@ arm9:
         type: struct script_level[length / 12]
     - name: ENTITIES
       address:
-        NA: 0x20A7FF0
         EU: 0x20A8890
+        NA: 0x20A7FF0
         JP: 0x20A9438
       length:
-        NA: 0x1218
         EU: 0x1218
+        NA: 0x1218
         JP: 0x1218
       description: |-
         Table of entities for the script engine, which can move around and do things within a scene. There are 386 12-byte entries.
@@ -3106,11 +3106,11 @@ arm9:
         type: struct script_entity[386]
     - name: MAP_MARKER_PLACEMENTS
       address:
-        NA: 0x20A94D0
         EU: 0x20A9D70
+        NA: 0x20A94D0
       length:
-        NA: 0x9B0
         EU: 0x9B0
+        NA: 0x9B0
       description: |-
         The map marker position of each dungeon on the Wonder Map.
         
@@ -3121,30 +3121,30 @@ arm9:
         type: struct map_marker[310]
     - name: MEMORY_ALLOCATION_ARENA_GETTERS
       address:
-        NA: 0x20AEF00
         EU: 0x20AF7A0
+        NA: 0x20AEF00
       length:
-        NA: 0x8
         EU: 0x8
+        NA: 0x8
       description: |-
         Functions to get the desired memory arena for allocating and freeing heap memory.
         
         type: struct mem_arena_getters
     - name: PRNG_SEQUENCE_NUM
       address:
-        NA: 0x20AEF2C
         EU: 0x20AF7CC
+        NA: 0x20AEF2C
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: "[Runtime] The current PRNG sequence number for the general-purpose PRNG. See Rand16Bit for more information on how the general-purpose PRNG works."
     - name: LOADED_OVERLAY_GROUP_0
       address:
-        NA: 0x20AF230
         EU: 0x20AFAD0
+        NA: 0x20AF230
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         [Runtime] The overlay group ID of the overlay currently loaded in slot 0. A group ID of 0 denotes no overlay.
         
@@ -3181,11 +3181,11 @@ arm9:
         type: enum overlay_group_id
     - name: LOADED_OVERLAY_GROUP_1
       address:
-        NA: 0x20AF234
         EU: 0x20AFAD4
+        NA: 0x20AF234
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         [Runtime] The overlay group ID of the overlay currently loaded in slot 1. A group ID of 0 denotes no overlay.
         
@@ -3199,11 +3199,11 @@ arm9:
         type: enum overlay_group_id
     - name: LOADED_OVERLAY_GROUP_2
       address:
-        NA: 0x20AF238
         EU: 0x20AFAD8
+        NA: 0x20AF238
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         [Runtime] The overlay group ID of the overlay currently loaded in slot 2. A group ID of 0 denotes no overlay.
         
@@ -3215,86 +3215,86 @@ arm9:
         type: enum overlay_group_id
     - name: PACK_FILE_PATHS_TABLE
       address:
-        NA: 0x20AF6A0
         EU: 0x20AFF58
+        NA: 0x20AF6A0
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
       description: |-
         List of pointers to path strings to all known pack files.
         The game uses this table to load its resources when launching dungeon mode.
     - name: GAME_STATE_VALUES
       address:
-        NA: 0x20AF6B8
         EU: 0x20AFF70
+        NA: 0x20AF6B8
       description: "[Runtime]"
     - name: DUNGEON_MOVE_TABLES
       address:
-        NA: 0x20AF6DC
         EU: 0x20AFFA8
+        NA: 0x20AF6DC
       description: "[Runtime] Seems to be some sort of region (a table of tables?) that holds pointers to various important tables related to moves."
     - name: MOVE_DATA_TABLE_PTR
       address:
-        NA: 0x20AF6E4
         EU: 0x20AFFB0
+        NA: 0x20AF6E4
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         [Runtime] Points to the contents of the move data table loaded from waza_p.bin
         
         type: struct move_data_table*
     - name: LANGUAGE_INFO_DATA
       address:
-        NA: 0x20AFCE8
         EU: 0x20B05A8
+        NA: 0x20AFCE8
       description: "[Runtime]"
     - name: NOTIFY_NOTE
       address:
-        NA: 0x20AFEF8
         EU: 0x20B0814
+        NA: 0x20AFEF8
       description: |-
         [Runtime] Flag related to saving and loading state?
         
         type: bool
     - name: DEFAULT_HERO_ID
       address:
-        NA: 0x20AFEFC
         EU: 0x20B0818
+        NA: 0x20AFEFC
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: |-
         The default monster ID for the hero (0x4: Charmander)
         
         type: struct monster_id_16
     - name: DEFAULT_PARTNER_ID
       address:
-        NA: 0x20AFEFE
         EU: 0x20B081A
+        NA: 0x20AFEFE
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: |-
         The default monster ID for the partner (0x1: Bulbasaur)
         
         type: struct monster_id_16
     - name: GAME_MODE
       address:
-        NA: 0x20AFF70
         EU: 0x20B088C
+        NA: 0x20AFF70
       description: |-
         [Runtime]
         
         type: uint8_t
     - name: ADVENTURE_LOG_PTR
       address:
-        NA: 0x20AFF78
         EU: 0x20B0894
+        NA: 0x20AFF78
         JP: 0x20B17EC
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
         JP: 0x4
       description: |-
         [Runtime]
@@ -3302,25 +3302,25 @@ arm9:
         type: struct adventure_log*
     - name: ITEM_TABLES_PTRS_1
       address:
-        NA: 0x20B0948
         EU: 0x20B1264
+        NA: 0x20B0948
       length:
-        NA: 0x68
         EU: 0x68
+        NA: 0x68
     - name: SMD_EVENTS_FUN_TABLE
       address:
-        NA: 0x20B0B90
         EU: 0x20B14D4
+        NA: 0x20B0B90
       length:
-        NA: 0x1FC
         EU: 0x1FC
+        NA: 0x1FC
     - name: MEMORY_ALLOCATION_TABLE
       address:
-        NA: 0x20B3380
         EU: 0x20B3CC0
+        NA: 0x20B3380
       length:
-        NA: 0x40
         EU: 0x40
+        NA: 0x40
       description: |-
         [Runtime] Keeps track of all active heap allocations.
         
@@ -3331,22 +3331,22 @@ arm9:
         type: struct mem_alloc_table
     - name: DEFAULT_MEMORY_ARENA
       address:
-        NA: 0x20B3384
         EU: 0x20B3CC4
+        NA: 0x20B3384
       length:
-        NA: 0x1C
         EU: 0x1C
+        NA: 0x1C
       description: |-
         [Runtime] The default memory allocation arena. This is part of MEMORY_ALLOCATION_TABLE, but is also referenced on its own by various functions.
         
         type: struct mem_arena
     - name: DEFAULT_MEMORY_ARENA_BLOCKS
       address:
-        NA: 0x20B33C0
         EU: 0x20B3D00
+        NA: 0x20B33C0
       length:
-        NA: 0x1800
         EU: 0x1800
+        NA: 0x1800
       description: |-
         [Runtime] The block array for DEFAULT_MEMORY_ARENA.
         

--- a/symbols/literals.yml
+++ b/symbols/literals.yml
@@ -1,564 +1,564 @@
 arm9:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2000000
     EU: 0x2000000
+    NA: 0x2000000
   length:
-    NA: 0xB73F8
     EU: 0xB7D38
+    NA: 0xB73F8
     JP: 0xB8CB8
   description: Hard-coded immediate values (literals) in instructions within the ARM 9 binary.
   functions: []
   data:
     - name: JUICE_BAR_NECTAR_IQ_GAIN
       address:
-        NA: 0x2011810
         EU: 0x20118B8
+        NA: 0x2011810
       length:
-        NA: 0x1
         EU: 0x1
+        NA: 0x1
       description: IQ gain when ingesting nectar at the Juice Bar.
     - name: TEXT_SPEED
       address:
-        NA: 0x2020C98
         EU: 0x2020DF0
+        NA: 0x2020C98
       description: Controls text speed.
     - name: HERO_START_LEVEL
       address:
-        NA: 0x2048880
         EU: 0x2048B9C
+        NA: 0x2048880
       description: Starting level of the hero.
     - name: PARTNER_START_LEVEL
       address:
-        NA: 0x20488F0
         EU: 0x2048C0C
+        NA: 0x20488F0
       description: Starting level of the partner.
 overlay0:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22BCA80
     EU: 0x22BD3C0
+    NA: 0x22BCA80
     JP: 0x22BE220
   length:
-    NA: 0x609A0
     EU: 0x60880
+    NA: 0x609A0
     JP: 0x609A0
   description: Hard-coded immediate values (literals) in instructions within overlay 0.
   functions: []
   data:
     - name: TOP_MENU_MUSIC_ID
       address:
-        NA: 0x22BE1A0
         EU: 0x22BE9B4
+        NA: 0x22BE1A0
       description: Music ID to play in the top menu.
 overlay10:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22BCA80
     EU: 0x22BD3C0
+    NA: 0x22BCA80
     JP: 0x22BE220
   length:
-    NA: 0x1F7A0
     EU: 0x1F7A0
+    NA: 0x1F7A0
     JP: 0x1F6A0
   description: Hard-coded immediate values (literals) in instructions within overlay 10.
   functions: []
   data: []
 overlay11:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22DC240
     EU: 0x22DCB80
+    NA: 0x22DC240
     JP: 0x22DD8E0
   length:
-    NA: 0x48C40
     EU: 0x48E40
+    NA: 0x48C40
     JP: 0x48B00
   description: Hard-coded immediate values (literals) in instructions within overlay 11.
   functions: []
   data: []
 overlay29:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22DC240
     EU: 0x22DCB80
+    NA: 0x22DC240
     JP: 0x22DD8E0
   length:
-    NA: 0x77620
     EU: 0x77900
+    NA: 0x77620
     JP: 0x77200
   description: Hard-coded immediate values (literals) in instructions within overlay 29.
   functions: []
   data:
     - name: NECTAR_IQ_BOOST
       address:
-        NA: 0x231C384
         EU: 0x231CDE4
+        NA: 0x231C384
       description: IQ boost from ingesting Nectar.
 overlay34:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22DC240
     EU: 0x22DCB80
+    NA: 0x22DC240
     JP: 0x22DD8E0
   length:
-    NA: 0xE60
     EU: 0xDC0
+    NA: 0xE60
     JP: 0xDC0
   description: Hard-coded immediate values (literals) in instructions within overlay 34.
   functions: []
   data: []
 overlay1:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2329520
     EU: 0x2329D40
+    NA: 0x2329520
     JP: 0x232ACC0
   length:
-    NA: 0x12D20
     EU: 0x12C80
+    NA: 0x12D20
     JP: 0x12E00
   description: Hard-coded immediate values (literals) in instructions within overlay 1.
   functions: []
   data: []
 overlay2:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2329520
     EU: 0x2329D40
+    NA: 0x2329520
     JP: 0x232ACC0
   length:
-    NA: 0x2AFA0
     EU: 0x2AFC0
+    NA: 0x2AFA0
     JP: 0x2AFA0
   description: Hard-coded immediate values (literals) in instructions within overlay 2.
   functions: []
   data: []
 overlay3:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0xA160
     EU: 0xA160
+    NA: 0xA160
     JP: 0xA160
   description: Hard-coded immediate values (literals) in instructions within overlay 3.
   functions: []
   data: []
 overlay4:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x2BE0
     EU: 0x2BE0
+    NA: 0x2BE0
     JP: 0x2BE0
   description: Hard-coded immediate values (literals) in instructions within overlay 4.
   functions: []
   data: []
 overlay5:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x3240
     EU: 0x3240
+    NA: 0x3240
     JP: 0x3260
   description: Hard-coded immediate values (literals) in instructions within overlay 5.
   functions: []
   data: []
 overlay6:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x2460
     EU: 0x2460
+    NA: 0x2460
     JP: 0x2460
   description: Hard-coded immediate values (literals) in instructions within overlay 6.
   functions: []
   data: []
 overlay7:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x5100
     EU: 0x3300
+    NA: 0x5100
     JP: 0x53E0
   description: Hard-coded immediate values (literals) in instructions within overlay 7.
   functions: []
   data: []
 overlay8:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x2200
     EU: 0x2620
+    NA: 0x2200
     JP: 0x2200
   description: Hard-coded immediate values (literals) in instructions within overlay 8.
   functions: []
   data: []
 overlay9:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x2D80
     EU: 0x2D80
+    NA: 0x2D80
     JP: 0x2D20
   description: Hard-coded immediate values (literals) in instructions within overlay 9.
   functions: []
   data:
     - name: TOP_MENU_RETURN_MUSIC_ID
       address:
-        NA: 0x233D900
         EU: 0x233E080
+        NA: 0x233D900
       description: Song playing in the main menu when returning from the Sky Jukebox.
 overlay30:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2382820
     EU: 0x2383420
+    NA: 0x2382820
     JP: 0x2383AA0
   length:
-    NA: 0x38A0
     EU: 0x38A0
+    NA: 0x38A0
     JP: 0x3880
   description: Hard-coded immediate values (literals) in instructions within overlay 30.
   functions: []
   data: []
 overlay31:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2382820
     EU: 0x2383420
+    NA: 0x2382820
     JP: 0x2383AA0
   length:
-    NA: 0x7A80
     EU: 0x7AA0
+    NA: 0x7A80
     JP: 0x7AC0
   description: Hard-coded immediate values (literals) in instructions within overlay 31.
   functions: []
   data: []
 overlay13:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x2E80
     EU: 0x2E80
+    NA: 0x2E80
     JP: 0x2E80
   description: Hard-coded immediate values (literals) in instructions within overlay 13.
   functions: []
   data: []
 overlay14:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x3AE0
     EU: 0x3B40
+    NA: 0x3AE0
     JP: 0x3AE0
   description: Hard-coded immediate values (literals) in instructions within overlay 14.
   functions: []
   data: []
 overlay15:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x1060
     EU: 0x1080
+    NA: 0x1060
     JP: 0x1060
   description: Hard-coded immediate values (literals) in instructions within overlay 15.
   functions: []
   data: []
 overlay16:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x2D20
     EU: 0x2D20
+    NA: 0x2D20
     JP: 0x2D40
   description: Hard-coded immediate values (literals) in instructions within overlay 16.
   functions: []
   data: []
 overlay17:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x1CE0
     EU: 0x1CE0
+    NA: 0x1CE0
     JP: 0x1CE0
   description: Hard-coded immediate values (literals) in instructions within overlay 17.
   functions: []
   data: []
 overlay18:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x3500
     EU: 0x3500
+    NA: 0x3500
     JP: 0x3520
   description: Hard-coded immediate values (literals) in instructions within overlay 18.
   functions: []
   data: []
 overlay19:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x4240
     EU: 0x4220
+    NA: 0x4240
     JP: 0x4220
   description: Hard-coded immediate values (literals) in instructions within overlay 19.
   functions: []
   data: []
 overlay20:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x3000
     EU: 0x3000
+    NA: 0x3000
     JP: 0x3000
   description: Hard-coded immediate values (literals) in instructions within overlay 20.
   functions: []
   data: []
 overlay21:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x2E20
     EU: 0x2E20
+    NA: 0x2E20
     JP: 0x2E40
   description: Hard-coded immediate values (literals) in instructions within overlay 21.
   functions: []
   data: []
 overlay22:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x4B40
     EU: 0x4B40
+    NA: 0x4B40
     JP: 0x4B40
   description: Hard-coded immediate values (literals) in instructions within overlay 22.
   functions: []
   data: []
 overlay23:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x3780
     EU: 0x3780
+    NA: 0x3780
     JP: 0x37E0
   description: Hard-coded immediate values (literals) in instructions within overlay 23.
   functions: []
   data: []
 overlay24:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x24E0
     EU: 0x24E0
+    NA: 0x24E0
     JP: 0x24E0
   description: Hard-coded immediate values (literals) in instructions within overlay 24.
   functions: []
   data: []
 overlay25:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x14C0
     EU: 0x14C0
+    NA: 0x14C0
     JP: 0x14C0
   description: Hard-coded immediate values (literals) in instructions within overlay 25.
   functions: []
   data: []
 overlay26:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0xE40
     EU: 0xE40
+    NA: 0xE40
     JP: 0xE40
   description: Hard-coded immediate values (literals) in instructions within overlay 26.
   functions: []
   data: []
 overlay27:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x2D60
     EU: 0x2D60
+    NA: 0x2D60
     JP: 0x2DA0
   description: Hard-coded immediate values (literals) in instructions within overlay 27.
   functions: []
   data: []
 overlay28:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0xC60
     EU: 0xC60
+    NA: 0xC60
     JP: 0xC60
   description: Hard-coded immediate values (literals) in instructions within overlay 28.
   functions: []

--- a/symbols/overlay00.yml
+++ b/symbols/overlay00.yml
@@ -1,15 +1,15 @@
 overlay0:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22BCA80
     EU: 0x22BD3C0
+    NA: 0x22BCA80
     JP: 0x22BE220
   length:
-    NA: 0x609A0
     EU: 0x60880
+    NA: 0x609A0
     JP: 0x609A0
   description: |-
     Likely contains supporting data and code related to the top menu.

--- a/symbols/overlay01.yml
+++ b/symbols/overlay01.yml
@@ -1,15 +1,15 @@
 overlay1:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2329520
     EU: 0x2329D40
+    NA: 0x2329520
     JP: 0x232ACC0
   length:
-    NA: 0x12D20
     EU: 0x12C80
+    NA: 0x12D20
     JP: 0x12E00
   description: |-
     Likely controls the top menu.
@@ -21,43 +21,43 @@ overlay1:
   data:
     - name: CONTINUE_CHOICE
       address:
-        NA: 0x233B568
         EU: 0x233BCB4
+        NA: 0x233B568
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: SUBMENU
       address:
-        NA: 0x233B588
         EU: 0x233BCD4
+        NA: 0x233B588
       length:
-        NA: 0x48
         EU: 0x48
+        NA: 0x48
     - name: MAIN_MENU
       address:
-        NA: 0x233B5D0
         EU: 0x233BD1C
+        NA: 0x233B5D0
       length:
-        NA: 0xA0
         EU: 0xA0
+        NA: 0xA0
     - name: MAIN_MENU_CONFIRM
       address:
-        NA: 0x233B74C
         EU: 0x233BE98
+        NA: 0x233B74C
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: MAIN_DEBUG_MENU_1
       address:
-        NA: 0x233B810
         EU: 0x233BF5C
+        NA: 0x233B810
       length:
-        NA: 0x60
         EU: 0x60
+        NA: 0x60
     - name: MAIN_DEBUG_MENU_2
       address:
-        NA: 0x233B890
         EU: 0x233BFDC
+        NA: 0x233B890
       length:
-        NA: 0x38
         EU: 0x38
+        NA: 0x38

--- a/symbols/overlay02.yml
+++ b/symbols/overlay02.yml
@@ -1,15 +1,15 @@
 overlay2:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2329520
     EU: 0x2329D40
+    NA: 0x2329520
     JP: 0x232ACC0
   length:
-    NA: 0x2AFA0
     EU: 0x2AFC0
+    NA: 0x2AFA0
     JP: 0x2AFA0
   description: "Controls the Nintendo WFC Settings interface, accessed from the top menu (Other > Nintendo WFC > Nintendo WFC Settings). Presumably contains code for Nintendo Wi-Fi setup."
   functions: []

--- a/symbols/overlay03.yml
+++ b/symbols/overlay03.yml
@@ -1,15 +1,15 @@
 overlay3:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0xA160
     EU: 0xA160
+    NA: 0xA160
     JP: 0xA160
   description: Controls the Friend Rescue submenu within the top menu.
   functions: []

--- a/symbols/overlay04.yml
+++ b/symbols/overlay04.yml
@@ -1,15 +1,15 @@
 overlay4:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x2BE0
     EU: 0x2BE0
+    NA: 0x2BE0
     JP: 0x2BE0
   description: Controls the Trade Items submenu within the top menu.
   functions: []

--- a/symbols/overlay05.yml
+++ b/symbols/overlay05.yml
@@ -1,15 +1,15 @@
 overlay5:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x3240
     EU: 0x3240
+    NA: 0x3240
     JP: 0x3260
   description: Controls the Trade Team submenu within the top menu.
   functions: []

--- a/symbols/overlay06.yml
+++ b/symbols/overlay06.yml
@@ -1,15 +1,15 @@
 overlay6:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x2460
     EU: 0x2460
+    NA: 0x2460
     JP: 0x2460
   description: Controls the Wonder Mail S submenu within the top menu.
   functions: []

--- a/symbols/overlay07.yml
+++ b/symbols/overlay07.yml
@@ -1,15 +1,15 @@
 overlay7:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x5100
     EU: 0x3300
+    NA: 0x5100
     JP: 0x53E0
   description: "Controls the Nintendo WFC submenu within the top menu (under \"Other\")."
   functions: []

--- a/symbols/overlay08.yml
+++ b/symbols/overlay08.yml
@@ -1,15 +1,15 @@
 overlay8:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x2200
     EU: 0x2620
+    NA: 0x2200
     JP: 0x2200
   description: "Controls the Send Demo Dungeon submenu within the top menu (under \"Other\")."
   functions: []

--- a/symbols/overlay09.yml
+++ b/symbols/overlay09.yml
@@ -1,15 +1,15 @@
 overlay9:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x233CA80
     EU: 0x233D200
+    NA: 0x233CA80
     JP: 0x233E300
   length:
-    NA: 0x2D80
     EU: 0x2D80
+    NA: 0x2D80
     JP: 0x2D20
   description: Controls the Sky Jukebox.
   functions: []

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -1,26 +1,26 @@
 overlay10:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22BCA80
     EU: 0x22BD3C0
+    NA: 0x22BCA80
     JP: 0x22BE220
   length:
-    NA: 0x1F7A0
     EU: 0x1F7A0
+    NA: 0x1F7A0
     JP: 0x1F6A0
   description: "Appears to be used both during ground mode and dungeon mode. With dungeon mode, whereas overlay 29 contains the main dungeon engine, this overlay seems to contain routines and data for dungeon mechanics."
   functions:
     - name: SprintfStatic
       address:
-        NA:
-          - 0x22BD44C
-          - 0x22C183C
         EU:
           - 0x22BDD8C
           - 0x22C2194
+        NA:
+          - 0x22BD44C
+          - 0x22C183C
       description: |-
         Statically defined copy of sprintf(3) in overlay 10. See arm9.yml for more information.
         
@@ -31,352 +31,352 @@ overlay10:
   data:
     - name: FIRST_DUNGEON_WITH_MONSTER_HOUSE_TRAPS
       address:
-        NA: 0x22C440C
         EU: 0x22C4D64
+        NA: 0x22C440C
       length:
-        NA: 0x1
         EU: 0x1
+        NA: 0x1
       description: |-
         The first dungeon that can have extra traps spawn in Monster Houses, Dark Hill
         
         type: struct dungeon_id_8
     - name: BAD_POISON_DAMAGE_COOLDOWN
       address:
-        NA: 0x22C4414
         EU: 0x22C4D6C
+        NA: 0x22C4414
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The number of turns between passive bad poison (toxic) damage.
     - name: PROTEIN_STAT_BOOST
       address:
-        NA: 0x22C4420
         EU: 0x22C4D78
+        NA: 0x22C4420
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The permanent attack boost from ingesting a Protein.
     - name: SPAWN_CAP_NO_MONSTER_HOUSE
       address:
-        NA: 0x22C4430
         EU: 0x22C4D88
+        NA: 0x22C4430
       description: The maximum number of enemies that can spawn on a floor without a monster house (15).
     - name: OREN_BERRY_DAMAGE
       address:
-        NA: 0x22C4438
         EU: 0x22C4D90
+        NA: 0x22C4438
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Damage dealt by eating an Oren Berry.
     - name: SITRUS_BERRY_HP_RESTORATION
       address:
-        NA: 0x22C4478
         EU: 0x22C4DD0
+        NA: 0x22C4478
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The amount of HP restored by eating a Sitrus Berry.
     - name: EXP_ELITE_EXP_BOOST
       address:
-        NA: 0x22C44A8
         EU: 0x22C4E00
+        NA: 0x22C44A8
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The percentage increase in experience from the Exp. Elite IQ skill
     - name: MONSTER_HOUSE_MAX_NON_MONSTER_SPAWNS
       address:
-        NA: 0x22C44AC
         EU: 0x22C4E04
+        NA: 0x22C44AC
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: "The maximum number of extra non-monster spawns (items/traps) in a Monster House, 7"
     - name: GOLD_THORN_POWER
       address:
-        NA: 0x22C44D0
         EU: 0x22C4E28
+        NA: 0x22C44D0
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Attack power for Golden Thorns.
     - name: SPAWN_COOLDOWN
       address:
-        NA: 0x22C44DC
         EU: 0x22C4E34
+        NA: 0x22C44DC
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The number of turns between enemy spawns under normal conditions.
     - name: ORAN_BERRY_FULL_HP_BOOST
       address:
-        NA: 0x22C44F4
         EU: 0x22C4E4C
+        NA: 0x22C44F4
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The permanent HP boost from eating an Oran Berry at full HP (0).
     - name: LIFE_SEED_HP_BOOST
       address:
-        NA: 0x22C44F8
         EU: 0x22C4E50
+        NA: 0x22C44F8
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The permanent HP boost from eating a Life Seed.
     - name: EXCLUSIVE_ITEM_EXP_BOOST
       address:
-        NA: 0x22C458C
         EU: 0x22C4EE4
+        NA: 0x22C458C
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The percentage increase in experience from exp-boosting exclusive items
     - name: INTIMIDATOR_ACTIVATION_CHANCE
       address:
-        NA: 0x22C45B8
         EU: 0x22C4F10
+        NA: 0x22C45B8
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The percentage chance that Intimidator will activate.
     - name: ORAN_BERRY_HP_RESTORATION
       address:
-        NA: 0x22C45EC
         EU: 0x22C4F44
+        NA: 0x22C45EC
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The amount of HP restored by eating a Oran Berry.
     - name: SITRUS_BERRY_FULL_HP_BOOST
       address:
-        NA: 0x22C45F4
         EU: 0x22C4F4C
+        NA: 0x22C45F4
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The permanent HP boost from eating a Sitrus Berry at full HP.
     - name: BURN_DAMAGE_COOLDOWN
       address:
-        NA: 0x22C4610
         EU: 0x22C4F68
+        NA: 0x22C4610
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The number of turns between passive burn damage.
     - name: STICK_POWER
       address:
-        NA: 0x22C4624
         EU: 0x22C4F7C
+        NA: 0x22C4624
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Attack power for Sticks.
     - name: SPAWN_COOLDOWN_THIEF_ALERT
       address:
-        NA: 0x22C4640
         EU: 0x22C4F98
+        NA: 0x22C4640
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The number of turns between enemy spawns when the Thief Alert condition is active.
     - name: MONSTER_HOUSE_MAX_MONSTER_SPAWNS
       address:
-        NA: 0x22C4660
         EU: 0x22C4FB8
+        NA: 0x22C4660
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: "The maximum number of monster spawns in a Monster House, 30, but multiplied by 2/3 for some reason (so the actual maximum is 45)"
     - name: SPEED_BOOST_TURNS
       address:
-        NA: 0x22C466C
         EU: 0x22C4FC4
+        NA: 0x22C466C
       description: Number of turns (250) after which Speed Boost will trigger and increase speed by one stage.
     - name: MIRACLE_CHEST_EXP_BOOST
       address:
-        NA: 0x22C4698
         EU: 0x22C4FF0
+        NA: 0x22C4698
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The percentage increase in experience from the Miracle Chest item
     - name: WONDER_CHEST_EXP_BOOST
       address:
-        NA: 0x22C469C
         EU: 0x22C4FF4
+        NA: 0x22C469C
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The percentage increase in experience from the Wonder Chest item
     - name: SPAWN_CAP_WITH_MONSTER_HOUSE
       address:
-        NA: 0x22C46A4
         EU: 0x22C4FFC
+        NA: 0x22C46A4
       description: "The maximum number of enemies that can spawn on a floor with a monster house, not counting those in the monster house (4)."
     - name: POISON_DAMAGE_COOLDOWN
       address:
-        NA: 0x22C46A8
         EU: 0x22C5000
+        NA: 0x22C46A8
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The number of turns between passive poison damage.
     - name: GEO_PEBBLE_DAMAGE
       address:
-        NA: 0x22C46B4
         EU: 0x22C500C
+        NA: 0x22C46B4
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Damage dealt by Geo Pebbles.
     - name: GRAVELEROCK_DAMAGE
       address:
-        NA: 0x22C46B8
         EU: 0x22C5010
+        NA: 0x22C46B8
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Damage dealt by Gravelerocks.
     - name: RARE_FOSSIL_DAMAGE
       address:
-        NA: 0x22C46BC
         EU: 0x22C5014
+        NA: 0x22C46BC
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Damage dealt by Rare Fossils.
     - name: GINSENG_CHANCE_3
       address:
-        NA: 0x22C46C0
         EU: 0x22C5018
+        NA: 0x22C46C0
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The percentage chance for...something to be set to 3 in a calculation related to the Ginseng boost.
     - name: ZINC_STAT_BOOST
       address:
-        NA: 0x22C46C4
         EU: 0x22C501C
+        NA: 0x22C46C4
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The permanent special defense boost from ingesting a Zinc.
     - name: IRON_STAT_BOOST
       address:
-        NA: 0x22C46C8
         EU: 0x22C5020
+        NA: 0x22C46C8
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The permanent defense boost from ingesting an Iron.
     - name: CALCIUM_STAT_BOOST
       address:
-        NA: 0x22C46CC
         EU: 0x22C5024
+        NA: 0x22C46CC
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The permanent special attack boost from ingesting a Calcium.
     - name: CORSOLA_TWIG_POWER
       address:
-        NA: 0x22C46D8
         EU: 0x22C5030
+        NA: 0x22C46D8
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Attack power for Corsola Twigs.
     - name: CACNEA_SPIKE_POWER
       address:
-        NA: 0x22C46DC
         EU: 0x22C5034
+        NA: 0x22C46DC
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Attack power for Cacnea Spikes.
     - name: GOLD_FANG_POWER
       address:
-        NA: 0x22C46E0
         EU: 0x22C5038
+        NA: 0x22C46E0
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Attack power for Gold Fangs.
     - name: SILVER_SPIKE_POWER
       address:
-        NA: 0x22C46E4
         EU: 0x22C503C
+        NA: 0x22C46E4
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Attack power for Silver Spikes.
     - name: IRON_THORN_POWER
       address:
-        NA: 0x22C46E8
         EU: 0x22C5040
+        NA: 0x22C46E8
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: Attack power for Iron Thorns.
     - name: SLEEP_DURATION_RANGE
       address:
-        NA: 0x22C4720
         EU: 0x22C5078
+        NA: 0x22C4720
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Appears to control the range of turns for which the sleep condition can last.
         
         The first two bytes are the low value of the range, and the later two bytes are the high value.
     - name: POWER_PITCHER_DAMAGE_MULTIPLIER
       address:
-        NA: 0x22C47F8
         EU: 0x22C5150
+        NA: 0x22C47F8
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "The multiplier for projectile damage from Power Pitcher (1.5), as a binary fixed-point number (8 fraction bits)"
     - name: AIR_BLADE_DAMAGE_MULTIPLIER
       address:
-        NA: 0x22C4844
         EU: 0x22C519C
+        NA: 0x22C4844
       description: "The multiplier for damage from the Air Blade (1.5), as a binary fixed-point number (8 fraction bits)"
     - name: SPEED_BOOST_DURATION_RANGE
       address:
-        NA: 0x22C4888
         EU: 0x22C51E0
+        NA: 0x22C4888
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Appears to control the range of turns for which a speed boost can last.
         
         The first two bytes are the low value of the range, and the later two bytes are the high value.
     - name: OFFENSIVE_STAT_STAGE_MULTIPLIERS
       address:
-        NA: 0x22C4D98
         EU: 0x22C56F0
+        NA: 0x22C4D98
       length:
-        NA: 0x54
         EU: 0x54
+        NA: 0x54
       description: "Table of multipliers for offensive stats (attack/special attack) for each stage 0-20, as binary fixed-point numbers (8 fraction bits)"
     - name: DEFENSIVE_STAT_STAGE_MULTIPLIERS
       address:
-        NA: 0x22C4DEC
         EU: 0x22C5744
+        NA: 0x22C4DEC
       length:
-        NA: 0x54
         EU: 0x54
+        NA: 0x54
       description: "Table of multipliers for defensive stats (defense/special defense) for each stage 0-20, as binary fixed-point numbers (8 fraction bits)"
     - name: RANDOM_MUSIC_ID_TABLE
       address:
-        NA: 0x22C51FC
         EU: 0x22C5B54
+        NA: 0x22C51FC
       length:
-        NA: 0xF0
         EU: 0xF0
+        NA: 0xF0
       description: |-
         Table of music IDs for dungeons with a random assortment of music tracks.
         
@@ -385,43 +385,43 @@ overlay10:
         type: struct music_id_16[30][4]
     - name: MALE_ACCURACY_STAGE_MULTIPLIERS
       address:
-        NA: 0x22C540C
         EU: 0x22C5D64
+        NA: 0x22C540C
       length:
-        NA: 0x54
         EU: 0x54
+        NA: 0x54
       description: "Table of multipliers for the accuracy stat for males for each stage 0-20, as binary fixed-point numbers (8 fraction bits)"
     - name: MALE_EVASION_STAGE_MULTIPLIERS
       address:
-        NA: 0x22C5460
         EU: 0x22C5DB8
+        NA: 0x22C5460
       length:
-        NA: 0x54
         EU: 0x54
+        NA: 0x54
       description: "Table of multipliers for the evasion stat for males for each stage 0-20, as binary fixed-point numbers (8 fraction bits)"
     - name: FEMALE_ACCURACY_STAGE_MULTIPLIERS
       address:
-        NA: 0x22C54B4
         EU: 0x22C5E0C
+        NA: 0x22C54B4
       length:
-        NA: 0x54
         EU: 0x54
+        NA: 0x54
       description: "Table of multipliers for the accuracy stat for females for each stage 0-20, as binary fixed-point numbers (8 fraction bits)"
     - name: FEMALE_EVASION_STAGE_MULTIPLIERS
       address:
-        NA: 0x22C5508
         EU: 0x22C5E60
+        NA: 0x22C5508
       length:
-        NA: 0x54
         EU: 0x54
+        NA: 0x54
       description: "Table of multipliers for the evasion stat for females for each stage 0-20, as binary fixed-point numbers (8 fraction bits)"
     - name: MUSIC_ID_TABLE
       address:
-        NA: 0x22C555C
         EU: 0x22C5EB4
+        NA: 0x22C555C
       length:
-        NA: 0x154
         EU: 0x154
+        NA: 0x154
       description: |-
         List of music IDs used in dungeons with a single music track.
         
@@ -430,11 +430,11 @@ overlay10:
         type: struct music_id_16[170] (or not a music ID if the highest bit is set)
     - name: TYPE_MATCHUP_TABLE
       address:
-        NA: 0x22C56B0
         EU: 0x22C6008
+        NA: 0x22C56B0
       length:
-        NA: 0x288
         EU: 0x288
+        NA: 0x288
       description: |-
         Table of type matchups.
         
@@ -443,11 +443,11 @@ overlay10:
         type: struct type_matchup_table
     - name: FIXED_ROOM_MONSTER_SPAWN_STATS_TABLE
       address:
-        NA: 0x22C5938
         EU: 0x22C6290
+        NA: 0x22C5938
       length:
-        NA: 0x4A4
         EU: 0x4A4
+        NA: 0x4A4
       description: |-
         Table of stats for monsters that can spawn in fixed rooms, pointed into by the FIXED_ROOM_MONSTER_SPAWN_TABLE.
         
@@ -456,18 +456,18 @@ overlay10:
         type: struct fixed_room_monster_spawn_stats_entry[99]
     - name: TILESET_PROPERTIES
       address:
-        NA: 0x22C631C
         EU: 0x22C6C74
+        NA: 0x22C631C
       length:
-        NA: 0x954
         EU: 0x954
+        NA: 0x954
     - name: FIXED_ROOM_PROPERTIES_TABLE
       address:
-        NA: 0x22C6C70
         EU: 0x22C75C8
+        NA: 0x22C6C70
       length:
-        NA: 0xC00
         EU: 0xC00
+        NA: 0xC00
       description: |-
         Table of properties for fixed rooms.
         
@@ -478,5 +478,5 @@ overlay10:
         type: struct fixed_room_properties_entry[256]
     - name: MOVE_ANIMATION_INFO
       address:
-        NA: 0x22C9064
         EU: 0x22C99BC
+        NA: 0x22C9064

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -1,15 +1,15 @@
 overlay11:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22DC240
     EU: 0x22DCB80
+    NA: 0x22DC240
     JP: 0x22DD8E0
   length:
-    NA: 0x48C40
     EU: 0x48E40
+    NA: 0x48C40
     JP: 0x48B00
   description: |-
     The script engine.
@@ -18,38 +18,38 @@ overlay11:
   functions:
     - name: FuncThatCallsCommandParsing
       address:
-        NA: 0x22DD164
         EU: 0x22DDAA4
+        NA: 0x22DD164
         JP: 0x22DE804
     - name: ScriptCommandParsing
       address:
-        NA: 0x22DDD64
         EU: 0x22DE6A4
+        NA: 0x22DDD64
         JP: 0x22DF404
     - name: SsbLoad2
       address:
-        NA: 0x22E46FC
         EU: 0x22E503C
+        NA: 0x22E46FC
         JP: 0x22E5D28
     - name: StationLoadHanger
       address:
-        NA: 0x22E4BD4
         EU: 0x22E5514
+        NA: 0x22E4BD4
         JP: 0x22E6200
     - name: ScriptStationLoadTalk
       address:
-        NA: 0x22E53E4
         EU: 0x22E5D24
+        NA: 0x22E53E4
         JP: 0x22E6A10
     - name: SsbLoad1
       address:
-        NA: 0x22E5D50
         EU: 0x22E6690
+        NA: 0x22E5D50
         JP: 0x22E737C
     - name: ScriptSpecialProcessCall
       address:
-        NA: 0x22E7118
         EU: 0x22E7A58
+        NA: 0x22E7118
         JP: 0x22E874C
       description: |-
         Processes calls to the OPCODE_PROCESS_SPECIAL script opcode.
@@ -61,8 +61,8 @@ overlay11:
         return: return value of the special process if it has one, otherwise 0
     - name: GetSpecialRecruitmentSpecies
       address:
-        NA: 0x22E803C
         EU: 0x22E897C
+        NA: 0x22E803C
         JP: 0x22E9670
       description: |-
         Returns an entry from RECRUITMENT_TABLE_SPECIES.
@@ -73,8 +73,8 @@ overlay11:
         return: enum monster_id
     - name: PrepareMenuAcceptTeamMember
       address:
-        NA: 0x22E8080
         EU: 0x22E89C0
+        NA: 0x22E8080
         JP: 0x22E96B4
       description: |-
         Implements SPECIAL_PROC_PREPARE_MENU_ACCEPT_TEAM_MEMBER (see ScriptSpecialProcessCall).
@@ -82,8 +82,8 @@ overlay11:
         r0: index into RECRUITMENT_TABLE_SPECIES
     - name: InitRandomNpcJobs
       address:
-        NA: 0x22E8124
         EU: 0x22E8A64
+        NA: 0x22E8124
         JP: 0x22E9758
       description: |-
         Implements SPECIAL_PROC_INIT_RANDOM_NPC_JOBS (see ScriptSpecialProcessCall).
@@ -92,8 +92,8 @@ overlay11:
         r1: ?
     - name: GetRandomNpcJobType
       address:
-        NA: 0x22E81BC
         EU: 0x22E8AFC
+        NA: 0x22E81BC
         JP: 0x22E97F0
       description: |-
         Implements SPECIAL_PROC_GET_RANDOM_NPC_JOB_TYPE (see ScriptSpecialProcessCall).
@@ -101,8 +101,8 @@ overlay11:
         return: job type?
     - name: GetRandomNpcJobSubtype
       address:
-        NA: 0x22E81D4
         EU: 0x22E8B14
+        NA: 0x22E81D4
         JP: 0x22E9808
       description: |-
         Implements SPECIAL_PROC_GET_RANDOM_NPC_JOB_SUBTYPE (see ScriptSpecialProcessCall).
@@ -110,8 +110,8 @@ overlay11:
         return: job subtype?
     - name: GetRandomNpcJobStillAvailable
       address:
-        NA: 0x22E81F0
         EU: 0x22E8B30
+        NA: 0x22E81F0
         JP: 0x22E9824
       description: |-
         Implements SPECIAL_PROC_GET_RANDOM_NPC_JOB_STILL_AVAILABLE (see ScriptSpecialProcessCall).
@@ -119,8 +119,8 @@ overlay11:
         return: bool
     - name: AcceptRandomNpcJob
       address:
-        NA: 0x22E8258
         EU: 0x22E8B98
+        NA: 0x22E8258
         JP: 0x22E988C
       description: |-
         Implements SPECIAL_PROC_ACCEPT_RANDOM_NPC_JOB (see ScriptSpecialProcessCall).
@@ -128,8 +128,8 @@ overlay11:
         return: bool
     - name: GroundMainLoop
       address:
-        NA: 0x22E8774
         EU: 0x22E90B4
+        NA: 0x22E8774
         JP: 0x22E9DA8
       description: |-
         Appears to be the main loop for ground mode.
@@ -140,8 +140,8 @@ overlay11:
         return: return code
     - name: GetAllocArenaGround
       address:
-        NA: 0x22E935C
         EU: 0x22E9C9C
+        NA: 0x22E935C
         JP: 0x22EA990
       description: |-
         The GetAllocArena function used for ground mode. See SetMemAllocatorParams for more information.
@@ -151,8 +151,8 @@ overlay11:
         return: memory arena pointer, or null
     - name: GetFreeArenaGround
       address:
-        NA: 0x22E93C0
         EU: 0x22E9D00
+        NA: 0x22E93C0
         JP: 0x22EA9F4
       description: |-
         The GetFreeArena function used for ground mode. See SetMemAllocatorParams for more information.
@@ -162,8 +162,8 @@ overlay11:
         return: memory arena pointer, or null
     - name: GroundMainReturnDungeon
       address:
-        NA: 0x22E9414
         EU: 0x22E9D54
+        NA: 0x22E9414
         JP: 0x22EAA48
       description: |-
         Implements SPECIAL_PROC_RETURN_DUNGEON (see ScriptSpecialProcessCall).
@@ -171,8 +171,8 @@ overlay11:
         No params.
     - name: GroundMainNextDay
       address:
-        NA: 0x22E9438
         EU: 0x22E9D78
+        NA: 0x22E9438
         JP: 0x22EAA6C
       description: |-
         Implements SPECIAL_PROC_NEXT_DAY (see ScriptSpecialProcessCall).
@@ -180,8 +180,8 @@ overlay11:
         No params.
     - name: JumpToTitleScreen
       address:
-        NA: 0x22E95DC
         EU: 0x22E9F1C
+        NA: 0x22E95DC
         JP: 0x22EAC10
       description: |-
         Implements SPECIAL_PROC_JUMP_TO_TITLE_SCREEN and SPECIAL_PROC_0x1A (see ScriptSpecialProcessCall).
@@ -190,8 +190,8 @@ overlay11:
         return: bool (but note that the special process ignores this and always returns 0)
     - name: ReturnToTitleScreen
       address:
-        NA: 0x22E9694
         EU: 0x22E9FD4
+        NA: 0x22E9694
         JP: 0x22EACC8
       description: |-
         Implements SPECIAL_PROC_RETURN_TO_TITLE_SCREEN (see ScriptSpecialProcessCall).
@@ -200,8 +200,8 @@ overlay11:
         return: bool (but note that the special process ignores this and always returns 0)
     - name: ScriptSpecialProcess0x16
       address:
-        NA: 0x22E96F4
         EU: 0x22EA034
+        NA: 0x22E96F4
         JP: 0x22EAD28
       description: |-
         Implements SPECIAL_PROC_0x16 (see ScriptSpecialProcessCall).
@@ -209,8 +209,8 @@ overlay11:
         r0: bool
     - name: SprintfStatic
       address:
-        NA: 0x2308ECC
         EU: 0x2309868
+        NA: 0x2308ECC
         JP: 0x230A478
       description: |-
         Statically defined copy of sprintf(3) in overlay 11. See arm9.yml for more information.
@@ -221,8 +221,8 @@ overlay11:
         return: number of characters printed, excluding the null-terminator
     - name: StatusUpdate
       address:
-        NA: 0x2313A98
         EU: 0x2314478
+        NA: 0x2313A98
         JP: 0x2314FFC
       description: |-
         Implements SPECIAL_PROC_STATUS_UPDATE (see ScriptSpecialProcessCall).
@@ -231,12 +231,12 @@ overlay11:
   data:
     - name: SCRIPT_OP_CODES
       address:
-        NA: 0x2318610
         EU: 0x2318FF0
+        NA: 0x2318610
         JP: 0x2319B74
       length:
-        NA: 0xBF8
         EU: 0xBF8
+        NA: 0xBF8
         JP: 0xBF8
       description: |-
         Table of opcodes for the script engine. There are 383 8-byte entries.
@@ -246,8 +246,8 @@ overlay11:
         type: struct script_opcode_table
     - name: C_ROUTINES
       address:
-        NA: 0x231C828
         EU: 0x231D208
+        NA: 0x231C828
         JP: 0x231DD8C
       length:
         NA: 0x15E8
@@ -260,12 +260,12 @@ overlay11:
         type: struct common_routine_table
     - name: OBJECTS
       address:
-        NA: 0x231EE54
         EU: 0x231F8DC
+        NA: 0x231EE54
         JP: 0x23203B8
       length:
-        NA: 0x1A04
         EU: 0x1AAC
+        NA: 0x1A04
         JP: 0x1A04
       description: |-
         Table of objects for the script engine, which can be placed in scenes. There are a version-dependent number of 12-byte entries.
@@ -273,33 +273,33 @@ overlay11:
         type: struct script_object[length / 12]
     - name: RECRUITMENT_TABLE_LOCATIONS
       address:
-        NA: 0x2320894
         EU: 0x23213C4
+        NA: 0x2320894
       length:
-        NA: 0x16
         EU: 0x16
+        NA: 0x16
       description: |-
         Table of dungeon IDs corresponding to entries in RECRUITMENT_TABLE_SPECIES.
         
         type: struct dungeon_id_16[22]
     - name: RECRUITMENT_TABLE_LEVELS
       address:
-        NA: 0x23208AC
         EU: 0x23213DC
+        NA: 0x23208AC
       length:
-        NA: 0x2C
         EU: 0x2C
+        NA: 0x2C
       description: |-
         Table of levels for recruited Pokémon, corresponding to entries in RECRUITMENT_TABLE_SPECIES.
         
         type: uint16_t[22]
     - name: RECRUITMENT_TABLE_SPECIES
       address:
-        NA: 0x23208D8
         EU: 0x2321408
+        NA: 0x23208D8
       length:
-        NA: 0x2C
         EU: 0x2C
+        NA: 0x2C
       description: |-
         Table of Pokémon recruited at special locations, such as at the ends of certain dungeons (e.g., Dialga or the Seven Treasures legendaries) or during a cutscene (e.g., Cresselia and Manaphy).
         
@@ -308,15 +308,15 @@ overlay11:
         type: struct monster_id_16[22]
     - name: LEVEL_TILEMAP_LIST
       address:
-        NA: 0x2320D2C
         EU: 0x232185C
+        NA: 0x2320D2C
       length:
-        NA: 0x288
         EU: 0x288
+        NA: 0x288
     - name: OVERLAY11_OVERLAY_LOAD_TABLE
       address:
-        NA: 0x232306C
         EU: 0x2323B9C
+        NA: 0x232306C
       description: |-
         The overlays that can be loaded while this one is loaded.
         
@@ -327,21 +327,21 @@ overlay11:
         - possibly function pointer to frame-update function?
     - name: UNIONALL_RAM_ADDRESS
       address:
-        NA: 0x2324CA4
         EU: 0x23257E4
+        NA: 0x2324CA4
       description: "[Runtime]"
     - name: GROUND_STATE_MAP
       address:
-        NA: 0x2324CC0
         EU: 0x2325800
+        NA: 0x2324CC0
       description: "[Runtime]"
     - name: GROUND_STATE_PTRS
       address:
-        NA: 0x2324CF4
         EU: 0x2325834
+        NA: 0x2324CF4
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
       description: |-
         Host pointers to multiple structure used for performing an overworld scene
         

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -247,6 +247,7 @@ overlay11:
     - name: C_ROUTINES
       address:
         NA: 0x231C828
+        EU: 0x231D208
         JP: 0x231DD8C
       length:
         NA: 0x15E8
@@ -260,6 +261,7 @@ overlay11:
     - name: OBJECTS
       address:
         NA: 0x231EE54
+        EU: 0x231F8DC
         JP: 0x23203B8
       length:
         NA: 0x1A04

--- a/symbols/overlay12.yml
+++ b/symbols/overlay12.yml
@@ -1,15 +1,15 @@
 overlay12:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x20
     EU: 0x20
+    NA: 0x20
     JP: 0x20
   description: Unused; all zeroes.
   functions: []

--- a/symbols/overlay13.yml
+++ b/symbols/overlay13.yml
@@ -1,60 +1,60 @@
 overlay13:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x2E80
     EU: 0x2E80
+    NA: 0x2E80
     JP: 0x2E80
   description: "Controls the personality test, including the available partners and playable Pokémon. The actual personality test questions are stored in the MESSAGE folder."
   functions: []
   data:
     - name: STARTERS_PARTNER_IDS
       address:
-        NA: 0x238C08C
         EU: 0x238CBCC
+        NA: 0x238C08C
       length:
-        NA: 0x2A
         EU: 0x2A
+        NA: 0x2A
       description: "type: struct monster_id_16[21]"
     - name: STARTERS_HERO_IDS
       address:
-        NA: 0x238C0B8
         EU: 0x238CBF8
+        NA: 0x238C0B8
       length:
-        NA: 0x40
         EU: 0x40
+        NA: 0x40
       description: "type: struct monster_id_16[32]"
     - name: STARTERS_STRINGS
       address:
-        NA: 0x238C14C
         EU: 0x238CC8C
+        NA: 0x238C14C
       length:
-        NA: 0x60
         EU: 0x60
+        NA: 0x60
     - name: QUIZ_QUESTION_STRINGS
       address:
-        NA: 0x238C1AC
         EU: 0x238CCEC
+        NA: 0x238C1AC
       length:
-        NA: 0x84
         EU: 0x84
+        NA: 0x84
     - name: QUIZ_ANSWER_STRINGS
       address:
-        NA: 0x238C230
         EU: 0x238CD70
+        NA: 0x238C230
       length:
-        NA: 0x160
         EU: 0x160
+        NA: 0x160
     - name: UNKNOWN_MENU_1
       address:
-        NA: 0x238CECC
         EU: 0x238DA0C
+        NA: 0x238CECC
       length:
-        NA: 0x48
         EU: 0x48
+        NA: 0x48

--- a/symbols/overlay14.yml
+++ b/symbols/overlay14.yml
@@ -1,23 +1,23 @@
 overlay14:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x3AE0
     EU: 0x3B40
+    NA: 0x3AE0
     JP: 0x3AE0
   description: Runs the sentry duty minigame.
   functions: []
   data:
     - name: FOOTPRINT_DEBUG_MENU
       address:
-        NA: 0x238DAA0
         EU: 0x238E640
+        NA: 0x238DAA0
       length:
-        NA: 0x48
         EU: 0x48
+        NA: 0x48

--- a/symbols/overlay15.yml
+++ b/symbols/overlay15.yml
@@ -1,23 +1,23 @@
 overlay15:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x1060
     EU: 0x1080
+    NA: 0x1060
     JP: 0x1060
   description: Controls the Duskull Bank.
   functions: []
   data:
     - name: BANK_MAIN_MENU
       address:
-        NA: 0x238B054
         EU: 0x238BBC0
+        NA: 0x238B054
       length:
-        NA: 0x28
         EU: 0x28
+        NA: 0x28

--- a/symbols/overlay16.yml
+++ b/symbols/overlay16.yml
@@ -1,37 +1,37 @@
 overlay16:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x2D20
     EU: 0x2D20
+    NA: 0x2D20
     JP: 0x2D40
   description: Controls Luminous Spring.
   functions: []
   data:
     - name: EVO_MENU_CONFIRM
       address:
-        NA: 0x238CD08
         EU: 0x238D84C
+        NA: 0x238CD08
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: EVO_SUBMENU
       address:
-        NA: 0x238CD20
         EU: 0x238D864
+        NA: 0x238CD20
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: EVO_MAIN_MENU
       address:
-        NA: 0x238CD40
         EU: 0x238D884
+        NA: 0x238CD40
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20

--- a/symbols/overlay17.yml
+++ b/symbols/overlay17.yml
@@ -1,86 +1,86 @@
 overlay17:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x1CE0
     EU: 0x1CE0
+    NA: 0x1CE0
     JP: 0x1CE0
   description: Controls the Chimecho Assembly.
   functions: []
   data:
     - name: ASSEMBLY_MENU_CONFIRM
       address:
-        NA: 0x238BB84
         EU: 0x238C6C4
+        NA: 0x238BB84
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: ASSEMBLY_MAIN_MENU_1
       address:
-        NA: 0x238BB9C
         EU: 0x238C6DC
+        NA: 0x238BB9C
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: ASSEMBLY_MAIN_MENU_2
       address:
-        NA: 0x238BBB4
         EU: 0x238C6F4
+        NA: 0x238BBB4
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: ASSEMBLY_SUBMENU_1
       address:
-        NA: 0x238BBD4
         EU: 0x238C714
+        NA: 0x238BBD4
       length:
-        NA: 0x28
         EU: 0x28
+        NA: 0x28
     - name: ASSEMBLY_SUBMENU_2
       address:
-        NA: 0x238BBFC
         EU: 0x238C73C
+        NA: 0x238BBFC
       length:
-        NA: 0x30
         EU: 0x30
+        NA: 0x30
     - name: ASSEMBLY_SUBMENU_3
       address:
-        NA: 0x238BC2C
         EU: 0x238C76C
+        NA: 0x238BC2C
       length:
-        NA: 0x30
         EU: 0x30
+        NA: 0x30
     - name: ASSEMBLY_SUBMENU_4
       address:
-        NA: 0x238BC5C
         EU: 0x238C79C
+        NA: 0x238BC5C
       length:
-        NA: 0x38
         EU: 0x38
+        NA: 0x38
     - name: ASSEMBLY_SUBMENU_5
       address:
-        NA: 0x238BC94
         EU: 0x238C7D4
+        NA: 0x238BC94
       length:
-        NA: 0x38
         EU: 0x38
+        NA: 0x38
     - name: ASSEMBLY_SUBMENU_6
       address:
-        NA: 0x238BCCC
         EU: 0x238C80C
+        NA: 0x238BCCC
       length:
-        NA: 0x38
         EU: 0x38
+        NA: 0x38
     - name: ASSEMBLY_SUBMENU_7
       address:
-        NA: 0x238BD04
         EU: 0x238C844
+        NA: 0x238BD04
       length:
-        NA: 0x40
         EU: 0x40
+        NA: 0x40

--- a/symbols/overlay18.yml
+++ b/symbols/overlay18.yml
@@ -1,79 +1,79 @@
 overlay18:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x3500
     EU: 0x3500
+    NA: 0x3500
     JP: 0x3520
   description: Controls the Electivire Link Shop.
   functions: []
   data:
     - name: MOVES_MENU_CONFIRM
       address:
-        NA: 0x238D320
         EU: 0x238DE60
+        NA: 0x238D320
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: MOVES_SUBMENU_1
       address:
-        NA: 0x238D338
         EU: 0x238DE78
+        NA: 0x238D338
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: MOVES_SUBMENU_2
       address:
-        NA: 0x238D358
         EU: 0x238DE98
+        NA: 0x238D358
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: MOVES_MAIN_MENU
       address:
-        NA: 0x238D378
         EU: 0x238DEB8
+        NA: 0x238D378
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: MOVES_SUBMENU_3
       address:
-        NA: 0x238D398
         EU: 0x238DED8
+        NA: 0x238D398
       length:
-        NA: 0x28
         EU: 0x28
+        NA: 0x28
     - name: MOVES_SUBMENU_4
       address:
-        NA: 0x238D3C0
         EU: 0x238DF00
+        NA: 0x238D3C0
       length:
-        NA: 0x30
         EU: 0x30
+        NA: 0x30
     - name: MOVES_SUBMENU_5
       address:
-        NA: 0x238D3F0
         EU: 0x238DF30
+        NA: 0x238D3F0
       length:
-        NA: 0x48
         EU: 0x48
+        NA: 0x48
     - name: MOVES_SUBMENU_6
       address:
-        NA: 0x238D438
         EU: 0x238DF78
+        NA: 0x238D438
       length:
-        NA: 0x48
         EU: 0x48
+        NA: 0x48
     - name: MOVES_SUBMENU_7
       address:
-        NA: 0x238D480
         EU: 0x238DFC0
+        NA: 0x238D480
       length:
-        NA: 0x48
         EU: 0x48
+        NA: 0x48

--- a/symbols/overlay19.yml
+++ b/symbols/overlay19.yml
@@ -1,51 +1,51 @@
 overlay19:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x4240
     EU: 0x4220
+    NA: 0x4240
     JP: 0x4220
   description: "Controls Spinda's Juice Bar."
   functions: []
   data:
     - name: BAR_MENU_CONFIRM_1
       address:
-        NA: 0x238E208
         EU: 0x238ED3C
+        NA: 0x238E208
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: BAR_MENU_CONFIRM_2
       address:
-        NA: 0x238E220
         EU: 0x238ED54
+        NA: 0x238E220
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: BAR_MAIN_MENU
       address:
-        NA: 0x238E250
         EU: 0x238ED84
+        NA: 0x238E250
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: BAR_SUBMENU_1
       address:
-        NA: 0x238E270
         EU: 0x238EDA4
+        NA: 0x238E270
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: BAR_SUBMENU_2
       address:
-        NA: 0x238E290
         EU: 0x238EDC4
+        NA: 0x238E290
       length:
-        NA: 0x30
         EU: 0x30
+        NA: 0x30

--- a/symbols/overlay20.yml
+++ b/symbols/overlay20.yml
@@ -1,65 +1,65 @@
 overlay20:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x3000
     EU: 0x3000
+    NA: 0x3000
     JP: 0x3000
   description: Controls the Recycle Shop.
   functions: []
   data:
     - name: RECYCLE_MENU_CONFIRM_1
       address:
-        NA: 0x238CF84
         EU: 0x238DAC4
+        NA: 0x238CF84
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: RECYCLE_MENU_CONFIRM_2
       address:
-        NA: 0x238CF9C
         EU: 0x238DADC
+        NA: 0x238CF9C
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: RECYCLE_SUBMENU_1
       address:
-        NA: 0x238CFB4
         EU: 0x238DAF4
+        NA: 0x238CFB4
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: RECYCLE_SUBMENU_2
       address:
-        NA: 0x238CFCC
         EU: 0x238DB0C
+        NA: 0x238CFCC
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: RECYCLE_MAIN_MENU_1
       address:
-        NA: 0x238CFEC
         EU: 0x238DB2C
+        NA: 0x238CFEC
       length:
-        NA: 0x28
         EU: 0x28
+        NA: 0x28
     - name: RECYCLE_MAIN_MENU_2
       address:
-        NA: 0x238D088
         EU: 0x238DBC8
+        NA: 0x238D088
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: RECYCLE_MAIN_MENU_3
       address:
-        NA: 0x238D0F8
         EU: 0x238DC38
+        NA: 0x238D0F8
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18

--- a/symbols/overlay21.yml
+++ b/symbols/overlay21.yml
@@ -1,58 +1,58 @@
 overlay21:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x2E20
     EU: 0x2E20
+    NA: 0x2E20
     JP: 0x2E40
   description: Controls the Croagunk Swap Shop.
   functions: []
   data:
     - name: SWAP_SHOP_MENU_CONFIRM
       address:
-        NA: 0x238CA38
         EU: 0x238D578
+        NA: 0x238CA38
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: SWAP_SHOP_SUBMENU_1
       address:
-        NA: 0x238CA50
         EU: 0x238D590
+        NA: 0x238CA50
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: SWAP_SHOP_SUBMENU_2
       address:
-        NA: 0x238CA68
         EU: 0x238D5A8
+        NA: 0x238CA68
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: SWAP_SHOP_MAIN_MENU_1
       address:
-        NA: 0x238CA88
         EU: 0x238D5C8
+        NA: 0x238CA88
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: SWAP_SHOP_MAIN_MENU_2
       address:
-        NA: 0x238CAA8
         EU: 0x238D5E8
+        NA: 0x238CAA8
       length:
-        NA: 0x28
         EU: 0x28
+        NA: 0x28
     - name: SWAP_SHOP_SUBMENU_3
       address:
-        NA: 0x238CAD0
         EU: 0x238D610
+        NA: 0x238CAD0
       length:
-        NA: 0x30
         EU: 0x30
+        NA: 0x30

--- a/symbols/overlay22.yml
+++ b/symbols/overlay22.yml
@@ -1,44 +1,44 @@
 overlay22:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x4B40
     EU: 0x4B40
+    NA: 0x4B40
     JP: 0x4B40
   description: Controls the Kecleon Shop in Treasure Town.
   functions: []
   data:
     - name: SHOP_MENU_CONFIRM
       address:
-        NA: 0x238E868
         EU: 0x238F3A8
+        NA: 0x238E868
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: SHOP_MAIN_MENU_1
       address:
-        NA: 0x238E880
         EU: 0x238F3C0
+        NA: 0x238E880
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: SHOP_MAIN_MENU_2
       address:
-        NA: 0x238E8A0
         EU: 0x238F3E0
+        NA: 0x238E8A0
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: SHOP_MAIN_MENU_3
       address:
-        NA: 0x238E8C0
         EU: 0x238F400
+        NA: 0x238E8C0
       length:
-        NA: 0x30
         EU: 0x30
+        NA: 0x30

--- a/symbols/overlay23.yml
+++ b/symbols/overlay23.yml
@@ -1,51 +1,51 @@
 overlay23:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x3780
     EU: 0x3780
+    NA: 0x3780
     JP: 0x37E0
   description: Controls Kangaskhan Storage (both in Treasure Town and via Kangaskhan Rocks).
   functions: []
   data:
     - name: STORAGE_MENU_CONFIRM
       address:
-        NA: 0x238D2FC
         EU: 0x238DE3C
+        NA: 0x238D2FC
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: STORAGE_MAIN_MENU_1
       address:
-        NA: 0x238D314
         EU: 0x238DE54
+        NA: 0x238D314
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: STORAGE_MAIN_MENU_2
       address:
-        NA: 0x238D334
         EU: 0x238DE74
+        NA: 0x238D334
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: STORAGE_MAIN_MENU_3
       address:
-        NA: 0x238D354
         EU: 0x238DE94
+        NA: 0x238D354
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: STORAGE_MAIN_MENU_4
       address:
-        NA: 0x238D374
         EU: 0x238DEB4
+        NA: 0x238D374
       length:
-        NA: 0x28
         EU: 0x28
+        NA: 0x28

--- a/symbols/overlay24.yml
+++ b/symbols/overlay24.yml
@@ -1,30 +1,30 @@
 overlay24:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x24E0
     EU: 0x24E0
+    NA: 0x24E0
     JP: 0x24E0
   description: Controls the Chansey Day Care.
   functions: []
   data:
     - name: DAYCARE_MENU_CONFIRM
       address:
-        NA: 0x238C520
         EU: 0x238D060
+        NA: 0x238C520
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: DAYCARE_MAIN_MENU
       address:
-        NA: 0x238C538
         EU: 0x238D078
+        NA: 0x238C538
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20

--- a/symbols/overlay25.yml
+++ b/symbols/overlay25.yml
@@ -1,37 +1,37 @@
 overlay25:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x14C0
     EU: 0x14C0
+    NA: 0x14C0
     JP: 0x14C0
   description: Controls Xatu Appraisal.
   functions: []
   data:
     - name: APPRAISAL_MENU_CONFIRM
       address:
-        NA: 0x238B4B4
         EU: 0x238BFF4
+        NA: 0x238B4B4
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: APPRAISAL_MAIN_MENU
       address:
-        NA: 0x238B4CC
         EU: 0x238C00C
+        NA: 0x238B4CC
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: APPRAISAL_SUBMENU
       address:
-        NA: 0x238B4EC
         EU: 0x238C02C
+        NA: 0x238B4EC
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20

--- a/symbols/overlay26.yml
+++ b/symbols/overlay26.yml
@@ -1,15 +1,15 @@
 overlay26:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0xE40
     EU: 0xE40
+    NA: 0xE40
     JP: 0xE40
   description: "Related to mission completion. It's loaded when the dungeon completion summary is shown upon exiting a dungeon, and during the cutscenes where you collect mission rewards from clients."
   functions: []

--- a/symbols/overlay27.yml
+++ b/symbols/overlay27.yml
@@ -1,44 +1,44 @@
 overlay27:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0x2D60
     EU: 0x2D60
+    NA: 0x2D60
     JP: 0x2DA0
   description: Controls the special episode item discard menu.
   functions: []
   data:
     - name: DISCARD_ITEMS_MENU_CONFIRM
       address:
-        NA: 0x238C95C
         EU: 0x238D49C
+        NA: 0x238C95C
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: DISCARD_ITEMS_SUBMENU_1
       address:
-        NA: 0x238C974
         EU: 0x238D4B4
+        NA: 0x238C974
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: DISCARD_ITEMS_SUBMENU_2
       address:
-        NA: 0x238C994
         EU: 0x238D4D4
+        NA: 0x238C994
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: DISCARD_ITEMS_MAIN_MENU
       address:
-        NA: 0x238C9B4
         EU: 0x238D4F4
+        NA: 0x238C9B4
       length:
-        NA: 0x28
         EU: 0x28
+        NA: 0x28

--- a/symbols/overlay28.yml
+++ b/symbols/overlay28.yml
@@ -1,15 +1,15 @@
 overlay28:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x238A140
     EU: 0x238AC80
+    NA: 0x238A140
     JP: 0x238B6A0
   length:
-    NA: 0xC60
     EU: 0xC60
+    NA: 0xC60
     JP: 0xC60
   description: Controls the staff credits sequence.
   functions: []

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -1,15 +1,15 @@
 overlay29:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22DC240
     EU: 0x22DCB80
+    NA: 0x22DC240
     JP: 0x22DD8E0
   length:
-    NA: 0x77620
     EU: 0x77900
+    NA: 0x77620
     JP: 0x77200
   description: |-
     The dungeon engine.
@@ -18,8 +18,8 @@ overlay29:
   functions:
     - name: DungeonAlloc
       address:
-        NA: 0x22DEA5C
         EU: 0x22DF39C
+        NA: 0x22DEA5C
         JP: 0x22E00FC
       description: |-
         Allocates a new dungeon struct.
@@ -29,16 +29,16 @@ overlay29:
         return: pointer to a newly allocated dungeon struct
     - name: GetDungeonPtrMaster
       address:
-        NA: 0x22DEA80
         EU: 0x22DF3C0
+        NA: 0x22DEA80
       description: |-
         Returns the master dungeon pointer (a global, see DUNGEON_PTR_MASTER).
         
         return: pointer to a newly allocated dungeon struct
     - name: DungeonZInit
       address:
-        NA: 0x22DEA90
         EU: 0x22DF3D0
+        NA: 0x22DEA90
         JP: 0x22E0130
       description: |-
         Zero-initializes the dungeon struct pointed to by the master dungeon pointer.
@@ -46,20 +46,74 @@ overlay29:
         No params.
     - name: DungeonFree
       address:
-        NA: 0x22DEAB0
         EU: 0x22DF3F0
+        NA: 0x22DEAB0
       description: |-
         Frees the dungeons struct pointer to by the master dungeon pointer, and nullifies the pointer.
         
         No params.
     - name: InitializeDungeon
       address:
-        NA: 0x22DEF38
         EU: 0x22DF878
+        NA: 0x22DEF38
         JP: 0x22E05D8
       description: Seems to initialize the dungeon struct from specified dungeon data.
     - name: EntityIsValid
       address:
+        EU:
+          - 0x22E0C94
+          - 0x22E235C
+          - 0x22E2947
+          - 0x22E3C98
+          - 0x22E4168
+          - 0x22E9FA4
+          - 0x22ECFB8
+          - 0x22ED770
+          - 0x22EECF8
+          - 0x22F0154
+          - 0x22F0F44
+          - 0x22F5C48
+          - 0x22F6C60
+          - 0x22F7D1C
+          - 0x22FD398
+          - 0x22FEEB8
+          - 0x2300B10
+          - 0x2303464
+          - 0x23051E4
+          - 0x2305FB8
+          - 0x2306630
+          - 0x2308924
+          - 0x23099E8
+          - 0x230F364
+          - 0x230FA7C
+          - 0x2311A70
+          - 0x2312314
+          - 0x2315B78
+          - 0x2319794
+          - 0x23198AC
+          - 0x231A9EC
+          - 0x231BBF4
+          - 0x231D630
+          - 0x231F840
+          - 0x231FFD8
+          - 0x2320664
+          - 0x2320BE4
+          - 0x23211CC
+          - 0x2326088
+          - 0x2328A78
+          - 0x232AE44
+          - 0x232CF70
+          - 0x232EC90
+          - 0x232F280
+          - 0x23349EC
+          - 0x2335B18
+          - 0x2338878
+          - 0x23456DC
+          - 0x2346284
+          - 0x23487A4
+          - 0x234A47C
+          - 0x234E9D0
+          - 0x234F820
         NA:
           - 0x22E0354
           - 0x22E1A1C
@@ -115,60 +169,6 @@ overlay29:
           - 0x234987C
           - 0x234DDD0
           - 0x234EC14
-        EU:
-          - 0x22E0C94
-          - 0x22E235C
-          - 0x22E2947
-          - 0x22E3C98
-          - 0x22E4168
-          - 0x22E9FA4
-          - 0x22ECFB8
-          - 0x22ED770
-          - 0x22EECF8
-          - 0x22F0154
-          - 0x22F0F44
-          - 0x22F5C48
-          - 0x22F6C60
-          - 0x22F7D1C
-          - 0x22FD398
-          - 0x22FEEB8
-          - 0x2300B10
-          - 0x2303464
-          - 0x23051E4
-          - 0x2305FB8
-          - 0x2306630
-          - 0x2308924
-          - 0x23099E8
-          - 0x230F364
-          - 0x230FA7C
-          - 0x2311A70
-          - 0x2312314
-          - 0x2315B78
-          - 0x2319794
-          - 0x23198AC
-          - 0x231A9EC
-          - 0x231BBF4
-          - 0x231D630
-          - 0x231F840
-          - 0x231FFD8
-          - 0x2320664
-          - 0x2320BE4
-          - 0x23211CC
-          - 0x2326088
-          - 0x2328A78
-          - 0x232AE44
-          - 0x232CF70
-          - 0x232EC90
-          - 0x232F280
-          - 0x23349EC
-          - 0x2335B18
-          - 0x2338878
-          - 0x23456DC
-          - 0x2346284
-          - 0x23487A4
-          - 0x234A47C
-          - 0x234E9D0
-          - 0x234F820
       description: |-
         Checks if an entity pointer points to a valid entity (not entity type 0, which represents no entity).
         
@@ -176,8 +176,8 @@ overlay29:
         return: bool
     - name: GetFloorType
       address:
-        NA: 0x22E03B0
         EU: 0x22E0CF0
+        NA: 0x22E03B0
         JP: 0x22E1A48
       description: |-
         Get the current floor type.
@@ -190,8 +190,8 @@ overlay29:
         return: floor type
     - name: TryForcedLoss
       address:
-        NA: 0x22E0620
         EU: 0x22E0F60
+        NA: 0x22E0620
         JP: 0x22E1CAC
       description: |-
         Attempts to trigger a forced loss of the type specified in dungeon::forced_loss_reason.
@@ -200,24 +200,24 @@ overlay29:
         return: true if the forced loss happens, false otherwise
     - name: FixedRoomIsSubstituteRoom
       address:
-        NA: 0x22E08CC
         EU: 0x22E120C
+        NA: 0x22E08CC
       description: |-
         Checks if the current fixed room is the "substitute room" (ID 0x6E).
         
         return: bool
     - name: ShouldGameOverOnImportantTeamMemberFaint
       address:
-        NA: 0x22E0928
         EU: 0x22E1268
+        NA: 0x22E0928
       description: |-
         Returns true if you should get kicked out of the dungeon if an important team member (like the partner or certain story allies) faints.
         
         return: dungeon::nonstory_flag || dungeon::hidden_land_flag
     - name: GetTileAtEntity
       address:
-        NA: 0x22E1628
         EU: 0x22E1F68
+        NA: 0x22E1628
         JP: 0x22E2CB8
       description: |-
         Returns a pointer to the tile where an entity is located.
@@ -226,8 +226,8 @@ overlay29:
         returns: pointer to tile
     - name: SubstitutePlaceholderStringTags
       address:
-        NA: 0x22E2AD8
         EU: 0x22E3418
+        NA: 0x22E2AD8
         JP: 0x22E416C
       description: |-
         Replaces instances of a given placeholder tag by the string representation of the given entity.
@@ -241,8 +241,8 @@ overlay29:
         r2: ?
     - name: UpdateMapSurveyorFlag
       address:
-        NA: 0x22E2DD8
         EU: 0x22E375C
+        NA: 0x22E2DD8
       description: |-
         Sets the Map Surveyor flag in the dungeon struct to true if a team member has Map Surveyor, sets it to false otherwise.
         
@@ -251,20 +251,6 @@ overlay29:
         return: bool
     - name: ItemIsActive
       address:
-        NA:
-          - 0x22E330C
-          - 0x22EE318
-          - 0x22F5994
-          - 0x22FF898
-          - 0x23026CC
-          - 0x2307F1C
-          - 0x230A9DC
-          - 0x230E578
-          - 0x230F810
-          - 0x2311034
-          - 0x2311BF8
-          - 0x231513C
-          - 0x2347B50
         EU:
           - 0x22E3CBC
           - 0x22EECC8
@@ -279,6 +265,20 @@ overlay29:
           - 0x2312658
           - 0x2315B9C
           - 0x2348750
+        NA:
+          - 0x22E330C
+          - 0x22EE318
+          - 0x22F5994
+          - 0x22FF898
+          - 0x23026CC
+          - 0x2307F1C
+          - 0x230A9DC
+          - 0x230E578
+          - 0x230F810
+          - 0x2311034
+          - 0x2311BF8
+          - 0x231513C
+          - 0x2347B50
       description: |-
         Checks if a monster is holding a certain item that isn't disabled by Klutz.
         
@@ -287,8 +287,8 @@ overlay29:
         return: bool
     - name: IsOnMonsterSpawnList
       address:
-        NA: 0x22E7D4C
         EU: 0x22E86FC
+        NA: 0x22E7D4C
       description: |-
         Returns true if the specified monster is included in the floor's monster spawn list (the modified list after a maximum of 14 different species were chosen, not the raw list read from the mappa file).
         
@@ -296,8 +296,8 @@ overlay29:
         return: bool
     - name: GetMonsterIdToSpawn
       address:
-        NA: 0x22E7DA0
         EU: 0x22E8750
+        NA: 0x22E7DA0
         JP: 0x22E9408
       description: |-
         Get the id of the monster to be randomly spawned.
@@ -306,8 +306,8 @@ overlay29:
         return: monster ID
     - name: GetMonsterLevelToSpawn
       address:
-        NA: 0x22E7E58
         EU: 0x22E8808
+        NA: 0x22E7E58
         JP: 0x22E94C0
       description: |-
         Get the level of the monster to be spawned, given its id.
@@ -316,16 +316,16 @@ overlay29:
         return: Level of the monster to be spawned, or 1 if the specified ID can't be found on the floor's spawn table.
     - name: GetLeader
       address:
-        NA: 0x22E9580
         EU: 0x22E9F30
+        NA: 0x22E9580
       description: |-
         Gets the pointer to the entity that is currently leading the team, or null if none of the first 4 entities is a valid monster with its is_team_leader flag set. It also sets LEADER_PTR to the result before returning it.
         
         return: Pointer to the current leader of the team or null if there's no valid leader.
     - name: TickStatusTurnCounter
       address:
-        NA: 0x22E9A44
         EU: 0x22EA3F4
+        NA: 0x22E9A44
         JP: 0x22EB0AC
       description: |-
         Ticks down a turn counter for a status condition. If the counter equals 0x7F, it will not be decreased.
@@ -334,8 +334,8 @@ overlay29:
         return: new counter value
     - name: GenerateDungeonRngSeed
       address:
-        NA: 0x22EA980
         EU: 0x22EB330
+        NA: 0x22EA980
         JP: 0x22EBFE8
       description: |-
         Generates a seed with which to initialize the dungeon PRNG.
@@ -349,8 +349,8 @@ overlay29:
         return: RNG seed
     - name: GetDungeonRngPreseed
       address:
-        NA: 0x22EA9CC
         EU: 0x22EB37C
+        NA: 0x22EA9CC
         JP: 0x22EC034
       description: |-
         Gets the current preseed stored in the global dungeon PRNG state. See GenerateDungeonRngSeed for more information.
@@ -358,8 +358,8 @@ overlay29:
         return: current dungeon RNG preseed
     - name: SetDungeonRngPreseed
       address:
-        NA: 0x22EA9DC
         EU: 0x22EB38C
+        NA: 0x22EA9DC
         JP: 0x22EC044
       description: |-
         Sets the preseed in the global dungeon PRNG state. See GenerateDungeonRngSeed for more information.
@@ -367,8 +367,8 @@ overlay29:
         r0: preseed
     - name: InitDungeonRng
       address:
-        NA: 0x22EA9EC
         EU: 0x22EB39C
+        NA: 0x22EA9EC
         JP: 0x22EC054
       description: |-
         Initialize (or reinitialize) the dungeon PRNG with a given seed. The primary LCG and the five secondary LCGs are initialized jointly, and with the same seed.
@@ -376,8 +376,8 @@ overlay29:
         r0: seed
     - name: DungeonRand16Bit
       address:
-        NA: 0x22EAA20
         EU: 0x22EB3D0
+        NA: 0x22EAA20
         JP: 0x22EC088
       description: |-
         Computes a pseudorandom 16-bit integer using the dungeon PRNG.
@@ -396,8 +396,8 @@ overlay29:
         return: pseudorandom int on the interval [0, 65535]
     - name: DungeonRandInt
       address:
-        NA: 0x22EAA98
         EU: 0x22EB448
+        NA: 0x22EAA98
         JP: 0x22EC100
       description: |-
         Compute a pseudorandom integer under a given maximum value using the dungeon PRNG.
@@ -406,8 +406,8 @@ overlay29:
         return: pseudorandom integer on the interval [0, high - 1]
     - name: DungeonRandRange
       address:
-        NA: 0x22EAAC0
         EU: 0x22EB470
+        NA: 0x22EAAC0
         JP: 0x22EC128
       description: |-
         Compute a pseudorandom value between two integers using the dungeon PRNG.
@@ -417,12 +417,12 @@ overlay29:
         return: pseudorandom integer on the interval [min(x, y), max(x, y) - 1]
     - name: DungeonRandOutcome
       address:
-        NA:
-          - 0x22EAB20
-          - 0x22EAB50
         EU:
           - 0x22EB4D0
           - 0x22EB500
+        NA:
+          - 0x22EAB20
+          - 0x22EAB50
       description: |-
         Returns the result of a possibly biased coin flip (a Bernoulli random variable) with some success probability p, using the dungeon PRNG.
         
@@ -430,8 +430,8 @@ overlay29:
         return: true with probability p, false with probability (1-p)
     - name: CalcStatusDuration
       address:
-        NA: 0x22EAB80
         EU: 0x22EB530
+        NA: 0x22EAB80
         JP: 0x22EC1E8
       description: |-
         Seems to calculate the duration of a volatile status on a monster.
@@ -442,8 +442,8 @@ overlay29:
         return: number of turns for the status condition
     - name: DungeonRngUnsetSecondary
       address:
-        NA: 0x22EAC34
         EU: 0x22EB5E4
+        NA: 0x22EAC34
         JP: 0x22EC29C
       description: |-
         Sets the dungeon PRNG to use the primary LCG for subsequent random number generation, and also resets the secondary LCG index back to 0.
@@ -453,8 +453,8 @@ overlay29:
         No params.
     - name: DungeonRngSetSecondary
       address:
-        NA: 0x22EAC4C
         EU: 0x22EB5FC
+        NA: 0x22EAC4C
         JP: 0x22EC2B4
       description: |-
         Sets the dungeon PRNG to use one of the 5 secondary LCGs for subsequent random number generation.
@@ -462,16 +462,16 @@ overlay29:
         r0: secondary LCG index
     - name: DungeonRngSetPrimary
       address:
-        NA: 0x22EAC64
         EU: 0x22EB614
+        NA: 0x22EAC64
       description: |-
         Sets the dungeon PRNG to use the primary LCG for subsequent random number generation.
         
         No params.
     - name: TrySwitchPlace
       address:
-        NA: 0x22EB178
         EU: 0x22EBB28
+        NA: 0x22EB178
         JP: 0x22EC7E0
       description: |-
         The user entity attempts to switch places with the target entity (i.e. by the effect of the Switcher Orb). 
@@ -482,8 +482,8 @@ overlay29:
         r1: pointer to target entity
     - name: RunFractionalTurn
       address:
-        NA: 0x22EBD08
         EU: 0x22EC6B8
+        NA: 0x22EBD08
         JP: 0x22ED370
       description: |-
         The main function which executes the actions that take place in a fractional turn. Called in a loop by InitializeDungeon while FloorIsOver returns false.
@@ -491,8 +491,8 @@ overlay29:
         r0: first loop flag (true when the function is first called during a floor)
     - name: TrySpawnMonsterAndActivatePlusMinus
       address:
-        NA: 0x22EC6DC
         EU: 0x22ED08C
+        NA: 0x22EC6DC
         JP: 0x22EDD44
       description: |-
         Called at the beginning of RunFractionalTurn. Executed only if FRACTIONAL_TURN_SEQUENCE[fractional_turn * 2] is not 0.
@@ -502,8 +502,8 @@ overlay29:
         No params.
     - name: FloorIsOver
       address:
-        NA: 0x22EC7E8
         EU: 0x22ED198
+        NA: 0x22EC7E8
         JP: 0x22EDE50
       description: |-
         Checks if the current floor should end, and updates dungeon::floor_loop_status if required.
@@ -513,24 +513,24 @@ overlay29:
         return: true if the current floor should end
     - name: SetForcedLossReason
       address:
-        NA: 0x22ED008
         EU: 0x22ED9B8
+        NA: 0x22ED008
       description: |-
         Sets dungeon::forced_loss_reason to the specified value
         
         r0: Forced loss reason
     - name: GetForcedLossReason
       address:
-        NA: 0x22ED01C
         EU: 0x22ED9CC
+        NA: 0x22ED01C
       description: |-
         Returns dungeon::forced_loss_reason
         
         return: forced_loss_reason
     - name: ResetDamageDesc
       address:
-        NA: 0x22F6E18
         EU: 0x22F77D0
+        NA: 0x22F6E18
         JP: 0x22F83FC
       description: |-
         Seems to zero some damage description struct, which is output by the damage calculation function.
@@ -538,8 +538,8 @@ overlay29:
         r0: damage description pointer
     - name: GetSpriteIndex
       address:
-        NA: 0x22F7388
         EU: 0x22F7D40
+        NA: 0x22F7388
       description: |-
         Gets the sprite index of the specified monster on this floor
         
@@ -547,8 +547,8 @@ overlay29:
         return: Sprite index of the specified monster ID
     - name: FloorNumberIsEven
       address:
-        NA: 0x22F73B4
         EU: 0x22F7D6C
+        NA: 0x22F73B4
         JP: 0x22F897C
       description: |-
         Checks if the current dungeon floor number is even.
@@ -558,17 +558,26 @@ overlay29:
         return: bool
     - name: GetKecleonIdToSpawnByFloor
       address:
-        NA: 0x22F73EC
         EU: 0x22F7DA4
+        NA: 0x22F73EC
         JP: 0x22F89B4
       description: |-
         If the current floor number is even, returns female Kecleon's id (0x3D7), otherwise returns male Kecleon's id (0x17F).
         
         return: monster ID
+    - name: EuFaintCheck
+      address:
+        EU: 0x22F88E8
+      description: |-
+        This function is exclusive to the EU ROM. Seems to perform a check to see if the monster who just fainted was a team member who should cause the minimap to be updated (or something like that, maybe related to the Map Surveyor IQ skill) and if it passes, updates the minimap.
+        The function ends by calling another 2 functions. In US ROMs, calls to EUFaintCheck are replaced by calls to those two functions. This seems to indicate that this function fixes some edge case glitch that can happen when a team member faints.
+        
+        r0: False if the fainted entity was a team member
+        r1: True to set an unknown byte in the RAM to 1
     - name: HandleFaint
       address:
-        NA: 0x22F7F30
         EU: 0x22F8938
+        NA: 0x22F7F30
       description: |-
         Handles a fainted pokémon (reviving does not count as fainting).
         
@@ -577,8 +586,8 @@ overlay29:
         r2: Entity responsible of the fainting
     - name: TryActivateSlowStart
       address:
-        NA: 0x22F923C
         EU: 0x22F9C48
+        NA: 0x22F923C
         JP: 0x22FA800
       description: |-
         Runs a check over all monsters on the field for the ability Slow Start, and lowers the speed of those who have it.
@@ -586,8 +595,8 @@ overlay29:
         No params
     - name: TryActivateArtificialWeatherAbilities
       address:
-        NA: 0x22F92D8
         EU: 0x22F9CE4
+        NA: 0x22F92D8
         JP: 0x22FA89C
       description: |-
         Runs a check over all monsters on the field for abilities that affect the weather and changes the floor's weather accordingly.
@@ -595,17 +604,6 @@ overlay29:
         No params
     - name: DefenderAbilityIsActive
       address:
-        NA:
-          - 0x22F96CC
-          - 0x2301A0C
-          - 0x230A940
-          - 0x2311B94
-          - 0x2322D64
-          - 0x2328634
-          - 0x2329F14
-          - 0x232BDD0
-          - 0x232DE20
-          - 0x2332A0C
         EU:
           - 0x22FA0D8
           - 0x2302438
@@ -617,6 +615,17 @@ overlay29:
           - 0x232C840
           - 0x232E860
           - 0x233344C
+        NA:
+          - 0x22F96CC
+          - 0x2301A0C
+          - 0x230A940
+          - 0x2311B94
+          - 0x2322D64
+          - 0x2328634
+          - 0x2329F14
+          - 0x232BDD0
+          - 0x232DE20
+          - 0x2332A0C
       description: |-
         Checks if a defender has an active ability that isn't disabled by an attacker's Mold Breaker.
         
@@ -629,16 +638,6 @@ overlay29:
         return: bool
     - name: IsMonster
       address:
-        NA:
-          - 0x22F9720
-          - 0x2301A60
-          - 0x230A994
-          - 0x230F980
-          - 0x2318AB0
-          - 0x231A9D4
-          - 0x231B318
-          - 0x2322DB8
-          - 0x234D460
         EU:
           - 0x22FA12C
           - 0x230248C
@@ -649,6 +648,16 @@ overlay29:
           - 0x231BD78
           - 0x2323820
           - 0x234E060
+        NA:
+          - 0x22F9720
+          - 0x2301A60
+          - 0x230A994
+          - 0x230F980
+          - 0x2318AB0
+          - 0x231A9D4
+          - 0x231B318
+          - 0x2322DB8
+          - 0x234D460
       description: |-
         Checks if an entity is a monster (entity type 1).
         
@@ -656,8 +665,8 @@ overlay29:
         return: bool
     - name: TryActivateTruant
       address:
-        NA: 0x22F97F0
         EU: 0x22FA1FC
+        NA: 0x22F97F0
         JP: 0x22FADA8
       description: |-
         Checks if an entity has the ability Truant, and if so tries to apply the pause status to it.
@@ -665,8 +674,8 @@ overlay29:
         r0: pointer to entity
     - name: RestorePpAllMovesSetFlags
       address:
-        NA: 0x22F9A74
         EU: 0x22FA480
+        NA: 0x22F9A74
       description: |-
         Restores PP for all moves, clears flags move::f_consume_2_pp, move::flags2_unk5 and move::flags2_unk7, and sets flag move::f_consume_pp.
         Called when a monster is revived.
@@ -674,8 +683,8 @@ overlay29:
         r0: pointer to entity whose moves will be restored
     - name: MewSpawnCheck
       address:
-        NA: 0x22FA5F0
         EU: 0x22FAFFC
+        NA: 0x22FA5F0
         JP: 0x22FBB98
       description: |-
         If the monster id parameter is 0x97 (Mew), returns false if either dungeon::mew_cannot_spawn or the second parameter are true.
@@ -687,19 +696,6 @@ overlay29:
         return: bool
     - name: ExclusiveItemEffectIsActive
       address:
-        NA:
-          - 0x22FAC98
-          - 0x22FFF28
-          - 0x230A9B8
-          - 0x230F8AC
-          - 0x2311064
-          - 0x23147EC
-          - 0x23197A8
-          - 0x231A87C
-          - 0x2323918
-          - 0x23329E8
-          - 0x2347B80
-          - 0x23482B0
         EU:
           - 0x22FB6A4
           - 0x2300954
@@ -713,6 +709,19 @@ overlay29:
           - 0x2333428
           - 0x2348780
           - 0x2348EB0
+        NA:
+          - 0x22FAC98
+          - 0x22FFF28
+          - 0x230A9B8
+          - 0x230F8AC
+          - 0x2311064
+          - 0x23147EC
+          - 0x23197A8
+          - 0x231A87C
+          - 0x2323918
+          - 0x23329E8
+          - 0x2347B80
+          - 0x23482B0
       description: |-
         Checks if a monster is a team member under the effects of a certain exclusive item effect.
         
@@ -721,8 +730,8 @@ overlay29:
         return: bool
     - name: GetTeamMemberWithIqSkill
       address:
-        NA: 0x22FAFF8
         EU: 0x22FBA04
+        NA: 0x22FAFF8
         JP: 0x22FC580
       description: |-
         Returns an entity pointer to the first team member which has the specified iq skill.
@@ -731,8 +740,8 @@ overlay29:
         return: pointer to entity
     - name: TeamMemberHasEnabledIqSkill
       address:
-        NA: 0x22FB064
         EU: 0x22FBA70
+        NA: 0x22FB064
         JP: 0x22FC5EC
       description: |-
         Returns true if any team member has the specified iq skill.
@@ -741,8 +750,8 @@ overlay29:
         return: bool
     - name: TeamLeaderIqSkillIsEnabled
       address:
-        NA: 0x22FB080
         EU: 0x22FBA8C
+        NA: 0x22FB080
         JP: 0x22FC608
       description: |-
         Returns true the leader has the specified iq skill.
@@ -751,8 +760,8 @@ overlay29:
         return: bool
     - name: HasLowHealth
       address:
-        NA: 0x22FB610
         EU: 0x22FC01C
+        NA: 0x22FB610
         JP: 0x22FCAE4
       description: |-
         Checks if the entity passed is a valid monster, and if it's at low health (below 25% rounded down)
@@ -761,8 +770,8 @@ overlay29:
         return: bool
     - name: IsSpecialStoryAlly
       address:
-        NA: 0x22FBAD0
         EU: 0x22FC4CC
+        NA: 0x22FBAD0
         JP: 0x22FCFA4
       description: |-
         Checks if a monster is a special story ally.
@@ -773,8 +782,8 @@ overlay29:
         return: bool
     - name: IsExperienceLocked
       address:
-        NA: 0x22FBAF0
         EU: 0x22FC4EC
+        NA: 0x22FBAF0
         JP: 0x22FCFC4
       description: |-
         Checks if a monster does not gain experience.
@@ -785,8 +794,8 @@ overlay29:
         return: bool
     - name: SpawnMonster
       address:
-        NA: 0x22FD084
         EU: 0x22FDA80
+        NA: 0x22FD084
         JP: 0x22FE478
       description: |-
         Spawns the given monster on a tile.
@@ -796,8 +805,8 @@ overlay29:
         return: pointer to entity
     - name: CalcSpeedStage
       address:
-        NA: 0x22FFDF4
         EU: 0x2300820
+        NA: 0x22FFDF4
         JP: 0x2301224
       description: |-
         Calculates the speed stage of a monster from its speed up/down counters. The second parameter is the weight of each counter (how many stages it will add/remove), but appears to be always 1. 
@@ -810,8 +819,8 @@ overlay29:
         return: speed stage
     - name: GetNumberOfAttacks
       address:
-        NA: 0x22FFF5C
         EU: 0x2300988
+        NA: 0x22FFF5C
         JP: 0x230138C
       description: |-
         Returns the number of attacks that a monster can do in one turn (1 or 2).
@@ -822,8 +831,8 @@ overlay29:
         returns: int
     - name: SprintfStatic
       address:
-        NA: 0x23002C8
         EU: 0x2300CF4
+        NA: 0x23002C8
         JP: 0x23016D0
       description: |-
         Statically defined copy of sprintf(3) in overlay 29. See arm9.yml for more information.
@@ -834,8 +843,8 @@ overlay29:
         return: number of characters printed, excluding the null-terminator
     - name: NoGastroAcidStatus
       address:
-        NA: 0x2301CDC
         EU: 0x2302708
+        NA: 0x2301CDC
         JP: 0x2303234
       description: |-
         Checks if a monster does not have the Gastro Acid status.
@@ -844,8 +853,8 @@ overlay29:
         return: bool
     - name: AbilityIsActive
       address:
-        NA: 0x2301D10
         EU: 0x230273C
+        NA: 0x2301D10
         JP: 0x2303268
       description: |-
         Checks if a monster has a certain ability that isn't disabled by Gastro Acid.
@@ -855,8 +864,8 @@ overlay29:
         return: bool
     - name: LevitateIsActive
       address:
-        NA: 0x2301E18
         EU: 0x2302844
+        NA: 0x2301E18
         JP: 0x2303368
       description: |-
         Checks if a monster is levitating (has the effect of Levitate and Gravity is not active).
@@ -865,8 +874,8 @@ overlay29:
         return: bool
     - name: MonsterIsType
       address:
-        NA: 0x2301E50
         EU: 0x230287C
+        NA: 0x2301E50
         JP: 0x23033A0
       description: |-
         Checks if a monster is a given type.
@@ -876,8 +885,8 @@ overlay29:
         return: bool
     - name: IqSkillIsEnabled
       address:
-        NA: 0x2301F80
         EU: 0x23029AC
+        NA: 0x2301F80
         JP: 0x23034D0
       description: |-
         Checks if a monster has a certain IQ skill enabled.
@@ -887,8 +896,8 @@ overlay29:
         return: bool
     - name: GetMoveTypeForMonster
       address:
-        NA: 0x230227C
         EU: 0x2302CA8
+        NA: 0x230227C
       description: |-
         Check the type of a move when used by a certain monster. Accounts for special cases such as Hidden Power, Weather Ball, the regular attack...
         
@@ -897,8 +906,8 @@ overlay29:
         return: Type of the move
     - name: GetMovePower
       address:
-        NA: 0x230231C
         EU: 0x2302D48
+        NA: 0x230231C
         JP: 0x230386C
       description: |-
         Gets the power of a move, factoring in Ginseng/Space Globe boosts.
@@ -908,8 +917,8 @@ overlay29:
         return: move power
     - name: AddExpSpecial
       address:
-        NA: 0x230253C
         EU: 0x2302F68
+        NA: 0x230253C
         JP: 0x2303A8C
       description: |-
         Adds to a monster's experience points, subject to experience boosting effects.
@@ -923,16 +932,16 @@ overlay29:
         r2: base experience gain, before boosts
     - name: EnemyEvolution
       address:
-        NA: 0x23026FC
         EU: 0x2303128
+        NA: 0x23026FC
       description: |-
         Checks if the specified enemy should evolve because it just defeated an ally, and if so, attempts to evolve it.
         
         r0: Pointer to the enemy to check
     - name: EvolveMonster
       address:
-        NA: 0x2303C7C
         EU: 0x23046A8
+        NA: 0x2303C7C
       description: |-
         Makes the specified monster evolve into the specified species.
         
@@ -941,8 +950,8 @@ overlay29:
         r2: Species to evolve into
     - name: GetSleepAnimationId
       address:
-        NA: 0x2304AB4
         EU: 0x23054E0
+        NA: 0x2304AB4
         JP: 0x2306004
       description: |-
         Returns the animation id to be applied to a monster that has the sleep, napping, nightmare or bide status.
@@ -953,8 +962,8 @@ overlay29:
         return: animation ID
     - name: EndFrozenClassStatus
       address:
-        NA: 0x2306258
         EU: 0x2306C84
+        NA: 0x2306258
         JP: 0x23077A8
       description: |-
         Cures the target's freeze, shadow hold, ingrain, petrified, constriction or wrap (both as user and as target) status due to the action of the user.
@@ -964,8 +973,8 @@ overlay29:
         r2: if true, the event will be printed to the log
     - name: EndCringeClassStatus
       address:
-        NA: 0x23063D4
         EU: 0x2306E00
+        NA: 0x23063D4
         JP: 0x2307904
       description: |-
         Cures the target's cringe, confusion, cowering, pause, taunt, encore or infatuated status due to the action of the user, and prints the event to the log.
@@ -974,8 +983,8 @@ overlay29:
         r1: pointer to target
     - name: ApplyDamage
       address:
-        NA: 0x2308FE0
         EU: 0x2309A0C
+        NA: 0x2308FE0
       description: |-
         Applies damage to a monster. Displays the damage animation, lowers its health and handles reviving if applicable.
         The EU version has some additional checks related to printing fainting messages under specific circumstances.
@@ -989,8 +998,8 @@ overlay29:
         return: True if the target fainted (reviving does not count as fainting)
     - name: GetTypeMatchup
       address:
-        NA: 0x230AC58
         EU: 0x230B6CC
+        NA: 0x230AC58
         JP: 0x230C1D0
       description: |-
         Gets the type matchup for a given combat interaction.
@@ -1006,8 +1015,8 @@ overlay29:
         return: enum type_matchup
     - name: CalcDamage
       address:
-        NA: 0x230BBAC
         EU: 0x230C620
+        NA: 0x230BBAC
       description: |-
         Probably the damage calculation function.
         
@@ -1022,8 +1031,8 @@ overlay29:
         stack[4]: ?
     - name: CalcRecoilDamageFixed
       address:
-        NA: 0x230D18C
         EU: 0x230DC00
+        NA: 0x230D18C
         JP: 0x230E6CC
       description: |-
         Appears to calculate recoil damage to a monster.
@@ -1041,8 +1050,8 @@ overlay29:
         others: ?
     - name: CalcDamageFixed
       address:
-        NA: 0x230D240
         EU: 0x230DCB4
+        NA: 0x230D240
         JP: 0x230E780
       description: |-
         Appears to calculate damage from a fixed-damage effect.
@@ -1059,8 +1068,8 @@ overlay29:
         others: ?
     - name: CalcDamageFixedNoCategory
       address:
-        NA: 0x230D3A8
         EU: 0x230DE1C
+        NA: 0x230D3A8
         JP: 0x230E8E4
       description: |-
         A wrapper around CalcDamageFixed with the move category set to none.
@@ -1073,8 +1082,8 @@ overlay29:
         others: ?
     - name: CalcDamageFixedWrapper
       address:
-        NA: 0x230D3F4
         EU: 0x230DE68
+        NA: 0x230D3F4
         JP: 0x230E930
       description: |-
         A wrapper around CalcDamageFixed.
@@ -1088,8 +1097,8 @@ overlay29:
         others: ?
     - name: ResetDamageCalcScratchSpace
       address:
-        NA: 0x230D528
         EU: 0x230DF9C
+        NA: 0x230D528
         JP: 0x230EA64
       description: |-
         CalcDamage seems to use scratch space of some kind, which this function zeroes.
@@ -1097,8 +1106,8 @@ overlay29:
         No params.
     - name: TrySpawnMonsterAndTickSpawnCounter
       address:
-        NA: 0x230E6BC
         EU: 0x230F130
+        NA: 0x230E6BC
         JP: 0x230FBF8
       description: |-
         First ticks up the spawn counter, and if it's equal or greater than the spawn cooldown, it will try to spawn an enemy if the number of enemies is below the spawn cap.
@@ -1108,8 +1117,8 @@ overlay29:
         No params.
     - name: AuraBowIsActive
       address:
-        NA: 0x230F6C8
         EU: 0x231013C
+        NA: 0x230F6C8
         JP: 0x2310C04
       description: |-
         Checks if a monster is holding an aura bow that isn't disabled by Klutz.
@@ -1118,8 +1127,8 @@ overlay29:
         return: bool
     - name: ExclusiveItemOffenseBoost
       address:
-        NA: 0x230F778
         EU: 0x23101EC
+        NA: 0x230F778
       description: |-
         Gets the exclusive item boost for attack/special attack for a monster
         
@@ -1128,8 +1137,8 @@ overlay29:
         return: boost
     - name: ExclusiveItemDefenseBoost
       address:
-        NA: 0x230F788
         EU: 0x23101FC
+        NA: 0x230F788
       description: |-
         Gets the exclusive item boost for defense/special defense for a monster
         
@@ -1138,8 +1147,8 @@ overlay29:
         return: boost
     - name: TickNoSlipCap
       address:
-        NA: 0x230FB90
         EU: 0x2310604
+        NA: 0x230FB90
         JP: 0x23110CC
       description: |-
         Checks if the entity is a team member and holds the No-Slip Cap, and if so attempts to make one item in the bag sticky.
@@ -1147,8 +1156,8 @@ overlay29:
         r0: pointer to entity
     - name: TickStatusAndHealthRegen
       address:
-        NA: 0x2311088
         EU: 0x2311AE8
+        NA: 0x2311088
         JP: 0x23125B0
       description: |-
         Applies the natural HP regen effect by taking modifiers into account (Poison Heal, Heal Ribbon, weather-related regen). Then it ticks down counters for volatile status effects, and heals them if the counter reached zero.
@@ -1156,8 +1165,8 @@ overlay29:
         r0: pointer to entity
     - name: InflictSleepStatusSingle
       address:
-        NA: 0x2311824
         EU: 0x2312284
+        NA: 0x2311824
         JP: 0x2312D3C
       description: |-
         This is called by TryInflictSleepStatus.
@@ -1166,8 +1175,8 @@ overlay29:
         r1: number of turns
     - name: TryInflictSleepStatus
       address:
-        NA: 0x23118D8
         EU: 0x2312338
+        NA: 0x23118D8
         JP: 0x2312DF0
       description: |-
         Inflicts the Sleep status condition on a target monster if possible.
@@ -1178,8 +1187,8 @@ overlay29:
         r3: flag to log a message on failure
     - name: TryInflictNightmareStatus
       address:
-        NA: 0x2311C4C
         EU: 0x23126AC
+        NA: 0x2311C4C
         JP: 0x2313158
       description: |-
         Inflicts the Nightmare status condition on a target monster if possible.
@@ -1189,8 +1198,8 @@ overlay29:
         r2: number of turns
     - name: TryInflictNappingStatus
       address:
-        NA: 0x2311D60
         EU: 0x23127C0
+        NA: 0x2311D60
         JP: 0x2313268
       description: |-
         Inflicts the Napping status condition (from Rest) on a target monster if possible.
@@ -1200,8 +1209,8 @@ overlay29:
         r2: number of turns
     - name: TryInflictYawningStatus
       address:
-        NA: 0x2311E70
         EU: 0x23128D0
+        NA: 0x2311E70
         JP: 0x2313374
       description: |-
         Inflicts the Yawning status condition on a target monster if possible.
@@ -1211,8 +1220,8 @@ overlay29:
         r2: number of turns
     - name: TryInflictSleeplessStatus
       address:
-        NA: 0x2311F80
         EU: 0x23129E0
+        NA: 0x2311F80
         JP: 0x2313484
       description: |-
         Inflicts the Sleepless status condition on a target monster if possible.
@@ -1221,8 +1230,8 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictPausedStatus
       address:
-        NA: 0x231206C
         EU: 0x2312ACC
+        NA: 0x231206C
         JP: 0x2313570
       description: |-
         Inflicts the Paused status condition on a target monster if possible.
@@ -1236,8 +1245,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictInfatuatedStatus
       address:
-        NA: 0x23121AC
         EU: 0x2312C0C
+        NA: 0x23121AC
         JP: 0x23136B0
       description: |-
         Inflicts the Infatuated status condition on a target monster if possible.
@@ -1249,8 +1258,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictBurnStatus
       address:
-        NA: 0x2312338
         EU: 0x2312D98
+        NA: 0x2312338
         JP: 0x2313838
       description: |-
         Inflicts the Burn status condition on a target monster if possible.
@@ -1263,8 +1272,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictBurnStatusWholeTeam
       address:
-        NA: 0x2312618
         EU: 0x2313078
+        NA: 0x2312618
         JP: 0x2313B14
       description: |-
         Inflicts the Burn status condition on all team members if possible.
@@ -1272,8 +1281,8 @@ overlay29:
         No params.
     - name: TryInflictPoisonedStatus
       address:
-        NA: 0x2312664
         EU: 0x23130C4
+        NA: 0x2312664
       description: |-
         Inflicts the Poisoned status condition on a target monster if possible.
         
@@ -1284,8 +1293,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictBadlyPoisonedStatus
       address:
-        NA: 0x231293C
         EU: 0x231339C
+        NA: 0x231293C
       description: |-
         Inflicts the Badly Poisoned status condition on a target monster if possible.
         
@@ -1296,8 +1305,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictFrozenStatus
       address:
-        NA: 0x2312BF8
         EU: 0x2313658
+        NA: 0x2312BF8
         JP: 0x23140EC
       description: |-
         Inflicts the Frozen status condition on a target monster if possible.
@@ -1307,8 +1316,8 @@ overlay29:
         r2: flag to log a message on failure
     - name: TryInflictConstrictionStatus
       address:
-        NA: 0x2312E20
         EU: 0x2313880
+        NA: 0x2312E20
         JP: 0x2314310
       description: |-
         Inflicts the Constriction status condition on a target monster if possible.
@@ -1319,8 +1328,8 @@ overlay29:
         r3: flag to log a message on failure
     - name: TryInflictShadowHoldStatus
       address:
-        NA: 0x2312F78
         EU: 0x23139D8
+        NA: 0x2312F78
         JP: 0x2314468
       description: |-
         Inflicts the Shadow Hold (AKA Immobilized) status condition on a target monster if possible.
@@ -1330,8 +1339,8 @@ overlay29:
         r2: flag to log a message on failure
     - name: TryInflictIngrainStatus
       address:
-        NA: 0x2313130
         EU: 0x2313B90
+        NA: 0x2313130
         JP: 0x231461C
       description: |-
         Inflicts the Ingrain status condition on a target monster if possible.
@@ -1340,8 +1349,8 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictWrappedStatus
       address:
-        NA: 0x23131F4
         EU: 0x2313C54
+        NA: 0x23131F4
         JP: 0x23146E0
       description: |-
         Inflicts the Wrapped status condition on a target monster if possible.
@@ -1352,8 +1361,8 @@ overlay29:
         r1: target entity pointer
     - name: FreeOtherWrappedMonsters
       address:
-        NA: 0x23133F0
         EU: 0x2313E50
+        NA: 0x23133F0
         JP: 0x23148DC
       description: |-
         Frees from the wrap status all monsters which are wrapped by/around the monster passed as parameter.
@@ -1361,8 +1370,8 @@ overlay29:
         r0: pointer to entity
     - name: TryInflictPetrifiedStatus
       address:
-        NA: 0x231346C
         EU: 0x2313ECC
+        NA: 0x231346C
         JP: 0x2314958
       description: |-
         Inflicts the Petrified status condition on a target monster if possible.
@@ -1371,8 +1380,8 @@ overlay29:
         r1: target entity pointer
     - name: LowerOffensiveStat
       address:
-        NA: 0x23135FC
         EU: 0x231405C
+        NA: 0x23135FC
       description: |-
         Lowers the specified offensive stat on the target monster.
         
@@ -1384,8 +1393,8 @@ overlay29:
         stack[1]: ?
     - name: LowerDefensiveStat
       address:
-        NA: 0x2313814
         EU: 0x2314274
+        NA: 0x2313814
         JP: 0x2314CFC
       description: |-
         Lowers the specified defensive stat on the target monster.
@@ -1398,8 +1407,8 @@ overlay29:
         stack[1]: ?
     - name: BoostOffensiveStat
       address:
-        NA: 0x231399C
         EU: 0x23143FC
+        NA: 0x231399C
         JP: 0x2314E84
       description: |-
         Boosts the specified offensive stat on the target monster.
@@ -1410,8 +1419,8 @@ overlay29:
         r3: number of stages
     - name: BoostDefensiveStat
       address:
-        NA: 0x2313B08
         EU: 0x2314568
+        NA: 0x2313B08
         JP: 0x2314FF0
       description: |-
         Boosts the specified defensive stat on the target monster.
@@ -1422,8 +1431,8 @@ overlay29:
         r3: number of stages
     - name: ApplyOffensiveStatMultiplier
       address:
-        NA: 0x2313D40
         EU: 0x23147A0
+        NA: 0x2313D40
       description: |-
         Applies a multiplier to the specified offensive stat on the target monster.
         
@@ -1436,8 +1445,8 @@ overlay29:
         stack[0]: ?
     - name: ApplyDefensiveStatMultiplier
       address:
-        NA: 0x2313F64
         EU: 0x23149C4
+        NA: 0x2313F64
         JP: 0x2315444
       description: |-
         Applies a multiplier to the specified defensive stat on the target monster.
@@ -1451,8 +1460,8 @@ overlay29:
         stack[0]: ?
     - name: BoostHitChanceStat
       address:
-        NA: 0x23140E4
         EU: 0x2314B44
+        NA: 0x23140E4
         JP: 0x23155C4
       description: |-
         Boosts the specified hit chance stat (accuracy or evasion) on the target monster.
@@ -1462,8 +1471,8 @@ overlay29:
         r2: stat index
     - name: LowerHitChanceStat
       address:
-        NA: 0x231422C
         EU: 0x2314C8C
+        NA: 0x231422C
         JP: 0x231570C
       description: |-
         Lowers the specified hit chance stat (accuracy or evasion) on the target monster.
@@ -1474,8 +1483,8 @@ overlay29:
         r3: ?
     - name: TryInflictCringeStatus
       address:
-        NA: 0x23143E8
         EU: 0x2314E48
+        NA: 0x23143E8
         JP: 0x23158C4
       description: |-
         Inflicts the Cringe status condition on a target monster if possible.
@@ -1487,8 +1496,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictParalysisStatus
       address:
-        NA: 0x2314544
         EU: 0x2314FA4
+        NA: 0x2314544
         JP: 0x2315A1C
       description: |-
         Inflicts the Paralysis status condition on a target monster if possible.
@@ -1500,8 +1509,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: BoostSpeed
       address:
-        NA: 0x2314810
         EU: 0x2315270
+        NA: 0x2314810
         JP: 0x2315CE4
       description: |-
         Boosts the speed of the target monster.
@@ -1515,8 +1524,8 @@ overlay29:
         stack[0]: flag to log a message on failure
     - name: BoostSpeedOneStage
       address:
-        NA: 0x231493C
         EU: 0x231539C
+        NA: 0x231493C
         JP: 0x2315E10
       description: |-
         A wrapper around BoostSpeed with the number of stages set to 1.
@@ -1527,8 +1536,8 @@ overlay29:
         r3: flag to log a message on failure
     - name: LowerSpeed
       address:
-        NA: 0x2314954
         EU: 0x23153B4
+        NA: 0x2314954
         JP: 0x2315E28
       description: |-
         Lowers the speed of the target monster.
@@ -1539,8 +1548,8 @@ overlay29:
         r3: flag to log a message on failure
     - name: TrySealMove
       address:
-        NA: 0x2314ABC
         EU: 0x231551C
+        NA: 0x2314ABC
         JP: 0x2315F90
       description: |-
         Seals one of the target monster's moves. The move to be sealed is randomly selected.
@@ -1551,8 +1560,8 @@ overlay29:
         return: Whether or not a move was sealed
     - name: BoostOrLowerSpeed
       address:
-        NA: 0x2314C2C
         EU: 0x231568C
+        NA: 0x2314C2C
         JP: 0x2316100
       description: |-
         Randomly boosts or lowers the speed of the target monster by one stage with equal probability.
@@ -1561,8 +1570,8 @@ overlay29:
         r1: target entity pointer
     - name: ResetHitChanceStat
       address:
-        NA: 0x2314C8C
         EU: 0x23156EC
+        NA: 0x2314C8C
         JP: 0x2316160
       description: |-
         Resets the specified hit chance stat (accuracy or evasion) back to normal on the target monster.
@@ -1573,8 +1582,8 @@ overlay29:
         r3: ?
     - name: TryActivateQuickFeet
       address:
-        NA: 0x2314E1C
         EU: 0x231587C
+        NA: 0x2314E1C
         JP: 0x23162F0
       description: |-
         Activate the Quick Feet ability on the defender, if the monster has it and it's active.
@@ -1584,8 +1593,8 @@ overlay29:
         return: bool, whether or not the ability was activated
     - name: TryInflictConfusedStatus
       address:
-        NA: 0x2314F38
         EU: 0x2315998
+        NA: 0x2314F38
         JP: 0x2316410
       description: |-
         Inflicts the Confused status condition on a target monster if possible.
@@ -1597,8 +1606,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictCoweringStatus
       address:
-        NA: 0x231516C
         EU: 0x2315CCC
+        NA: 0x231516C
         JP: 0x2316744
       description: |-
         Inflicts the Cowering status condition on a target monster if possible.
@@ -1610,8 +1619,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryIncreaseHp
       address:
-        NA: 0x23152E4
         EU: 0x2315D44
+        NA: 0x23152E4
         JP: 0x23167BC
       description: |-
         Restore HP and possibly boost max HP of the target monster if possible.
@@ -1624,8 +1633,8 @@ overlay29:
         return: Success flag
     - name: TryInflictLeechSeedStatus
       address:
-        NA: 0x23157EC
         EU: 0x231624C
+        NA: 0x23157EC
         JP: 0x2316CC4
       description: |-
         Inflicts the Leech Seed status condition on a target monster if possible.
@@ -1637,8 +1646,8 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictDestinyBond
       address:
-        NA: 0x2315A50
         EU: 0x23164B0
+        NA: 0x2315A50
         JP: 0x2316F28
       description: |-
         Inflicts the Destiny Bond status condition on a target monster if possible.
@@ -1647,8 +1656,8 @@ overlay29:
         r1: target entity pointer
     - name: IsBlinded
       address:
-        NA: 0x23177E4
         EU: 0x2318244
+        NA: 0x23177E4
         JP: 0x2318CB4
       description: |-
         Returns true if the monster has the blinded status (see statuses::blinded), or if it is not the leader and is holding Y-Ray Specs.
@@ -1658,8 +1667,8 @@ overlay29:
         return: bool
     - name: RestoreMovePP
       address:
-        NA: 0x2317C20
         EU: 0x2318680
+        NA: 0x2317C20
         JP: 0x23190F0
       description: |-
         Restores the PP of all the target's moves by the specified amount.
@@ -1670,8 +1679,8 @@ overlay29:
         r3: flag to suppress message logging
     - name: SetReflectDamageCountdownTo4
       address:
-        NA: 0x23183C0
         EU: 0x2318E20
+        NA: 0x23183C0
         JP: 0x2319890
       description: |-
         Sets the monster's reflect damage countdown to a global value (0x4).
@@ -1679,8 +1688,8 @@ overlay29:
         r0: pointer to entity
     - name: HasConditionalGroundImmunity
       address:
-        NA: 0x2318A4C
         EU: 0x23194AC
+        NA: 0x2318A4C
         JP: 0x2319F1C
       description: |-
         Checks if a monster is currently immune to Ground-type moves for reasons other than typing and ability.
@@ -1691,8 +1700,8 @@ overlay29:
         return: bool
     - name: Conversion2IsActive
       address:
-        NA: 0x2319814
         EU: 0x231A274
+        NA: 0x2319814
         JP: 0x231ACE4
       description: |-
         Checks if the monster is under the effect of Conversion 2 (its type was changed).
@@ -1703,8 +1712,8 @@ overlay29:
         return: int
     - name: IsTargetInRange
       address:
-        NA: 0x231A694
         EU: 0x231B0F4
+        NA: 0x231A694
         JP: 0x231BB64
       description: |-
         Returns true if the target is within range of the user's move, false otherwise.
@@ -1718,8 +1727,8 @@ overlay29:
         r3: move range (in number of tiles)
     - name: GetEntityMoveTargetAndRange
       address:
-        NA: 0x231ACAC
         EU: 0x231B70C
+        NA: 0x231ACAC
         JP: 0x231C17C
       description: |-
         Gets the move target-and-range field when used by a given entity. See struct move_target_and_range in the C headers.
@@ -1730,8 +1739,8 @@ overlay29:
         return: move target and range
     - name: ApplyItemEffect
       address:
-        NA: 0x231B68C
         EU: 0x231C0EC
+        NA: 0x231B68C
         JP: 0x231CB58
       description: |-
         Seems to apply an item's effect via a giant switch statement?
@@ -1742,8 +1751,8 @@ overlay29:
         others: ?
     - name: ViolentSeedBoost
       address:
-        NA: 0x231CE1C
         EU: 0x231D884
+        NA: 0x231CE1C
       description: |-
         Applies the Violent Seed boost to an entity.
         
@@ -1751,8 +1760,8 @@ overlay29:
         r1: defender pointer
     - name: ApplyGummiBoosts
       address:
-        NA: 0x231D0C0
         EU: 0x231DB28
+        NA: 0x231D0C0
         JP: 0x231E588
       description: |-
         Applies the IQ and possible stat boosts from eating a Gummi to the target monster.
@@ -1763,8 +1772,8 @@ overlay29:
         r3: Stat boost amount, if a random stat boost occurs
     - name: GetMaxPpWrapper
       address:
-        NA: 0x231E9F0
         EU: 0x231F458
+        NA: 0x231E9F0
         JP: 0x231FE9C
       description: |-
         Gets the maximum PP for a given move. A wrapper around the function in the ARM 9 binary.
@@ -1773,8 +1782,8 @@ overlay29:
         return: max PP for the given move, capped at 99
     - name: MoveIsNotPhysical
       address:
-        NA: 0x231EA18
         EU: 0x231F480
+        NA: 0x231EA18
         JP: 0x231FEC4
       description: |-
         Checks if a move isn't a physical move.
@@ -1783,8 +1792,8 @@ overlay29:
         return: bool
     - name: TryPounce
       address:
-        NA: 0x231FC20
         EU: 0x2320688
+        NA: 0x231FC20
         JP: 0x23210CC
       description: |-
         Makes the target monster execute the Pounce action in a given direction if possible.
@@ -1796,8 +1805,8 @@ overlay29:
         r2: direction ID
     - name: TryBlowAway
       address:
-        NA: 0x231FDE0
         EU: 0x2320848
+        NA: 0x231FDE0
         JP: 0x232128C
       description: |-
         Blows away the target monster in a given direction if possible.
@@ -1807,8 +1816,8 @@ overlay29:
         r2: direction ID
     - name: TryWarp
       address:
-        NA: 0x2320D08
         EU: 0x2321770
+        NA: 0x2320D08
         JP: 0x23221B4
       description: |-
         Makes the target monster warp if possible.
@@ -1819,8 +1828,8 @@ overlay29:
         r3: position (if warp type is position-based)
     - name: MoveHitCheck
       address:
-        NA: 0x2323C48
         EU: 0x23246B0
+        NA: 0x2323C48
       description: |-
         Determines if a move used hits or misses the target. It gets called twice per target, once with r3 = false and a second time with r3 = true.
         
@@ -1831,8 +1840,8 @@ overlay29:
         returns: True if the move hits, false if it misses.
     - name: DungeonRandOutcomeUserTargetInteraction
       address:
-        NA: 0x2324934
         EU: 0x232539C
+        NA: 0x2324934
         JP: 0x2325DC4
       description: |-
         Like DungeonRandOutcome, but specifically for user-target interactions.
@@ -1844,8 +1853,8 @@ overlay29:
         r2: base success percentage (100*p). 0 is treated specially and guarantees success.
     - name: DungeonRandOutcomeUserAction
       address:
-        NA: 0x2324A20
         EU: 0x2325488
+        NA: 0x2324A20
         JP: 0x2325EAC
       description: |-
         Like DungeonRandOutcome, but specifically for user actions.
@@ -1856,8 +1865,8 @@ overlay29:
         r1: base success percentage (100*p). 0 is treated specially and guarantees success.
     - name: UpdateMovePp
       address:
-        NA: 0x2324D8C
         EU: 0x23257F4
+        NA: 0x2324D8C
         JP: 0x2326218
       description: |-
         Updates the PP of any moves that were used by a monster, if PP should be consumed.
@@ -1866,8 +1875,8 @@ overlay29:
         r1: flag for whether or not PP should be consumed
     - name: LowerSshort
       address:
-        NA: 0x2324E64
         EU: 0x23258CC
+        NA: 0x2324E64
         JP: 0x23262F0
       description: |-
         Gets the lower 2 bytes of a 4-byte number and interprets it as a signed short.
@@ -1876,8 +1885,8 @@ overlay29:
         return: (short)x
     - name: DealDamageWithRecoil
       address:
-        NA: 0x2327F34
         EU: 0x23289A0
+        NA: 0x2327F34
         JP: 0x23293BC
       description: |-
         Deals damage from a move or item used by an attacking monster on a defending monster, and also deals recoil damage to the attacker.
@@ -1889,8 +1898,8 @@ overlay29:
         return: bool, whether or not damage was dealt
     - name: ExecuteMoveEffect
       address:
-        NA: 0x232E864
         EU: 0x232F2A4
+        NA: 0x232E864
       description: |-
         Handles the effects that happen after a move is used. Includes a loop that is run for each target, mutiple ability checks and the giant switch statement that executes the effect of the move used given its ID.
         
@@ -1901,8 +1910,8 @@ overlay29:
         stack[0]: ?
     - name: DealDamage
       address:
-        NA: 0x2332B20
         EU: 0x2333560
+        NA: 0x2332B20
         JP: 0x2333F10
       description: |-
         Deals damage from a move or item used by an attacking monster on a defending monster.
@@ -1915,8 +1924,8 @@ overlay29:
         return: amount of damage dealt
     - name: CalcDamageProjectile
       address:
-        NA: 0x2332C4C
         EU: 0x233368C
+        NA: 0x2332C4C
         JP: 0x233403C
       description: |-
         Appears to calculate damage from a variable-damage projectile.
@@ -1928,8 +1937,8 @@ overlay29:
         others: ?
     - name: CalcDamageFinal
       address:
-        NA: 0x2332D6C
         EU: 0x23337AC
+        NA: 0x2332D6C
       description: |-
         Last function called by DealDamage to determine the final damage dealt by the move. The result of this call is the return value of DealDamage. 
         
@@ -1940,8 +1949,8 @@ overlay29:
         stack[0]: Pointer to some struct. The first byte contains the ID of the move used.
     - name: GetApparentWeather
       address:
-        NA: 0x2334D08
         EU: 0x2335748
+        NA: 0x2334D08
         JP: 0x23360F4
       description: |-
         Get the weather, as experienced by a specific entity.
@@ -1950,8 +1959,8 @@ overlay29:
         return: weather ID
     - name: TryWeatherFormChange
       address:
-        NA: 0x2335170
         EU: 0x2335BB0
+        NA: 0x2335170
         JP: 0x233655C
       description: |-
         Tries to change a monster into one of its weather-related alternative forms. Applies to Castform and Cherrim, and checks for their unique abilities.
@@ -1959,8 +1968,8 @@ overlay29:
         r0: pointer to entity
     - name: GetTile
       address:
-        NA: 0x23360FC
         EU: 0x2336CCC
+        NA: 0x23360FC
         JP: 0x23374CC
       description: |-
         Get the tile at some position. If the coordinates are out of bounds, returns a default tile.
@@ -1970,8 +1979,8 @@ overlay29:
         return: tile pointer
     - name: GetTileSafe
       address:
-        NA: 0x2336164
         EU: 0x2336D34
+        NA: 0x2336164
         JP: 0x2337534
       description: |-
         Get the tile at some position. If the coordinates are out of bounds, returns a pointer to a copy of the default tile.
@@ -1981,32 +1990,32 @@ overlay29:
         return: tile pointer
     - name: GravityIsActive
       address:
-        NA: 0x2338390
         EU: 0x2338F60
+        NA: 0x2338390
       description: |-
         Checks if gravity is active on the floor.
         
         return: bool
     - name: IsSecretBazaar
       address:
-        NA: 0x23385C4
         EU: 0x2339194
+        NA: 0x23385C4
       description: |-
         Checks if the current floor is the Secret Bazaar.
         
         return: bool
     - name: IsSecretRoom
       address:
-        NA: 0x233865C
         EU: 0x233922C
+        NA: 0x233865C
       description: |-
         Checks if the current floor is the Secret Room fixed floor (from hidden stairs).
         
         return: bool
     - name: IsSecretFloor
       address:
-        NA: 0x2338684
         EU: 0x2339254
+        NA: 0x2338684
         JP: 0x2339A48
       description: |-
         Checks if the current floor is a secret bazaar or a secret room.
@@ -2014,32 +2023,39 @@ overlay29:
         returns: bool
     - name: GetMinimapData
       address:
-        NA: 0x2339118
         EU: 0x2339CE8
+        NA: 0x2339118
       description: |-
         Returns a pointer to the minimap_display_data struct in the dungeon struct.
         
         return: minimap_display_data*
     - name: SetMinimapDataE447
       address:
-        NA: 0x233A218
         EU: 0x233ADE8
+        NA: 0x233A218
       description: |-
         Sets minimap_display_data::field_0xE447 to the specified value
         
         r0: Value to set the field to
+    - name: GetMinimapDataE447
+      address:
+        EU: 0x233AE00
+      description: |-
+        Exclusive to the EU ROM. Returns minimap_display_data::field_0xE447.
+        
+        return: minimap_display_data::field_0xE447
     - name: SetMinimapDataE448
       address:
-        NA: 0x233A230
         EU: 0x233AE14
+        NA: 0x233A230
       description: |-
         Sets minimap_display_data::field_0xE448 to the specified value
         
         r0: Value to set the field to
     - name: LoadFixedRoomDataVeneer
       address:
-        NA: 0x233A624
         EU: 0x233B208
+        NA: 0x233A624
       description: |-
         Likely a linker-generated veneer for LoadFixedRoomData.
         
@@ -2048,8 +2064,8 @@ overlay29:
         No params.
     - name: IsNormalFloor
       address:
-        NA: 0x233A654
         EU: 0x233B238
+        NA: 0x233A654
         JP: 0x233BA18
       description: |-
         Checks if the current floor is a normal layout.
@@ -2065,8 +2081,8 @@ overlay29:
         return: bool
     - name: GenerateFloor
       address:
-        NA: 0x233A6D8
         EU: 0x233B2BC
+        NA: 0x233A6D8
         JP: 0x233BA9C
       description: |-
         This is the master function that generates the dungeon floor.
@@ -2078,8 +2094,8 @@ overlay29:
         No params.
     - name: GetTileTerrain
       address:
-        NA: 0x233AE78
         EU: 0x233BA5C
+        NA: 0x233AE78
         JP: 0x233C23C
       description: |-
         Gets the terrain type of a tile.
@@ -2088,8 +2104,8 @@ overlay29:
         return: terrain ID
     - name: DungeonRand100
       address:
-        NA: 0x233AE84
         EU: 0x233BA68
+        NA: 0x233AE84
         JP: 0x233C248
       description: |-
         Compute a pseudorandom integer on the interval [0, 100) using the dungeon PRNG.
@@ -2097,8 +2113,8 @@ overlay29:
         return: pseudorandom integer
     - name: FlagHallwayJunctions
       address:
-        NA: 0x233AF0C
         EU: 0x233BAF0
+        NA: 0x233AF0C
         JP: 0x233C2D0
       description: |-
         Sets the junction flag (bit 3 of the terrain flags) on any hallway junction tiles in some range [x0, x1), [y0, y1). This leaves tiles within rooms untouched.
@@ -2111,8 +2127,8 @@ overlay29:
         r3: y1
     - name: GenerateStandardFloor
       address:
-        NA: 0x233B028
         EU: 0x233BC0C
+        NA: 0x233B028
         JP: 0x233C3EC
       description: |-
         Generate a standard floor with the given parameters.
@@ -2128,8 +2144,8 @@ overlay29:
         r2: floor properties
     - name: GenerateOuterRingFloor
       address:
-        NA: 0x233B190
         EU: 0x233BD74
+        NA: 0x233B190
         JP: 0x233C554
       description: |-
         Generates a floor layout with a 4x2 grid of rooms, surrounded by an outer ring of hallways.
@@ -2137,8 +2153,8 @@ overlay29:
         r0: floor properties
     - name: GenerateCrossroadsFloor
       address:
-        NA: 0x233B61C
         EU: 0x233C200
+        NA: 0x233B61C
         JP: 0x233C9E0
       description: |-
         Generates a floor layout with a mesh of hallways on the interior 3x2 grid, surrounded by a boundary of rooms protruding from the interior like spikes, excluding the corner cells.
@@ -2146,8 +2162,8 @@ overlay29:
         r0: floor properties
     - name: GenerateLineFloor
       address:
-        NA: 0x233BA7C
         EU: 0x233C660
+        NA: 0x233BA7C
         JP: 0x233CE40
       description: |-
         Generates a floor layout with 5 grid cells in a horizontal line.
@@ -2155,8 +2171,8 @@ overlay29:
         r0: floor properties
     - name: GenerateCrossFloor
       address:
-        NA: 0x233BBDC
         EU: 0x233C7C0
+        NA: 0x233BBDC
         JP: 0x233CFA0
       description: |-
         Generates a floor layout with 5 rooms arranged in a cross ("plus sign") formation.
@@ -2164,8 +2180,8 @@ overlay29:
         r0: floor properties
     - name: GenerateBeetleFloor
       address:
-        NA: 0x233BD74
         EU: 0x233C958
+        NA: 0x233BD74
         JP: 0x233D138
       description: |-
         Generates a floor layout in a "beetle" formation, which is created by taking a 3x3 grid of rooms, connecting the rooms within each row, and merging the central column into one big room.
@@ -2173,8 +2189,8 @@ overlay29:
         r0: floor properties
     - name: MergeRoomsVertically
       address:
-        NA: 0x233BF30
         EU: 0x233CB14
+        NA: 0x233BF30
         JP: 0x233D2F4
       description: |-
         Merges two vertically stacked rooms into one larger room.
@@ -2185,8 +2201,8 @@ overlay29:
         r3: grid to update
     - name: GenerateOuterRoomsFloor
       address:
-        NA: 0x233C07C
         EU: 0x233CC60
+        NA: 0x233C07C
         JP: 0x233D440
       description: |-
         Generates a floor layout with a ring of rooms on the grid boundary and nothing in the interior.
@@ -2198,8 +2214,8 @@ overlay29:
         r2: floor properties
     - name: IsNotFullFloorFixedRoom
       address:
-        NA: 0x233C310
         EU: 0x233CEF4
+        NA: 0x233C310
         JP: 0x233D6D4
       description: |-
         Checks if a fixed room ID does not correspond to a fixed, full-floor layout.
@@ -2210,8 +2226,8 @@ overlay29:
         return: bool
     - name: GenerateFixedRoom
       address:
-        NA: 0x233C32C
         EU: 0x233CF10
+        NA: 0x233C32C
       description: |-
         Handles fixed room generation if the floor contains a fixed room.
         
@@ -2220,8 +2236,8 @@ overlay29:
         return: bool
     - name: GenerateOneRoomMonsterHouseFloor
       address:
-        NA: 0x233C774
         EU: 0x233D358
+        NA: 0x233C774
         JP: 0x233DB34
       description: |-
         Generates a floor layout with just a large, one-room Monster House.
@@ -2231,8 +2247,8 @@ overlay29:
         No params.
     - name: GenerateTwoRoomsWithMonsterHouseFloor
       address:
-        NA: 0x233C844
         EU: 0x233D428
+        NA: 0x233C844
         JP: 0x233DC04
       description: |-
         Generate a floor layout with two rooms (left and right), one of which is a Monster House.
@@ -2240,8 +2256,8 @@ overlay29:
         No params.
     - name: GenerateExtraHallways
       address:
-        NA: 0x233C9E8
         EU: 0x233D5CC
+        NA: 0x233C9E8
         JP: 0x233DDA8
       description: |-
         Generate extra hallways on the floor via a series of random walks.
@@ -2254,8 +2270,8 @@ overlay29:
         r3: number of extra hallways to generate
     - name: GetGridPositions
       address:
-        NA: 0x233CF84
         EU: 0x233DB68
+        NA: 0x233CF84
         JP: 0x233E344
       description: |-
         Get the grid cell positions for a given set of floor grid dimensions.
@@ -2266,8 +2282,8 @@ overlay29:
         r3: grid size y
     - name: InitDungeonGrid
       address:
-        NA: 0x233D004
         EU: 0x233DBE8
+        NA: 0x233D004
         JP: 0x233E3C4
       description: |-
         Initialize a dungeon grid with defaults.
@@ -2281,8 +2297,8 @@ overlay29:
         r2: grid size y
     - name: AssignRooms
       address:
-        NA: 0x233D104
         EU: 0x233DCE8
+        NA: 0x233D104
         JP: 0x233E4C4
       description: |-
         Randomly selects a subset of grid cells to become rooms.
@@ -2297,8 +2313,8 @@ overlay29:
         r3: number of rooms; if positive, a random value between [n_rooms, n_rooms+2] will be used. If negative, |n_rooms| will be used exactly.
     - name: CreateRoomsAndAnchors
       address:
-        NA: 0x233D318
         EU: 0x233DEFC
+        NA: 0x233D318
         JP: 0x233E6D8
       description: |-
         Creates rooms and hallway anchors in each grid cell as designated by AssignRooms.
@@ -2313,8 +2329,8 @@ overlay29:
         stack[1]: room bitflags; only uses bit 2 (mask: 0b100), which enables room imperfections
     - name: GenerateSecondaryStructures
       address:
-        NA: 0x233D674
         EU: 0x233E258
+        NA: 0x233D674
         JP: 0x233EA34
       description: |-
         Try to generate secondary structures in flagged rooms.
@@ -2334,8 +2350,8 @@ overlay29:
         r2: grid size y
     - name: AssignGridCellConnections
       address:
-        NA: 0x233E05C
         EU: 0x233EC40
+        NA: 0x233E05C
         JP: 0x233F41C
       description: |-
         Randomly assigns connections between adjacent grid cells.
@@ -2352,8 +2368,8 @@ overlay29:
         stack[1]: floor properties
     - name: CreateGridCellConnections
       address:
-        NA: 0x233E43C
         EU: 0x233F020
+        NA: 0x233E43C
         JP: 0x233F7FC
       description: |-
         Create grid cell connections either by creating hallways or merging rooms.
@@ -2370,8 +2386,8 @@ overlay29:
         stack[1]: disable room merging flag
     - name: GenerateRoomImperfections
       address:
-        NA: 0x233ED34
         EU: 0x233F918
+        NA: 0x233ED34
         JP: 0x23400F4
       description: |-
         Attempt to generate room imperfections for each room in the floor layout, if enabled.
@@ -2383,8 +2399,8 @@ overlay29:
         r2: grid size y
     - name: CreateHallway
       address:
-        NA: 0x233F120
         EU: 0x233FD04
+        NA: 0x233F120
         JP: 0x23404E0
       description: |-
         Create a hallway between two points.
@@ -2402,8 +2418,8 @@ overlay29:
         stack[2]: middle y coordinate for kinked vertical hallways
     - name: EnsureConnectedGrid
       address:
-        NA: 0x233F424
         EU: 0x2340008
+        NA: 0x233F424
         JP: 0x23407E4
       description: |-
         Ensure the grid forms a connected graph (all valid cells are reachable) by adding hallways to unreachable grid cells.
@@ -2417,8 +2433,8 @@ overlay29:
         stack[0]: array of the starting y coordinates of each grid row
     - name: SetTerrainObstacleChecked
       address:
-        NA: 0x233F900
         EU: 0x23404E4
+        NA: 0x233F900
         JP: 0x2340CC0
       description: |-
         Set the terrain of a specific tile to be an obstacle (wall or secondary terrain).
@@ -2430,8 +2446,8 @@ overlay29:
         r2: room index
     - name: FinalizeJunctions
       address:
-        NA: 0x233F93C
         EU: 0x2340520
+        NA: 0x233F93C
         JP: 0x2340CFC
       description: |-
         Finalizes junction tiles by setting the junction flag (bit 3 of the terrain flags) and ensuring open terrain.
@@ -2452,8 +2468,8 @@ overlay29:
         No params.
     - name: GenerateKecleonShop
       address:
-        NA: 0x233FBE8
         EU: 0x23407CC
+        NA: 0x233FBE8
         JP: 0x2340FA8
       description: |-
         Possibly generate a Kecleon shop on the floor.
@@ -2466,8 +2482,8 @@ overlay29:
         r3: Kecleon shop spawn chance (percentage from 0-100)
     - name: GenerateMonsterHouse
       address:
-        NA: 0x233FF9C
         EU: 0x2340B80
+        NA: 0x233FF9C
         JP: 0x234135C
       description: |-
         Possibly generate a Monster House on the floor.
@@ -2480,8 +2496,8 @@ overlay29:
         r3: Monster House spawn chance (percentage from 0-100)
     - name: GenerateMazeRoom
       address:
-        NA: 0x2340224
         EU: 0x2340E08
+        NA: 0x2340224
         JP: 0x23415E4
       description: |-
         Possibly generate a maze room on the floor.
@@ -2494,8 +2510,8 @@ overlay29:
         r3: maze room chance (percentage from 0-100)
     - name: GenerateMaze
       address:
-        NA: 0x2340458
         EU: 0x234103C
+        NA: 0x2340458
         JP: 0x2341818
       description: |-
         Generate a maze room within a given grid cell.
@@ -2506,8 +2522,8 @@ overlay29:
         r1: use secondary terrain flag (true for water/lava, false for walls)
     - name: GenerateMazeLine
       address:
-        NA: 0x23406D4
         EU: 0x23412B8
+        NA: 0x23406D4
         JP: 0x2341A94
       description: |-
         Generate a "maze line" from a given starting point, within the given bounds.
@@ -2524,8 +2540,8 @@ overlay29:
         stack[3]: room index
     - name: SetSpawnFlag5
       address:
-        NA: 0x234087C
         EU: 0x2341460
+        NA: 0x234087C
         JP: 0x2341C3C
       description: |-
         Set spawn flag 5 (0b100000 or 0x20) on all tiles in a room.
@@ -2533,8 +2549,8 @@ overlay29:
         r0: grid cell
     - name: IsNextToHallway
       address:
-        NA: 0x23408D0
         EU: 0x23414B4
+        NA: 0x23408D0
         JP: 0x2341C90
       description: |-
         Checks if a tile position is either in a hallway or next to one.
@@ -2544,8 +2560,8 @@ overlay29:
         return: bool
     - name: ResolveInvalidSpawns
       address:
-        NA: 0x2340974
         EU: 0x2341558
+        NA: 0x2340974
         JP: 0x2341D34
       description: |-
         Resolve invalid spawn flags on tiles.
@@ -2555,8 +2571,8 @@ overlay29:
         No params.
     - name: ConvertSecondaryTerrainToChasms
       address:
-        NA: 0x2340A0C
         EU: 0x23415F0
+        NA: 0x2340A0C
         JP: 0x2341DCC
       description: |-
         Converts all secondary terrain tiles (water/lava) to chasms.
@@ -2564,8 +2580,8 @@ overlay29:
         No params.
     - name: EnsureImpassableTilesAreWalls
       address:
-        NA: 0x2340A78
         EU: 0x234165C
+        NA: 0x2340A78
         JP: 0x2341E38
       description: |-
         Ensures all tiles with the impassable flag are walls.
@@ -2573,8 +2589,8 @@ overlay29:
         No params.
     - name: InitializeTile
       address:
-        NA: 0x2340AD4
         EU: 0x23416B8
+        NA: 0x2340AD4
         JP: 0x2341E94
       description: |-
         Initialize a tile struct.
@@ -2582,8 +2598,8 @@ overlay29:
         r0: tile pointer
     - name: ResetFloor
       address:
-        NA: 0x2340B0C
         EU: 0x23416F0
+        NA: 0x2340B0C
         JP: 0x2341ECC
       description: |-
         Resets the floor in preparation for a floor generation attempt.
@@ -2593,8 +2609,8 @@ overlay29:
         No params.
     - name: PosIsOutOfBounds
       address:
-        NA: 0x2340CAC
         EU: 0x2341890
+        NA: 0x2340CAC
         JP: 0x234206C
       description: |-
         Checks if a position (x, y) is out of bounds on the map: !((0 <= x <= 55) && (0 <= y <= 31)).
@@ -2604,8 +2620,8 @@ overlay29:
         return: bool
     - name: ShuffleSpawnPositions
       address:
-        NA: 0x2340CE4
         EU: 0x23418C8
+        NA: 0x2340CE4
         JP: 0x23420A4
       description: |-
         Randomly shuffle an array of spawn positions.
@@ -2614,8 +2630,8 @@ overlay29:
         r1: number of (x, y) pairs in the spawn position array
     - name: SpawnNonEnemies
       address:
-        NA: 0x2340D4C
         EU: 0x2341930
+        NA: 0x2340D4C
         JP: 0x234210C
       description: |-
         Spawn all non-enemy entities, which includes stairs, items, traps, and the player.
@@ -2634,8 +2650,8 @@ overlay29:
         r1: empty Monster House flag. An empty Monster House is one with no items or traps, and only a small number of enemies.
     - name: SpawnEnemies
       address:
-        NA: 0x2341470
         EU: 0x2342054
+        NA: 0x2341470
         JP: 0x2342830
       description: |-
         Spawn all enemies, which includes normal enemies and those in Monster Houses.
@@ -2648,8 +2664,8 @@ overlay29:
         r1: empty Monster House flag. An empty Monster House is one with no items or traps, and only a small number of enemies.
     - name: SetSecondaryTerrainOnWall
       address:
-        NA: 0x234176C
         EU: 0x2342350
+        NA: 0x234176C
         JP: 0x2342B2C
       description: |-
         Set a specific tile to have secondary terrain (water/lava), but only if it's a passable wall.
@@ -2657,8 +2673,8 @@ overlay29:
         r0: tile pointer
     - name: GenerateSecondaryTerrainFormations
       address:
-        NA: 0x23417AC
         EU: 0x2342390
+        NA: 0x23417AC
         JP: 0x2342B6C
       description: |-
         Generate secondary terrain (water/lava) formations.
@@ -2671,8 +2687,8 @@ overlay29:
         r1: floor properties
     - name: StairsAlwaysReachable
       address:
-        NA: 0x2341E6C
         EU: 0x2342A50
+        NA: 0x2341E6C
         JP: 0x234322C
       description: |-
         Checks that the stairs are reachable from every walkable tile on the floor.
@@ -2685,8 +2701,8 @@ overlay29:
         return: bool
     - name: ConvertWallsToChasms
       address:
-        NA: 0x2342548
         EU: 0x234312C
+        NA: 0x2342548
         JP: 0x2343908
       description: |-
         Converts all wall tiles to chasms.
@@ -2694,8 +2710,8 @@ overlay29:
         No params.
     - name: ResetInnerBoundaryTileRows
       address:
-        NA: 0x2342B7C
         EU: 0x2343760
+        NA: 0x2342B7C
         JP: 0x2343F3C
       description: |-
         Reset the inner boundary tile rows (y == 1 and y == 30) to their initial state of all wall tiles, with impassable walls at the edges (x == 0 and x == 55).
@@ -2703,8 +2719,8 @@ overlay29:
         No params.
     - name: SpawnStairs
       address:
-        NA: 0x2342C8C
         EU: 0x2343870
+        NA: 0x2342C8C
         JP: 0x234404C
       description: |-
         Spawn stairs at the given location.
@@ -2718,8 +2734,8 @@ overlay29:
         r2: hidden stairs flag
     - name: LoadFixedRoomData
       address:
-        NA: 0x2343D90
         EU: 0x2344974
+        NA: 0x2343D90
         JP: 0x2345154
       description: |-
         Loads fixed room data from BALANCE/fixed.bin into the buffer pointed to by FIXED_ROOM_DATA_PTR.
@@ -2727,8 +2743,8 @@ overlay29:
         No params.
     - name: IsHiddenStairsFloor
       address:
-        NA: 0x234450C
         EU: 0x23450F0
+        NA: 0x234450C
         JP: 0x23458D0
       description: |-
         Checks if the current floor is either the Secret Bazaar or a Secret Room.
@@ -2736,8 +2752,8 @@ overlay29:
         return: bool
     - name: HasHeldItem
       address:
-        NA: 0x23467E4
         EU: 0x23473D0
+        NA: 0x23467E4
         JP: 0x2347B94
       description: |-
         Checks if a monster has a certain held item.
@@ -2747,16 +2763,16 @@ overlay29:
         return: bool
     - name: IsOutlawOrChallengeRequestFloor
       address:
-        NA: 0x23491C4
         EU: 0x2349DC4
+        NA: 0x23491C4
       description: |-
         Checks if the current floor is an active mission destination of type MISSION_TAKE_ITEM_FROM_OUTLAW, MISSION_ARREST_OUTLAW or MISSION_CHALLENGE_REQUEST.
         
         return: bool
     - name: IsCurrentMissionType
       address:
-        NA: 0x234921C
         EU: 0x2349E1C
+        NA: 0x234921C
         JP: 0x234A544
       description: |-
         Checks if the current floor is an active mission destination of a given type (and any subtype).
@@ -2765,8 +2781,8 @@ overlay29:
         return: bool
     - name: IsCurrentMissionTypeExact
       address:
-        NA: 0x2349250
         EU: 0x2349E50
+        NA: 0x2349250
         JP: 0x234A578
       description: |-
         Checks if the current floor is an active mission destination of a given type and subtype.
@@ -2776,8 +2792,8 @@ overlay29:
         return: bool
     - name: IsOutlawMonsterHouseFloor
       address:
-        NA: 0x234928C
         EU: 0x2349E8C
+        NA: 0x234928C
         JP: 0x234A5B4
       description: |-
         Checks if the current floor is a mission destination for a Monster House outlaw mission.
@@ -2785,8 +2801,8 @@ overlay29:
         return: bool
     - name: IsGoldenChamber
       address:
-        NA: 0x23492B0
         EU: 0x2349EB0
+        NA: 0x23492B0
         JP: 0x234A5D8
       description: |-
         Checks if the current floor is a Golden Chamber floor.
@@ -2794,8 +2810,8 @@ overlay29:
         return: bool
     - name: IsLegendaryChallengeFloor
       address:
-        NA: 0x23492D4
         EU: 0x2349ED4
+        NA: 0x23492D4
         JP: 0x234A5FC
       description: |-
         Checks if the current floor is a boss floor for a Legendary Challenge Letter mission.
@@ -2803,8 +2819,8 @@ overlay29:
         return: bool
     - name: IsJirachiChallengeFloor
       address:
-        NA: 0x2349314
         EU: 0x2349F14
+        NA: 0x2349314
         JP: 0x234A63C
       description: |-
         Checks if the current floor is the boss floor in Star Cave Pit for Jirachi's Challenge Letter mission.
@@ -2812,8 +2828,8 @@ overlay29:
         return: bool
     - name: IsDestinationFloorWithMonster
       address:
-        NA: 0x234934C
         EU: 0x2349F4C
+        NA: 0x234934C
         JP: 0x234A674
       description: |-
         Checks if the current floor is a mission destination floor with a special monster.
@@ -2823,8 +2839,8 @@ overlay29:
         return: bool
     - name: MissionTargetEnemyIsDefeated
       address:
-        NA: 0x2349470
         EU: 0x234A070
+        NA: 0x2349470
         JP: 0x234A798
       description: |-
         Checks if the target enemy of the mission on the current floor has been defeated.
@@ -2832,8 +2848,8 @@ overlay29:
         return: bool
     - name: SetMissionTargetEnemyDefeated
       address:
-        NA: 0x2349490
         EU: 0x234A090
+        NA: 0x2349490
         JP: 0x234A7B8
       description: |-
         Set the flag for whether or not the target enemy of the current mission has been defeated.
@@ -2841,8 +2857,8 @@ overlay29:
         r0: new flag value
     - name: IsDestinationFloorWithFixedRoom
       address:
-        NA: 0x23494A4
         EU: 0x234A0A4
+        NA: 0x23494A4
         JP: 0x234A7CC
       description: |-
         Checks if the current floor is a mission destination floor with a fixed room.
@@ -2852,8 +2868,8 @@ overlay29:
         return: bool
     - name: GetItemToRetrieve
       address:
-        NA: 0x23494CC
         EU: 0x234A0CC
+        NA: 0x23494CC
         JP: 0x234A7F4
       description: |-
         Get the ID of the item that needs to be retrieve on the current floor for a mission, if one exists.
@@ -2861,8 +2877,8 @@ overlay29:
         return: item ID
     - name: GetItemToDeliver
       address:
-        NA: 0x23494F0
         EU: 0x234A0F0
+        NA: 0x23494F0
         JP: 0x234A818
       description: |-
         Get the ID of the item that needs to be delivered to a mission client on the current floor, if one exists.
@@ -2870,8 +2886,8 @@ overlay29:
         return: item ID
     - name: GetSpecialTargetItem
       address:
-        NA: 0x234951C
         EU: 0x234A11C
+        NA: 0x234951C
         JP: 0x234A844
       description: |-
         Get the ID of the special target item for a Sealed Chamber or Treasure Memo mission on the current floor.
@@ -2879,8 +2895,8 @@ overlay29:
         return: item ID
     - name: IsDestinationFloorWithItem
       address:
-        NA: 0x2349564
         EU: 0x234A164
+        NA: 0x2349564
         JP: 0x234A88C
       description: |-
         Checks if the current floor is a mission destination floor with a special item.
@@ -2890,8 +2906,8 @@ overlay29:
         return: bool
     - name: IsDestinationFloorWithHiddenOutlaw
       address:
-        NA: 0x23495C4
         EU: 0x234A1C4
+        NA: 0x23495C4
         JP: 0x234A8EC
       description: |-
         Checks if the current floor is a mission destination floor with a "hidden outlaw" that behaves like a normal enemy.
@@ -2899,8 +2915,8 @@ overlay29:
         return: bool
     - name: IsDestinationFloorWithFleeingOutlaw
       address:
-        NA: 0x23495E8
         EU: 0x234A1E8
+        NA: 0x23495E8
         JP: 0x234A910
       description: |-
         Checks if the current floor is a mission destination floor with a "fleeing outlaw" that runs away.
@@ -2908,8 +2924,8 @@ overlay29:
         return: bool
     - name: GetMissionTargetEnemy
       address:
-        NA: 0x2349620
         EU: 0x234A220
+        NA: 0x2349620
         JP: 0x234A948
       description: |-
         Get the monster ID of the target enemy to be defeated on the current floor for a mission, if one exists.
@@ -2917,8 +2933,8 @@ overlay29:
         return: monster ID
     - name: GetMissionEnemyMinionGroup
       address:
-        NA: 0x2349638
         EU: 0x234A238
+        NA: 0x2349638
         JP: 0x234A960
       description: |-
         Get the monster ID of the specified minion group on the current floor for a mission, if it exists.
@@ -2929,8 +2945,8 @@ overlay29:
         return: monster ID
     - name: FloorHasMissionMonster
       address:
-        NA: 0x2349748
         EU: 0x234A348
+        NA: 0x2349748
         JP: 0x234AA70
       description: |-
         Checks if a given floor is a mission destination with a special monster, either a target to rescue or an enemy to defeat.
@@ -2949,8 +2965,8 @@ overlay29:
         return: bool
     - name: LogMessageByIdWithPopupCheckUser
       address:
-        NA: 0x234B2A4
         EU: 0x234BEA4
+        NA: 0x234B2A4
         JP: 0x234C514
       description: |-
         Logs a message in the message log alongside a message popup, if the user hasn't fainted.
@@ -2959,8 +2975,8 @@ overlay29:
         r1: message ID
     - name: LogMessageWithPopupCheckUser
       address:
-        NA: 0x234B2E4
         EU: 0x234BEE4
+        NA: 0x234B2E4
         JP: 0x234C554
       description: |-
         Logs a message in the message log alongside a message popup, if the user hasn't fainted.
@@ -2969,8 +2985,8 @@ overlay29:
         r1: message string
     - name: LogMessageByIdQuiet
       address:
-        NA: 0x234B31C
         EU: 0x234BF1C
+        NA: 0x234B31C
         JP: 0x234C58C
       description: |-
         Logs a message in the message log (but without a message popup).
@@ -2979,8 +2995,8 @@ overlay29:
         r1: message ID
     - name: LogMessageQuiet
       address:
-        NA: 0x234B340
         EU: 0x234BF40
+        NA: 0x234B340
         JP: 0x234C5B0
       description: |-
         Logs a message in the message log (but without a message popup).
@@ -2989,8 +3005,8 @@ overlay29:
         r1: message string
     - name: LogMessageByIdWithPopupCheckUserTarget
       address:
-        NA: 0x234B350
         EU: 0x234BF50
+        NA: 0x234B350
         JP: 0x234C5C0
       description: |-
         Logs a message in the message log alongside a message popup, if some user check passes and the target hasn't fainted.
@@ -3000,8 +3016,8 @@ overlay29:
         r2: message ID
     - name: LogMessageWithPopupCheckUserTarget
       address:
-        NA: 0x234B3A4
         EU: 0x234BFA4
+        NA: 0x234B3A4
         JP: 0x234C614
       description: |-
         Logs a message in the message log alongside a message popup, if some user check passes and the target hasn't fainted.
@@ -3011,8 +3027,8 @@ overlay29:
         r2: message string
     - name: LogMessageByIdQuietCheckUserTarget
       address:
-        NA: 0x234B3F0
         EU: 0x234BFF0
+        NA: 0x234B3F0
         JP: 0x234C660
       description: |-
         Logs a message in the message log (but without a message popup), if some user check passes and the target hasn't fainted.
@@ -3022,8 +3038,8 @@ overlay29:
         r2: message ID
     - name: LogMessageByIdWithPopupCheckUserUnknown
       address:
-        NA: 0x234B444
         EU: 0x234C044
+        NA: 0x234B444
         JP: 0x234C6B4
       description: |-
         Logs a message in the message log alongside a message popup, if the user hasn't fainted and some other unknown check.
@@ -3033,8 +3049,8 @@ overlay29:
         r2: message ID
     - name: LogMessageByIdWithPopup
       address:
-        NA: 0x234B498
         EU: 0x234C098
+        NA: 0x234B498
         JP: 0x234C708
       description: |-
         Logs a message in the message log alongside a message popup.
@@ -3043,8 +3059,8 @@ overlay29:
         r1: message ID
     - name: LogMessageWithPopup
       address:
-        NA: 0x234B4BC
         EU: 0x234C0BC
+        NA: 0x234B4BC
       description: |-
         Logs a message in the message log alongside a message popup.
         
@@ -3052,8 +3068,8 @@ overlay29:
         r1: message string
     - name: LogMessage
       address:
-        NA: 0x234B508
         EU: 0x234C108
+        NA: 0x234B508
         JP: 0x234C778
       description: |-
         Logs a message in the message log.
@@ -3063,8 +3079,8 @@ overlay29:
         r2: bool, whether or not to present a message popup
     - name: LogMessageById
       address:
-        NA: 0x234B714
         EU: 0x234C314
+        NA: 0x234B714
         JP: 0x234C984
       description: |-
         Logs a message in the message log.
@@ -3074,8 +3090,8 @@ overlay29:
         r2: bool, whether or not to present a message popup
     - name: OpenMessageLog
       address:
-        NA: 0x234BB5C
         EU: 0x234C75C
+        NA: 0x234BB5C
       description: |-
         Opens the message log window.
         
@@ -3083,8 +3099,8 @@ overlay29:
         r1: ?
     - name: RunDungeonMode
       address:
-        NA: 0x234BF28
         EU: 0x234CB28
+        NA: 0x234BF28
         JP: 0x234D18C
       description: |-
         This appears to be the top-level function for running dungeon mode.
@@ -3094,8 +3110,8 @@ overlay29:
         This function is presumably in charge of allocating the dungeon struct, setting it up, launching the dungeon engine, etc.
     - name: DisplayDungeonTip
       address:
-        NA: 0x234CEF0
         EU: 0x234DAF0
+        NA: 0x234CEF0
       description: |-
         Checks if a given dungeon tip should be displayed at the start of a floor and if so, displays it. Called up to 4 times at the start of each new floor, with a different r0 parameter each time.
         
@@ -3103,8 +3119,8 @@ overlay29:
         r1: True to log the message in the message log
     - name: SetBothScreensWindowColorToDefault
       address:
-        NA: 0x234CF60
         EU: 0x234DB60
+        NA: 0x234CF60
         JP: 0x234E1C4
       description: |-
         This changes the palettes of windows in both screens to an appropiate value depending on the playthrough
@@ -3113,8 +3129,8 @@ overlay29:
         No params
     - name: DisplayMessage
       address:
-        NA: 0x234D258
         EU: 0x234DE58
+        NA: 0x234D258
       description: |-
         Displays a message in a dialogue box that optionally waits for player input before closing.
         
@@ -3123,13 +3139,13 @@ overlay29:
         r2: True to wait for player input before closing the dialogue box, false to close it automatically once all the characters get printed.
     - name: DisplayMessage2
       address:
-        NA: 0x234D2AC
         EU: 0x234DEAC
+        NA: 0x234D2AC
       description: Very similar to DisplayMessage
     - name: DisplayMessageInternal
       address:
-        NA: 0x234D590
         EU: 0x234E190
+        NA: 0x234D590
       description: |-
         Called by DisplayMessage. Seems to be the function that handles the display of the dialogue box. It won't return until all the characters have been written and after the player manually closes the dialogue box (if the corresponding parameter was set).
         
@@ -3139,324 +3155,280 @@ overlay29:
         r3: ?
         stack[0]: ?
         stack[1]: ?
-    - name: EuFaintCheck
-      address:
-        EU: 0x22F88E8
-      description: |-
-        This function is exclusive to the EU ROM. Seems to perform a check to see if the monster who just fainted was a team member who should cause the minimap to be updated (or something like that, maybe related to the Map Surveyor IQ skill) and if it passes, updates the minimap.
-        The function ends by calling another 2 functions. In US ROMs, calls to EUFaintCheck are replaced by calls to those two functions. This seems to indicate that this function fixes some edge case glitch that can happen when a team member faints.
-        
-        r0: False if the fainted entity was a team member
-        r1: True to set an unknown byte in the RAM to 1
-    - name: GetMinimapDataE447
-      address:
-        EU: 0x233AE00
-      description: |-
-        Exclusive to the EU ROM. Returns minimap_display_data::field_0xE447.
-        
-        return: minimap_display_data::field_0xE447
   data:
     - name: DUNGEON_STRUCT_SIZE
       address:
-        NA:
-          - 0x22DEA78
-          - 0x22DEAAC
         EU:
           - 0x22DF3B8
           - 0x22DF3EC
+        NA:
+          - 0x22DEA78
+          - 0x22DEAAC
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Size of the dungeon struct (0x2CB14)
     - name: OFFSET_OF_DUNGEON_FLOOR_PROPERTIES
       address:
-        NA:
-          - 0x22E79F8
-          - 0x233AE68
         EU:
           - 0x22E83A8
           - 0x233BA4C
+        NA:
+          - 0x22E79F8
+          - 0x233AE68
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Offset of the floor properties field in the dungeon struct (0x286B2)
     - name: SPAWN_RAND_MAX
       address:
-        NA: 0x22E7E50
         EU: 0x22E8800
+        NA: 0x22E7E50
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Equal to 10,000 (0x2710). Used as parameter for DungeonRandInt to generate the random number which determines the entity to spawn."
     - name: DUNGEON_PRNG_LCG_MULTIPLIER
       address:
-        NA:
-          - 0x22EA9C8
-          - 0x22EAA8C
         EU:
           - 0x22EB378
           - 0x22EB43C
+        NA:
+          - 0x22EA9C8
+          - 0x22EAA8C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "The multiplier shared by all of the dungeon PRNG's LCGs, 1566083941 (0x5D588B65)."
     - name: DUNGEON_PRNG_LCG_INCREMENT_SECONDARY
       address:
-        NA: 0x22EAA94
         EU: 0x22EB444
+        NA: 0x22EAA94
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "The increment for the dungeon PRNG's secondary LCGs, 2531011 (0x269EC3). This happens to be the same increment that the Microsoft Visual C++ runtime library uses in its implementation of the rand() function."
     - name: KECLEON_FEMALE_ID
       address:
-        NA: 0x22F7404
         EU: 0x22F7DBC
+        NA: 0x22F7404
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "0x3D7 (983). Used when spawning Kecleon on an even numbered floor."
     - name: KECLEON_MALE_ID
       address:
-        NA: 0x22F7408
         EU: 0x22F7DC0
+        NA: 0x22F7408
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "0x17F (383). Used when spawning Kecleon on an odd numbered floor."
     - name: MSG_ID_SLOW_START
       address:
-        NA: 0x22F92D0
         EU: 0x22F9CDC
+        NA: 0x22F92D0
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: ID of the message printed when a monster has the ability Slow Start at the beginning of the floor.
     - name: EXPERIENCE_POINT_GAIN_CAP
       address:
-        NA: 0x23026C8
         EU: 0x23030F4
+        NA: 0x23026C8
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: A cap on the experience that can be given to a monster in one call to AddExpSpecial
     - name: JUDGMENT_MOVE_ID
       address:
-        NA: 0x230C458
         EU: 0x230CECC
+        NA: 0x230C458
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Move ID for Judgment (0x1D3)
         
         type: enum move_id
     - name: REGULAR_ATTACK_MOVE_ID
       address:
-        NA: 0x230C45C
         EU: 0x230CED0
+        NA: 0x230C45C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Move ID for the regular attack (0x163)
         
         type: enum move_id
     - name: DEOXYS_ATTACK_ID
       address:
-        NA: 0x230C460
         EU: 0x230CED4
+        NA: 0x230C460
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Monster ID for Deoxys in Attack Forme (0x1A3)
         
         type: enum monster_id
     - name: DEOXYS_SPEED_ID
       address:
-        NA: 0x230C464
         EU: 0x230CED8
+        NA: 0x230C464
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Monster ID for Deoxys in Speed Forme (0x1A5)
         
         type: enum monster_id
     - name: GIRATINA_ALTERED_ID
       address:
-        NA: 0x230C468
         EU: 0x230CEDC
+        NA: 0x230C468
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Monster ID for Giratina in Altered Forme (0x211)
         
         type: enum monster_id
     - name: PUNISHMENT_MOVE_ID
       address:
-        NA: 0x230C46C
         EU: 0x230CEE0
+        NA: 0x230C46C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Move ID for Punishment (0x1BD)
         
         type: enum move_id
     - name: OFFENSE_STAT_MAX
       address:
-        NA: 0x230C49C
         EU: 0x230CF10
+        NA: 0x230C49C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Cap on an attacker's modified offense (attack or special attack) stat after boosts. Used during damage calculation."
     - name: PROJECTILE_MOVE_ID
       address:
-        NA:
-          - 0x230D07C
-          - 0x231C700
         EU:
           - 0x230DAF0
           - 0x231D160
+        NA:
+          - 0x230D07C
+          - 0x231C700
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         The move ID of the special "projectile" move (0x195)
         
         type: enum move_id
     - name: BELLY_LOST_PER_TURN
       address:
-        NA: 0x2310A70
         EU: 0x23114D0
+        NA: 0x2310A70
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         The base value by which belly is decreased every turn.
         
         Its raw value is 0x199A, which encodes a binary fixed-point number (16 fraction bits) with value (0x199A * 2^-16), and is the closest approximation to 0.1 representable in this number format.
     - name: MAX_HP_CAP
       address:
-        NA:
-          - 0x2311814
-          - 0x2318454
         EU:
           - 0x2312274
           - 0x2318EB4
+        NA:
+          - 0x2311814
+          - 0x2318454
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: The maximum amount of HP a monster can have (999).
     - name: MOVE_TARGET_AND_RANGE_SPECIAL_USER_HEALING
       address:
-        NA: 0x231AD34
         EU: 0x231B794
+        NA: 0x231AD34
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         The move target and range code for special healing moves that target just the user (0x273).
         
         type: struct move_target_and_range (+ padding)
     - name: PLAIN_SEED_VALUE
       address:
-        NA: 0x231C748
         EU: 0x231D1A8
+        NA: 0x231C748
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Some value related to the Plain Seed (0xBE9).
     - name: MAX_ELIXIR_PP_RESTORATION
       address:
-        NA: 0x231C74C
         EU: 0x231D1AC
+        NA: 0x231C74C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: The amount of PP restored per move by ingesting a Max Elixir (0x3E7).
     - name: SLIP_SEED_VALUE
       address:
-        NA: 0x231CBAC
         EU: 0x231D614
+        NA: 0x231CBAC
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Some value related to the Slip Seed (0xC75).
     - name: CASTFORM_NORMAL_FORM_MALE_ID
       address:
-        NA: 0x2335438
         EU: 0x2335E78
+        NA: 0x2335438
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Castform's male normal form ID (0x17B)"
     - name: CASTFORM_NORMAL_FORM_FEMALE_ID
       address:
-        NA: 0x233543C
         EU: 0x2335E7C
+        NA: 0x233543C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Castform's female normal form ID (0x3D3)"
     - name: CHERRIM_SUNSHINE_FORM_MALE_ID
       address:
-        NA: 0x2335440
         EU: 0x2335E80
+        NA: 0x2335440
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Cherrim's male sunshine form ID (0x1CD)"
     - name: CHERRIM_OVERCAST_FORM_FEMALE_ID
       address:
-        NA: 0x2335444
         EU: 0x2335E84
+        NA: 0x2335444
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Cherrim's female overcast form ID (0x424)"
     - name: CHERRIM_SUNSHINE_FORM_FEMALE_ID
       address:
-        NA: 0x2335448
         EU: 0x2335E88
+        NA: 0x2335448
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Cherrim's female sunshine form ID (0x425)"
     - name: FLOOR_GENERATION_STATUS_PTR
       address:
-        NA:
-          - 0x233AE6C
-          - 0x233AF08
-          - 0x233B18C
-          - 0x233B618
-          - 0x233BA78
-          - 0x233BBD8
-          - 0x233BD70
-          - 0x233BF2C
-          - 0x233C30C
-          - 0x233C76C
-          - 0x233CF80
-          - 0x233D100
-          - 0x233D310
-          - 0x233D670
-          - 0x233E058
-          - 0x233FF90
-          - 0x234021C
-          - 0x23406D0
-          - 0x234145C
-          - 0x2341764
-          - 0x2342178
-          - 0x2342510
-          - 0x23427E0
-          - 0x2342B74
-          - 0x2342C64
-          - 0x2342D98
-          - 0x2342F28
         EU:
           - 0x233BA50
           - 0x233BAEC
@@ -3485,48 +3457,55 @@ overlay29:
           - 0x2343848
           - 0x234397C
           - 0x2343B0C
+        NA:
+          - 0x233AE6C
+          - 0x233AF08
+          - 0x233B18C
+          - 0x233B618
+          - 0x233BA78
+          - 0x233BBD8
+          - 0x233BD70
+          - 0x233BF2C
+          - 0x233C30C
+          - 0x233C76C
+          - 0x233CF80
+          - 0x233D100
+          - 0x233D310
+          - 0x233D670
+          - 0x233E058
+          - 0x233FF90
+          - 0x234021C
+          - 0x23406D0
+          - 0x234145C
+          - 0x2341764
+          - 0x2342178
+          - 0x2342510
+          - 0x23427E0
+          - 0x2342B74
+          - 0x2342C64
+          - 0x2342D98
+          - 0x2342F28
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Pointer to the global FLOOR_GENERATION_STATUS
         
         type: struct floor_generation_status*
     - name: OFFSET_OF_DUNGEON_N_NORMAL_ITEM_SPAWNS
       address:
-        NA:
-          - 0x233AE74
-          - 0x2341464
         EU:
           - 0x233BA58
           - 0x2342048
+        NA:
+          - 0x233AE74
+          - 0x2341464
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Offset of the (number of base items + 1) field on the dungeon struct (0x12AFA)
     - name: DUNGEON_GRID_COLUMN_BYTES
       address:
-        NA:
-          - 0x233B614
-          - 0x233BA74
-          - 0x233BD6C
-          - 0x233BF28
-          - 0x233C308
-          - 0x233C770
-          - 0x233C9E4
-          - 0x233CF78
-          - 0x233D0FC
-          - 0x233D314
-          - 0x233D66C
-          - 0x233E054
-          - 0x233E438
-          - 0x233ED30
-          - 0x233F114
-          - 0x233F8FC
-          - 0x233FF94
-          - 0x2340220
-          - 0x2340454
-          - 0x23424CC
         EU:
           - 0x233C1F8
           - 0x233C658
@@ -3548,37 +3527,58 @@ overlay29:
           - 0x2340E04
           - 0x2341038
           - 0x23430B0
+        NA:
+          - 0x233B614
+          - 0x233BA74
+          - 0x233BD6C
+          - 0x233BF28
+          - 0x233C308
+          - 0x233C770
+          - 0x233C9E4
+          - 0x233CF78
+          - 0x233D0FC
+          - 0x233D314
+          - 0x233D66C
+          - 0x233E054
+          - 0x233E438
+          - 0x233ED30
+          - 0x233F114
+          - 0x233F8FC
+          - 0x233FF94
+          - 0x2340220
+          - 0x2340454
+          - 0x23424CC
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "The number of bytes in one column of the dungeon grid cell array, 450, which corresponds to a column of 15 grid cells."
     - name: DEFAULT_MAX_POSITION
       address:
-        NA: 0x233FF98
         EU: 0x2340B7C
+        NA: 0x233FF98
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: A large number (9999) to use as a default position for keeping track of min/max position values
     - name: OFFSET_OF_DUNGEON_GUARANTEED_ITEM_ID
       address:
-        NA:
-          - 0x2341460
-          - 0x2344E80
         EU:
           - 0x2342044
           - 0x2345A64
+        NA:
+          - 0x2341460
+          - 0x2344E80
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Offset of the guaranteed item ID field in the dungeon struct (0x2C9E8)
     - name: FIXED_ROOM_TILE_SPAWN_TABLE
       address:
-        NA: 0x234FDD0
         EU: 0x23509DC
+        NA: 0x234FDD0
       length:
-        NA: 0x2C
         EU: 0x2C
+        NA: 0x2C
       description: |-
         Table of tiles that can spawn in fixed rooms, pointed into by the FIXED_ROOM_TILE_SPAWN_TABLE.
         
@@ -3587,11 +3587,11 @@ overlay29:
         type: struct fixed_room_tile_spawn_entry[11]
     - name: FIXED_ROOM_REVISIT_OVERRIDES
       address:
-        NA: 0x234FE14
         EU: 0x2350A20
+        NA: 0x234FE14
       length:
-        NA: 0x100
         EU: 0x100
+        NA: 0x100
       description: |-
         Table of fixed room IDs, which if nonzero, overrides the normal fixed room ID for a floor (which is used to index the table) if the dungeon has already been cleared previously.
         
@@ -3600,11 +3600,11 @@ overlay29:
         type: struct fixed_room_id_8[256]
     - name: FIXED_ROOM_MONSTER_SPAWN_TABLE
       address:
-        NA: 0x234FF14
         EU: 0x2350B20
+        NA: 0x234FF14
       length:
-        NA: 0x1E0
         EU: 0x1E0
+        NA: 0x1E0
       description: |-
         Table of monsters that can spawn in fixed rooms, pointed into by the FIXED_ROOM_ENTITY_SPAWN_TABLE.
         
@@ -3613,11 +3613,11 @@ overlay29:
         type: struct fixed_room_monster_spawn_entry[120]
     - name: FIXED_ROOM_ITEM_SPAWN_TABLE
       address:
-        NA: 0x23500F4
         EU: 0x2350D00
+        NA: 0x23500F4
       length:
-        NA: 0x1F8
         EU: 0x1F8
+        NA: 0x1F8
       description: |-
         Table of items that can spawn in fixed rooms, pointed into by the FIXED_ROOM_ENTITY_SPAWN_TABLE.
         
@@ -3626,11 +3626,11 @@ overlay29:
         type: struct fixed_room_item_spawn_entry[63]
     - name: FIXED_ROOM_ENTITY_SPAWN_TABLE
       address:
-        NA: 0x23502EC
         EU: 0x2350EF8
+        NA: 0x23502EC
       length:
-        NA: 0xC9C
         EU: 0xC9C
+        NA: 0xC9C
       description: |-
         Table of entities (items, monsters, tiles) that can spawn in fixed rooms, which is indexed into by the main data structure for each fixed room.
         
@@ -3639,65 +3639,65 @@ overlay29:
         type: struct fixed_room_entity_spawn_entry[269]
     - name: DIRECTIONS_XY
       address:
-        NA: 0x235171C
         EU: 0x2352328
+        NA: 0x235171C
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
       description: |-
         An array mapping each direction index to its x and y displacements.
         
         Directions start with 0=down and proceed counterclockwise (see enum direction_id). Displacements for x and y are interleaved and encoded as 2-byte signed integers. For example, the first two integers are [0, 1], which correspond to the x and y displacements for the "down" direction (positive y means down).
     - name: FRACTIONAL_TURN_SEQUENCE
       address:
-        NA: 0x2352284
         EU: 0x2352EC2
+        NA: 0x2352284
       length:
-        NA: 0xFA
         EU: 0xFA
+        NA: 0xFA
       description: |-
         Read by certain functions that are called by RunFractionalTurn to see if they should be executed.
         
         Array is accessed via a pointer added to some multiple of fractional_turn, so that if the resulting memory location is zero, the function returns.
     - name: BELLY_DRAIN_IN_WALLS_INT
       address:
-        NA: 0x2352768
         EU: 0x2353374
+        NA: 0x2352768
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The additional amount by which belly is decreased every turn when inside walls (integer part)
     - name: BELLY_DRAIN_IN_WALLS_THOUSANDTHS
       address:
-        NA: 0x235276A
         EU: 0x2353376
+        NA: 0x235276A
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: The additional amount by which belly is decreased every turn when inside walls (fractional thousandths)
     - name: SPATK_STAT_IDX
       address:
-        NA: 0x2352AE8
         EU: 0x23536F4
+        NA: 0x2352AE8
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "The index (1) of the special attack entry in internal stat structs, such as the stat modifier array for a monster."
     - name: ATK_STAT_IDX
       address:
-        NA: 0x2352AEC
         EU: 0x23536F8
+        NA: 0x2352AEC
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "The index (0) of the attack entry in internal stat structs, such as the stat modifier array for a monster."
     - name: CORNER_CARDINAL_NEIGHBOR_IS_OPEN
       address:
-        NA: 0x2353010
         EU: 0x2353C24
+        NA: 0x2353010
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
       description: |-
         An array mapping each (corner index, neighbor direction index) to whether or not that neighbor is expected to be open floor.
         
@@ -3708,11 +3708,11 @@ overlay29:
         This array is used by the dungeon generation algorithm when generating room imperfections. See GenerateRoomImperfections.
     - name: DUNGEON_PTR
       address:
-        NA: 0x2353538
         EU: 0x2354138
+        NA: 0x2353538
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         [Runtime] Pointer to the dungeon struct in dungeon mode.
         
@@ -3721,11 +3721,11 @@ overlay29:
         type: struct dungeon*
     - name: DUNGEON_PTR_MASTER
       address:
-        NA: 0x235353C
         EU: 0x235413C
+        NA: 0x235353C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         [Runtime] Pointer to the dungeon struct in dungeon mode.
         
@@ -3734,22 +3734,22 @@ overlay29:
         type: struct dungeon*
     - name: LEADER_PTR
       address:
-        NA: 0x235355C
         EU: 0x235415C
+        NA: 0x235355C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         [Runtime] Pointer to the current leader of the team.
         
         type: struct entity*
     - name: DUNGEON_PRNG_STATE
       address:
-        NA: 0x2353570
         EU: 0x2354170
+        NA: 0x2353570
       length:
-        NA: 0x14
         EU: 0x14
+        NA: 0x14
       description: |-
         [Runtime] The global PRNG state for dungeon mode, not including the current values in the secondary sequences.
         
@@ -3758,54 +3758,54 @@ overlay29:
         type: struct prng_state
     - name: DUNGEON_PRNG_STATE_SECONDARY_VALUES
       address:
-        NA: 0x2353584
         EU: 0x2354184
+        NA: 0x2353584
       length:
-        NA: 0x14
         EU: 0x14
+        NA: 0x14
       description: |-
         [Runtime] An array of 5 integers corresponding to the last value generated for each secondary LCG sequence.
         
         Based on the assembly, this appears to be its own global array, separate from DUNGEON_PRNG_STATE.
     - name: EXCL_ITEM_EFFECTS_WEATHER_ATK_SPEED_BOOST
       address:
-        NA: 0x23535B0
         EU: 0x23541B0
+        NA: 0x23535B0
       length:
-        NA: 0x8
         EU: 0x8
+        NA: 0x8
       description: Array of IDs for exclusive item effects that increase attack speed with certain weather conditions.
     - name: EXCL_ITEM_EFFECTS_WEATHER_MOVE_SPEED_BOOST
       address:
-        NA: 0x23535B8
         EU: 0x23541B8
+        NA: 0x23535B8
       length:
-        NA: 0x8
         EU: 0x8
+        NA: 0x8
       description: Array of IDs for exclusive item effects that increase movement speed with certain weather conditions.
     - name: EXCL_ITEM_EFFECTS_WEATHER_NO_STATUS
       address:
-        NA: 0x23535C0
         EU: 0x23541C0
+        NA: 0x23535C0
       length:
-        NA: 0x8
         EU: 0x8
+        NA: 0x8
       description: Array of IDs for exclusive item effects that grant status immunity with certain weather conditions.
     - name: EXCL_ITEM_EFFECTS_EVASION_BOOST
       address:
-        NA: 0x2353710
         EU: 0x2354310
+        NA: 0x2353710
       length:
-        NA: 0x8
         EU: 0x8
+        NA: 0x8
       description: Array of IDs for exclusive item effects that grant an evasion boost with certain weather conditions.
     - name: DEFAULT_TILE
       address:
-        NA: 0x2353724
         EU: 0x235433C
+        NA: 0x2353724
       length:
-        NA: 0x14
         EU: 0x14
+        NA: 0x14
       description: |-
         The default tile struct.
         
@@ -3814,9 +3814,9 @@ overlay29:
         type: struct tile
     - name: FIXED_ROOM_DATA_PTR
       address:
-        NA: 0x2353794
         EU: 0x23543AC
+        NA: 0x2353794
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "[Runtime] Pointer to decoded fixed room data loaded from the BALANCE/fixed.bin file."

--- a/symbols/overlay30.yml
+++ b/symbols/overlay30.yml
@@ -1,15 +1,15 @@
 overlay30:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2382820
     EU: 0x2383420
+    NA: 0x2382820
     JP: 0x2383AA0
   length:
-    NA: 0x38A0
     EU: 0x38A0
+    NA: 0x38A0
     JP: 0x3880
   description: Controls quicksaving in dungeons.
   functions: []

--- a/symbols/overlay31.yml
+++ b/symbols/overlay31.yml
@@ -1,65 +1,65 @@
 overlay31:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2382820
     EU: 0x2383420
+    NA: 0x2382820
     JP: 0x2383AA0
   length:
-    NA: 0x7A80
     EU: 0x7AA0
+    NA: 0x7A80
     JP: 0x7AC0
   description: Controls the dungeon menu (during dungeon mode).
   functions: []
   data:
     - name: DUNGEON_MAIN_MENU
       address:
-        NA: 0x2389DD4
         EU: 0x238A9F8
+        NA: 0x2389DD4
       length:
-        NA: 0x40
         EU: 0x40
+        NA: 0x40
     - name: DUNGEON_SUBMENU_1
       address:
-        NA: 0x2389E70
         EU: 0x238AA94
+        NA: 0x2389E70
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: DUNGEON_SUBMENU_2
       address:
-        NA: 0x2389E90
         EU: 0x238AAB4
+        NA: 0x2389E90
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: DUNGEON_SUBMENU_3
       address:
-        NA: 0x2389EB0
         EU: 0x238AAD4
+        NA: 0x2389EB0
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: DUNGEON_SUBMENU_4
       address:
-        NA: 0x2389ED0
         EU: 0x238AAF4
+        NA: 0x2389ED0
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
     - name: DUNGEON_SUBMENU_5
       address:
-        NA: 0x238A11C
         EU: 0x238AD40
+        NA: 0x238A11C
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: DUNGEON_SUBMENU_6
       address:
-        NA: 0x238A1A0
         EU: 0x238ADC4
+        NA: 0x238A1A0
       length:
-        NA: 0x48
         EU: 0x48
+        NA: 0x48

--- a/symbols/overlay32.yml
+++ b/symbols/overlay32.yml
@@ -1,15 +1,15 @@
 overlay32:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2382820
     EU: 0x2383420
+    NA: 0x2382820
     JP: 0x2383AA0
   length:
-    NA: 0x20
     EU: 0x20
+    NA: 0x20
     JP: 0x20
   description: Unused; all zeroes.
   functions: []

--- a/symbols/overlay33.yml
+++ b/symbols/overlay33.yml
@@ -1,15 +1,15 @@
 overlay33:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2382820
     EU: 0x2383420
+    NA: 0x2382820
     JP: 0x2383AA0
   length:
-    NA: 0x20
     EU: 0x20
+    NA: 0x20
     JP: 0x20
   description: Unused; all zeroes.
   functions: []

--- a/symbols/overlay34.yml
+++ b/symbols/overlay34.yml
@@ -1,15 +1,15 @@
 overlay34:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22DC240
     EU: 0x22DCB80
+    NA: 0x22DC240
     JP: 0x22DD8E0
   length:
-    NA: 0xE60
     EU: 0xDC0
+    NA: 0xE60
     JP: 0xDC0
   description: |-
     Related to launching the game.
@@ -19,15 +19,15 @@ overlay34:
   data:
     - name: UNKNOWN_MENU_CONFIRM
       address:
-        NA: 0x22DD024
         EU: 0x22DD8CC
+        NA: 0x22DD024
       length:
-        NA: 0x18
         EU: 0x18
+        NA: 0x18
     - name: DUNGEON_DEBUG_MENU
       address:
-        NA: 0x22DD04C
         EU: 0x22DD8F4
+        NA: 0x22DD04C
       length:
-        NA: 0x28
         EU: 0x28
+        NA: 0x28

--- a/symbols/overlay35.yml
+++ b/symbols/overlay35.yml
@@ -1,15 +1,15 @@
 overlay35:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x22BCA80
     EU: 0x22BD3C0
+    NA: 0x22BCA80
     JP: 0x22BE220
   length:
-    NA: 0x20
     EU: 0x20
+    NA: 0x20
     JP: 0x20
   description: Unused; all zeroes.
   functions: []

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -1,15 +1,15 @@
 ram:
   versions:
-    - NA
     - EU
+    - NA
     - JP
   address:
-    NA: 0x2000000
     EU: 0x2000000
+    NA: 0x2000000
     JP: 0x2000000
   length:
-    NA: 0x400000
     EU: 0x400000
+    NA: 0x400000
     JP: 0x400000
   description: |-
     Main memory.
@@ -20,22 +20,22 @@ ram:
   data:
     - name: DUNGEON_COLORMAP_PTR
       address:
-        NA: 0x21B9CF4
         EU: 0x21BA634
+        NA: 0x21B9CF4
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: |-
         Pointer to a colormap used to render colors in a dungeon.
         
         The colormap is a list of 4-byte RGB colors of the form {R, G, B, padding}, which the game indexes into when rendering colors. Some weather conditions modify the colormap, which is how the color scheme changes when it's, e.g., raining.
     - name: DUNGEON_STRUCT
       address:
-        NA: 0x21B9D34
         EU: 0x21BA674
+        NA: 0x21B9D34
       length:
-        NA: 0x2CB14
         EU: 0x2CB14
+        NA: 0x2CB14
       description: |-
         The dungeon context struct used for tons of stuff in dungeon mode. See struct dungeon in the C headers.
         
@@ -44,11 +44,11 @@ ram:
         type: struct dungeon
     - name: MOVE_DATA_TABLE
       address:
-        NA: 0x22113CC
         EU: 0x2211D0C
+        NA: 0x22113CC
       length:
-        NA: 0x38C6
         EU: 0x38C6
+        NA: 0x38C6
       description: |-
         The move data table loaded directly from /BALANCE/waza_p.bin. See struct move_data_table in the C headers.
         
@@ -57,23 +57,23 @@ ram:
         type: struct move_data_table
     - name: FRAMES_SINCE_LAUNCH
       address:
-        NA:
-          - 0x22A354C
-          - 0x22A359C
         EU:
           - 0x22A3E8C
           - 0x22A3EDC
+        NA:
+          - 0x22A354C
+          - 0x22A359C
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Starts at 0 when the game is first launched, and continuously ticks up once per frame while the game is running."
     - name: BAG_ITEMS
       address:
-        NA: 0x22A3824
         EU: 0x22A4164
+        NA: 0x22A3824
       length:
-        NA: 0x12C
         EU: 0x12C
+        NA: 0x12C
       description: |-
         Array of item structs within the player's bag.
         
@@ -82,19 +82,19 @@ ram:
         type: struct item[50]
     - name: BAG_ITEMS_PTR
       address:
-        NA: 0x22A3BA8
         EU: 0x22A44E8
+        NA: 0x22A3BA8
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Pointer to BAG_ITEMS.
     - name: STORAGE_ITEMS
       address:
-        NA: 0x22A3BAE
         EU: 0x22A44EE
+        NA: 0x22A3BAE
       length:
-        NA: 0x7D0
         EU: 0x7D0
+        NA: 0x7D0
       description: |-
         Array of item IDs in the player's item storage.
         
@@ -103,103 +103,103 @@ ram:
         type: struct item_id_16[1000]
     - name: STORAGE_ITEM_QUANTITIES
       address:
-        NA: 0x22A437E
         EU: 0x22A4CBE
+        NA: 0x22A437E
       length:
-        NA: 0x7D0
         EU: 0x7D0
+        NA: 0x7D0
       description: |-
         Array of 1000 2-byte (unsigned) quantities corresponding to the item IDs in STORAGE_ITEMS.
         
         If the corresponding item ID is not a stackable item, the entry in this array is unused, and will be 0.
     - name: KECLEON_SHOP_ITEMS_PTR
       address:
-        NA: 0x22A4B50
         EU: 0x22A5490
+        NA: 0x22A4B50
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Pointer to KECLEON_SHOP_ITEMS.
     - name: KECLEON_SHOP_ITEMS
       address:
-        NA: 0x22A4B54
         EU: 0x22A5494
+        NA: 0x22A4B54
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
       description: |-
         Array of up to 8 items in the Kecleon Shop of the form {struct item_id_16 id, uint16_t quantity}.
         
         If there are fewer than 8 items, the array is expected to be null-terminated.
     - name: UNUSED_KECLEON_SHOP_ITEMS
       address:
-        NA: 0x22A4B74
         EU: 0x22A54B4
+        NA: 0x22A4B74
       length:
-        NA: 0x20
         EU: 0x20
+        NA: 0x20
       description: "Seems to be another array like KECLEON_SHOP_ITEMS, but don't actually appear to be used by the Kecleon Shop."
     - name: KECLEON_WARES_ITEMS_PTR
       address:
-        NA: 0x22A4B94
         EU: 0x22A54D4
+        NA: 0x22A4B94
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: Pointer to KECLEON_WARES_ITEMS.
     - name: KECLEON_WARES_ITEMS
       address:
-        NA: 0x22A4B98
         EU: 0x22A54D8
+        NA: 0x22A4B98
       length:
-        NA: 0x10
         EU: 0x10
+        NA: 0x10
       description: |-
         Array of up to 4 items in Kecleon Wares of the form {struct item_id_16 id, uint16_t quantity}.
         
         If there are fewer than 4 items, the array is expected to be null-terminated.
     - name: UNUSED_KECLEON_WARES_ITEMS
       address:
-        NA: 0x22A4BA8
         EU: 0x22A54E8
+        NA: 0x22A4BA8
       length:
-        NA: 0x10
         EU: 0x10
+        NA: 0x10
       description: "Seems to be another array like KECLEON_WARES_ITEMS, but don't actually appear to be used by Kecleon Wares."
     - name: MONEY_CARRIED
       address:
-        NA: 0x22A4BB8
         EU: 0x22A54F8
+        NA: 0x22A4BB8
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: The amount of money the player is currently carrying.
     - name: MONEY_STORED
       address:
-        NA: 0x22A4BC4
         EU: 0x22A5504
+        NA: 0x22A4BC4
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: The amount of money the player currently has stored in the Duskull Bank.
     - name: LAST_NEW_MOVE
       address:
-        NA: 0x22AAE4C
         EU: 0x22AB78C
+        NA: 0x22AAE4C
       length:
-        NA: 0x8
         EU: 0x8
+        NA: 0x8
       description: |-
         Move struct of the last new move introduced when learning a new move. Persists even after the move selection is made in the menu.
         
         type: struct move
     - name: SCRIPT_VARS_VALUES
       address:
-        NA: 0x22AB0AC
         EU: 0x22AB9EC
+        NA: 0x22AB0AC
       length:
-        NA: 0x400
         EU: 0x400
+        NA: 0x400
       description: |-
         The table of game variable values. Its structure is determined by SCRIPT_VARS.
         
@@ -208,19 +208,19 @@ ram:
         type: struct script_var_value_table
     - name: BAG_LEVEL
       address:
-        NA: 0x22AB15C
         EU: 0x22ABA9C
+        NA: 0x22AB15C
       length:
-        NA: 0x1
         EU: 0x1
+        NA: 0x1
       description: "The player's bag level, which determines the bag capacity. This indexes directly into the BAG_CAPACITY_TABLE in the ARM9 binary."
     - name: DEBUG_SPECIAL_EPISODE_NUMBER
       address:
-        NA: 0x22AB4AC
         EU: 0x22ABDEC
+        NA: 0x22AB4AC
       length:
-        NA: 0x1
         EU: 0x1
+        NA: 0x1
       description: |-
         The number of the special episode currently being played.
         
@@ -231,11 +231,11 @@ ram:
         4: In the Future of Darkness
     - name: PENDING_DUNGEON_ID
       address:
-        NA: 0x22AB4FC
         EU: 0x22ABE3C
+        NA: 0x22AB4FC
       length:
-        NA: 0x1
         EU: 0x1
+        NA: 0x1
       description: |-
         The ID of the selected dungeon when setting off from the overworld.
         
@@ -244,35 +244,35 @@ ram:
         type: struct dungeon_id_8
     - name: PENDING_STARTING_FLOOR
       address:
-        NA: 0x22AB4FD
         EU: 0x22ABE3D
+        NA: 0x22AB4FD
       length:
-        NA: 0x1
         EU: 0x1
+        NA: 0x1
       description: The floor number to start from in the dungeon specified by PENDING_DUNGEON_ID.
     - name: PLAY_TIME_SECONDS
       address:
-        NA: 0x22AB694
         EU: 0x22ABFD4
+        NA: 0x22AB694
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "The player's total play time in seconds."
     - name: PLAY_TIME_FRAME_COUNTER
       address:
-        NA: 0x22AB698
         EU: 0x22ABFD8
+        NA: 0x22AB698
       length:
-        NA: 0x1
         EU: 0x1
+        NA: 0x1
       description: "Counts from 0-59 in a loop, with the play time being incremented by 1 second with each rollover."
     - name: TEAM_NAME
       address:
-        NA: 0x22AB918
         EU: 0x22AC258
+        NA: 0x22AB918
       length:
-        NA: 0xC
         EU: 0xC
+        NA: 0xC
       description: |-
         The team name.
         
@@ -281,11 +281,11 @@ ram:
         This is presumably part of a larger struct, together with other nearby data.
     - name: HERO_SPECIES_ID
       address:
-        NA: 0x22ABDE4
         EU: 0x22AC724
+        NA: 0x22ABDE4
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: |-
         The hero's species ID.
         
@@ -294,11 +294,11 @@ ram:
         type: struct monster_id_16
     - name: HERO_NICKNAME
       address:
-        NA: 0x22ABE1A
         EU: 0x22AC75A
+        NA: 0x22ABE1A
       length:
-        NA: 0xA
         EU: 0xA
+        NA: 0xA
       description: |-
         The hero's nickname.
         
@@ -307,11 +307,11 @@ ram:
         This is presumably part of a larger struct, together with other nearby data.
     - name: PARTNER_SPECIES_ID
       address:
-        NA: 0x22ABE28
         EU: 0x22AC768
+        NA: 0x22ABE28
       length:
-        NA: 0x2
         EU: 0x2
+        NA: 0x2
       description: |-
         The partner's species ID.
         
@@ -320,11 +320,11 @@ ram:
         type: struct monster_id_16
     - name: LEADER_IQ_SKILLS
       address:
-        NA: 0x22B5198
         EU: 0x22B5AD8
+        NA: 0x22B5198
       length:
-        NA: 0xC
         EU: 0xC
+        NA: 0xC
       description: |-
         Unlocked IQ skills of the current leader, available for selection from the IQ skills menu.
         
@@ -333,11 +333,11 @@ ram:
         This is presumably part of a larger struct, together with other nearby data.
     - name: LEADER_NICKNAME
       address:
-        NA: 0x22B51AA
         EU: 0x22B5AEA
+        NA: 0x22B51AA
       length:
-        NA: 0xA
         EU: 0xA
+        NA: 0xA
       description: |-
         The current leader's nickname.
         
@@ -346,11 +346,11 @@ ram:
         This is presumably part of a larger struct, together with other nearby data.
     - name: PARTY_MEMBER_2_IQ_SKILLS
       address:
-        NA: 0x22B5200
         EU: 0x22B5B40
+        NA: 0x22B5200
       length:
-        NA: 0xC
         EU: 0xC
+        NA: 0xC
       description: |-
         Unlocked IQ skills of the second party member, available for selection from the IQ skills menu.
         
@@ -359,27 +359,27 @@ ram:
         This is presumably part of a larger struct, together with other nearby data.
     - name: FRAMES_SINCE_LAUNCH_TIMES_THREE
       address:
-        NA: 0x22B99C4
         EU: 0x22BA304
+        NA: 0x22B99C4
       length:
-        NA: 0x4
         EU: 0x4
+        NA: 0x4
       description: "Starts at 0 when the game is first launched, and ticks up by 3 per frame while the game is running."
     - name: TURNING_ON_THE_SPOT_FLAG
       address:
-        NA: 0x237C9A6
         EU: 0x237D5A6
+        NA: 0x237C9A6
       length:
-        NA: 0x1
         EU: 0x1
+        NA: 0x1
       description: "[Runtime] Flag for whether the player is turning on the spot (pressing Y)."
     - name: FLOOR_GENERATION_STATUS
       address:
-        NA: 0x237CFBC
         EU: 0x237DBBC
+        NA: 0x237CFBC
       length:
-        NA: 0x40
         EU: 0x40
+        NA: 0x40
       description: |-
         [Runtime] Status data related to generation of the current floor in a dungeon.
         

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -1,4 +1,4 @@
-arm9:
+ram:
   versions:
     - NA
     - EU


### PR DESCRIPTION
Fixes #49.

The only symbols that are moving relative to others are the EU-exclusive ones. The symbol order is otherwise unchanged.