### PR TITLE
Add subregion support to resymgen

### DIFF
--- a/.github/workflows/check-symbols.yml
+++ b/.github/workflows/check-symbols.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Install resymgen
         uses: ./.github/actions/build-resymgen
       - name: Test
-        run: resymgen check --complete-version-list --explicit-versions --in-bounds-symbols --no-function-overlap --nonempty-maps --unique-symbols --data-names SCREAMING_SNAKE_CASE --function-names PascalCase symbols/*.yml
+        run: resymgen check --complete-version-list --explicit-versions --in-bounds-symbols --no-overlap --nonempty-maps --unique-symbols --data-names SCREAMING_SNAKE_CASE --function-names PascalCase symbols/*.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resymgen"
 description = "Generates symbol tables for reverse engineering applications from a YAML specification"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["UsernameFodder <usernamefodder@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/UsernameFodder/pmdsky-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "Generates symbol tables for reverse engineering applications from
 version = "0.4.0"
 authors = ["UsernameFodder <usernamefodder@gmail.com>"]
 edition = "2018"
+rust-version = "1.58"
 repository = "https://github.com/UsernameFodder/pmdsky-debug"
 license = "GPL-3.0-only"
 readme = "docs/resymgen.md"

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,19 +1,22 @@
 //! Validating the substantive contents of `resymgen` YAML files. Implements the `check` command.
 
+use std::borrow::Borrow;
 use std::cmp;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::fs::File;
 use std::io::{self, Write};
-use std::path::Path;
+use std::iter;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 use syn::{self, Ident};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-use super::data_formats::symgen_yml::bounds;
+use super::data_formats::symgen_yml::bounds::{self, BoundViolation};
 use super::data_formats::symgen_yml::{
-    Block, MaybeVersionDep, OrdString, SymGen, Symbol, Uint, Version, VersionDep,
+    Block, MaybeVersionDep, OrdString, Subregion, SymGen, Symbol, Uint, Version, VersionDep,
 };
 use super::util::MultiFileError;
 
@@ -123,17 +126,20 @@ impl NamingConvention {
 pub enum Check {
     /// All addresses and lengths (for both blocks and symbols) must be explicitly listed by version.
     ExplicitVersions,
-    /// Any version used within a version-dependent address or length must appear in the version
-    /// list of the parent block.
+    /// Any version used within a version-dependent address or length, or within a subregion
+    /// version list, must appear in the version list of the parent block.
     CompleteVersionList,
     /// YAML maps (key-value pair lists) must have at least one entry.
     NonEmptyMaps,
-    /// Symbol names within a block must be unique.
+    /// Symbol and subregion names within a block must be unique.
     UniqueSymbols,
-    /// Symbols must fall within the address range of the parent block.
+    /// Symbol names must be unique within a block and all its subregions.
+    UniqueSymbolsAcrossSubregions,
+    /// Symbols and subregions must fall within the address range of the parent block.
     InBoundsSymbols,
-    /// Function symbols must not overlap with each other for a given block and version.
-    NoFunctionOverlap,
+    /// For a given block and version, function symbols must not overlap with each other, and
+    /// subregions must not overlap with other subregions, function symbols, or data symbols.
+    NoOverlap,
     /// Function symbol names must adhere to the specified [`NamingConvention`].
     FunctionNames(NamingConvention),
     /// Data symbol names must adhere to the specified [`NamingConvention`].
@@ -155,8 +161,11 @@ impl Check {
             Self::CompleteVersionList => self.result(check_complete_version_list(symgen)),
             Self::NonEmptyMaps => self.result(check_nonempty_maps(symgen)),
             Self::UniqueSymbols => self.result(check_unique_symbols(symgen)),
+            Self::UniqueSymbolsAcrossSubregions => {
+                self.result(check_unique_symbols_across_subregions(symgen))
+            }
             Self::InBoundsSymbols => self.result(check_in_bounds_symbols(symgen)),
-            Self::NoFunctionOverlap => self.result(check_no_function_overlap(symgen)),
+            Self::NoOverlap => self.result(check_no_overlap(symgen)),
             Self::FunctionNames(conv) => self.result(check_function_names(symgen, *conv)),
             Self::DataNames(conv) => self.result(check_data_names(symgen, *conv)),
         }
@@ -189,10 +198,10 @@ where
     }
 }
 
-/// Runs a simple boolean check on all address/length fields. The generic <'a> is the lifetime of
-/// the [`SymGen`] object to check, and allows the checker context to hold references to a block if
-/// needed.
-trait SimpleAddrLenChecker<'a> {
+/// Runs a simple boolean check on all address/length fields, and optionally all subregion blocks.
+/// The generic <'a> is the lifetime of the [`SymGen`] object to check, and allows the checker
+/// context to hold references to a block if needed.
+trait SimpleBlockContentsChecker<'a> {
     fn init_context(
         &mut self,
         _block_name: &'a OrdString,
@@ -200,41 +209,53 @@ trait SimpleAddrLenChecker<'a> {
     ) -> Result<(), String> {
         Ok(())
     }
-    fn check_val<T>(&self, val: &'a MaybeVersionDep<T>) -> bool;
-    fn error_stem<T>(&self, val: &'a MaybeVersionDep<T>) -> String;
+    fn should_check_subblocks() -> bool {
+        false
+    }
+    fn check_subblock(&self, _subblock: &'a Block) -> Result<(), String> {
+        Ok(())
+    }
+    fn check_val<T>(&self, val: &'a MaybeVersionDep<T>) -> Result<(), String>;
 
     fn check_symgen(&mut self, symgen: &'a SymGen) -> Result<(), String> {
         for (bname, b) in symgen.iter() {
             self.init_context(bname, b)?;
 
-            assert_check(self.check_val(&b.address), || {
-                format!(
-                    "block \"{}\": address {}",
-                    bname,
-                    self.error_stem(&b.address)
-                )
-            })?;
-            assert_check(self.check_val(&b.length), || {
-                format!("block \"{}\": length {}", bname, self.error_stem(&b.length))
-            })?;
+            if let Some(err_stem) = self.check_val(&b.address).err() {
+                return Err(format!("block \"{}\": address {}", bname, err_stem,));
+            }
+            if let Some(err_stem) = self.check_val(&b.length).err() {
+                return Err(format!("block \"{}\": length {}", bname, err_stem));
+            }
             for s in b.iter() {
-                assert_check(self.check_val(&s.address), || {
-                    format!(
+                if let Some(err_stem) = self.check_val(&s.address).err() {
+                    return Err(format!(
                         "block \"{}\", symbol \"{}\": address {}",
-                        bname,
-                        s.name,
-                        self.error_stem(&s.address)
-                    )
-                })?;
+                        bname, s.name, err_stem
+                    ));
+                }
                 if let Some(l) = &s.length {
-                    assert_check(self.check_val(l), || {
-                        format!(
+                    if let Some(err_stem) = self.check_val(l).err() {
+                        return Err(format!(
                             "block \"{}\", symbol \"{}\": length {}",
+                            bname, s.name, err_stem
+                        ));
+                    }
+                }
+            }
+
+            if Self::should_check_subblocks() {
+                // Use paths relative to the root symgen
+                for subblock in b.cursor(&bname.val, Path::new("")).subblocks() {
+                    if let Some(err_stem) = self.check_subblock(subblock.block()).err() {
+                        return Err(format!(
+                            "block \"{}\": subregion block \"{}::{}\" {}",
                             bname,
-                            s.name,
-                            self.error_stem(l)
-                        )
-                    })?;
+                            subblock.path().display(),
+                            subblock.name(),
+                            err_stem
+                        ));
+                    }
                 }
             }
         }
@@ -244,12 +265,13 @@ trait SimpleAddrLenChecker<'a> {
 
 fn check_explicit_versions(symgen: &SymGen) -> Result<(), String> {
     struct ExplicitVersionChecker {}
-    impl SimpleAddrLenChecker<'_> for ExplicitVersionChecker {
-        fn check_val<T>(&self, val: &MaybeVersionDep<T>) -> bool {
-            !val.is_common()
-        }
-        fn error_stem<T>(&self, _val: &MaybeVersionDep<T>) -> String {
-            "has no version".to_string()
+    impl SimpleBlockContentsChecker<'_> for ExplicitVersionChecker {
+        fn check_val<T>(&self, val: &MaybeVersionDep<T>) -> Result<(), String> {
+            if val.is_common() {
+                Err("has no version".to_string())
+            } else {
+                Ok(())
+            }
         }
     }
 
@@ -261,7 +283,24 @@ fn check_complete_version_list(symgen: &SymGen) -> Result<(), String> {
     struct CompleteVersionListChecker<'a> {
         block_versions: HashSet<&'a Version>,
     }
-    impl<'a> SimpleAddrLenChecker<'a> for CompleteVersionListChecker<'a> {
+    impl<'a> CompleteVersionListChecker<'a> {
+        fn err_stem(&self, versions: &HashSet<&Version>) -> String {
+            let mut vers_diff: Vec<String> = versions
+                .difference(&self.block_versions)
+                .map(|v| v.name().to_string())
+                .collect();
+            vers_diff.sort();
+            format!("contains unknown versions: [{}]", vers_diff.join(", "))
+        }
+        fn check(&self, versions: &HashSet<&Version>) -> Result<(), String> {
+            if versions.is_subset(&self.block_versions) {
+                Ok(())
+            } else {
+                Err(self.err_stem(versions))
+            }
+        }
+    }
+    impl<'a> SimpleBlockContentsChecker<'a> for CompleteVersionListChecker<'a> {
         fn init_context(
             &mut self,
             block_name: &'a OrdString,
@@ -277,20 +316,35 @@ fn check_complete_version_list(symgen: &SymGen) -> Result<(), String> {
             }
             Ok(())
         }
-        fn check_val<T>(&self, val: &MaybeVersionDep<T>) -> bool {
-            val.versions()
-                .collect::<HashSet<_>>()
-                .is_subset(&self.block_versions)
+        fn should_check_subblocks() -> bool {
+            true
         }
-        fn error_stem<T>(&self, val: &MaybeVersionDep<T>) -> String {
-            let mut vers_diff: Vec<String> = val
-                .versions()
-                .collect::<HashSet<_>>()
-                .difference(&self.block_versions)
-                .map(|v| v.name().to_string())
-                .collect();
-            vers_diff.sort();
-            format!("contains unknown versions: {:?}", vers_diff)
+        fn check_subblock(&self, subblock: &Block) -> Result<(), String> {
+            if let Some(versions) = &subblock.versions {
+                self.check(
+                    &versions
+                        .iter()
+                        .map(|v| {
+                            // Need to map versions to the parent block's ordinal space since
+                            // the subblock has its own, possibly incompatible ordinal space.
+                            if let Some(native_v) = self
+                                .block_versions
+                                .iter()
+                                .find(|parent_v| parent_v.name() == v.name())
+                            {
+                                native_v
+                            } else {
+                                v
+                            }
+                        })
+                        .collect::<HashSet<_>>(),
+                )
+            } else {
+                Ok(())
+            }
+        }
+        fn check_val<T>(&self, val: &MaybeVersionDep<T>) -> Result<(), String> {
+            self.check(&val.versions().collect::<HashSet<_>>())
         }
     }
 
@@ -302,12 +356,13 @@ fn check_complete_version_list(symgen: &SymGen) -> Result<(), String> {
 
 fn check_nonempty_maps(symgen: &SymGen) -> Result<(), String> {
     struct NonEmptyMapChecker {}
-    impl SimpleAddrLenChecker<'_> for NonEmptyMapChecker {
-        fn check_val<T>(&self, val: &MaybeVersionDep<T>) -> bool {
-            !val.is_empty()
-        }
-        fn error_stem<T>(&self, _val: &MaybeVersionDep<T>) -> String {
-            "is empty".to_string()
+    impl SimpleBlockContentsChecker<'_> for NonEmptyMapChecker {
+        fn check_val<T>(&self, val: &MaybeVersionDep<T>) -> Result<(), String> {
+            if val.is_empty() {
+                Err("is empty".to_string())
+            } else {
+                Ok(())
+            }
         }
     }
 
@@ -317,6 +372,7 @@ fn check_nonempty_maps(symgen: &SymGen) -> Result<(), String> {
 
 fn check_unique_symbols(symgen: &SymGen) -> Result<(), String> {
     let mut duplicate_names: BTreeMap<&OrdString, HashSet<&str>> = BTreeMap::new();
+    let mut duplicate_subregions: BTreeMap<&OrdString, HashSet<&Path>> = BTreeMap::new();
     for (bname, b) in symgen.iter() {
         let mut names: HashSet<&str> = HashSet::new();
         for name in b.iter().map(|s| &s.name) {
@@ -324,16 +380,135 @@ fn check_unique_symbols(symgen: &SymGen) -> Result<(), String> {
                 duplicate_names.entry(bname).or_default().insert(name);
             }
         }
+        if let Some(subregions) = &b.subregions {
+            let mut snames: HashSet<&Path> = HashSet::new();
+            for sname in subregions.iter().map(|s| &s.name) {
+                if !snames.insert(sname) {
+                    duplicate_subregions.entry(bname).or_default().insert(sname);
+                }
+            }
+        }
     }
-    assert_check(duplicate_names.is_empty(), || {
+    assert_check(
+        duplicate_names.is_empty() && duplicate_subregions.is_empty(),
+        || {
+            let mut components = Vec::with_capacity(2);
+            if !duplicate_names.is_empty() {
+                components.push(format!(
+                    "Found duplicate symbol names:\n{}",
+                    duplicate_names
+                        .into_iter()
+                        .map(|(bname, names)| {
+                            let mut names: Vec<_> = names.into_iter().collect();
+                            names.sort_unstable();
+                            format!("- block \"{}\": [{}]", bname, names.join(", "))
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                ));
+            }
+            if !duplicate_subregions.is_empty() {
+                components.push(format!(
+                    "Found duplicate subregion names:\n{}",
+                    duplicate_subregions
+                        .into_iter()
+                        .map(|(bname, subregions)| {
+                            let mut subregions: Vec<_> = subregions
+                                .into_iter()
+                                .map(|p| p.to_string_lossy())
+                                .collect();
+                            subregions.sort();
+                            format!("- block \"{}\": [{}]", bname, subregions.join(", "))
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                ));
+            }
+            components.join("\n")
+        },
+    )
+}
+
+fn check_unique_symbols_across_subregions(symgen: &SymGen) -> Result<(), String> {
+    #[derive(PartialEq, Eq, Hash)]
+    struct RcPathKey(Rc<PathBuf>);
+    impl Borrow<Path> for RcPathKey {
+        fn borrow(&self) -> &Path {
+            self.0.as_path()
+        }
+    }
+    struct PathCache(HashSet<RcPathKey>);
+    impl PathCache {
+        fn new() -> Self {
+            Self(HashSet::new())
+        }
+        fn get(&mut self, p: &Path) -> Rc<PathBuf> {
+            if let Some(RcPathKey(existing_path)) = self.0.get(p) {
+                Rc::clone(existing_path)
+            } else {
+                let new_path = Rc::new(p.to_owned());
+                self.0.insert(RcPathKey(Rc::clone(&new_path)));
+                new_path
+            }
+        }
+    }
+    type SymbolLocations<'s> = HashMap<&'s str, Vec<(Rc<PathBuf>, &'s str)>>;
+
+    let mut duplicate_symbols: BTreeMap<&str, SymbolLocations> = BTreeMap::new();
+
+    // Use paths relative to the root symgen
+    for cursor in symgen.cursor(Path::new("")).blocks() {
+        let mut all_symbols: SymbolLocations = HashMap::new();
+        let mut path_cache = PathCache::new();
+        let bname = cursor.name();
+
+        for block in cursor.dtraverse() {
+            let path = path_cache.get(block.path());
+            let symbols: HashSet<&str> = block.block().iter().map(|s| s.name.as_ref()).collect();
+            for symbol in symbols {
+                all_symbols
+                    .entry(symbol)
+                    .or_default()
+                    .push((Rc::clone(&path), block.name()));
+            }
+        }
+        let duplicates: SymbolLocations = all_symbols
+            .into_iter()
+            .filter(|(_, loc)| loc.len() > 1)
+            .collect();
+        if !duplicates.is_empty() {
+            duplicate_symbols.insert(bname, duplicates);
+        }
+    }
+
+    assert_check(duplicate_symbols.is_empty(), || {
         format!(
             "Found duplicate symbol names:\n{}",
-            duplicate_names
-                .iter()
-                .map(|(bname, names)| {
-                    let mut names: Vec<_> = names.iter().collect();
-                    names.sort();
-                    format!("- block \"{}\": {:?}", bname, names)
+            duplicate_symbols
+                .into_iter()
+                .map(|(bname, symbol_locations)| {
+                    let mut repeated_symbols: Vec<_> = symbol_locations
+                        .into_iter()
+                        .map(|(symbol, locations)| {
+                            format!(
+                                "  - \"{}\" repeated in: [{}]",
+                                symbol,
+                                locations
+                                    .into_iter()
+                                    .map(|(path, block)| {
+                                        if path.components().next().is_none() {
+                                            block.to_string()
+                                        } else {
+                                            format!("{}::{}", path.display(), block)
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            )
+                        })
+                        .collect();
+                    repeated_symbols.sort();
+                    format!("- block \"{}\":\n{}", bname, repeated_symbols.join("\n"))
                 })
                 .collect::<Vec<_>>()
                 .join("\n")
@@ -348,36 +523,56 @@ fn check_in_bounds_symbols(symgen: &SymGen) -> Result<(), String> {
             None => format!("{:#X}", addr),
         }
     }
+    fn violation_str(violation: BoundViolation, bname: &OrdString, identifier: String) -> String {
+        if let Some(vers) = &violation.version {
+            format!(
+                "block \"{}\" [{}]: {} at {} is outside of block bounds {}",
+                bname,
+                vers,
+                identifier,
+                range_str(violation.extent),
+                range_str(violation.bound),
+            )
+        } else {
+            format!(
+                "block \"{}\": {} at {} is outside of block bounds {}",
+                bname,
+                identifier,
+                range_str(violation.extent),
+                range_str(violation.bound),
+            )
+        }
+    }
 
     for (bname, b) in symgen.iter() {
         let bounds = b.extent();
         for s in b.iter() {
             if let Some(violation) = bounds::symbol_in_bounds(&bounds, s, &b.versions) {
-                return Err(if let Some(vers) = &violation.version {
+                return Err(violation_str(
+                    violation,
+                    bname,
+                    format!("symbol \"{}\"", s.name),
+                ));
+            }
+        }
+        for subblock in b.cursor(&bname.val, Path::new("")).subblocks() {
+            if let Some(violation) = bounds::block_in_bounds(&bounds, subblock.block()) {
+                return Err(violation_str(
+                    violation,
+                    bname,
                     format!(
-                        "block \"{}\" [{}]: symbol \"{}\" at {} is outside of block bounds {}",
-                        bname,
-                        vers,
-                        s.name,
-                        range_str(violation.extent),
-                        range_str(violation.bound),
-                    )
-                } else {
-                    format!(
-                        "block \"{}\": symbol \"{}\" at {} is outside of block bounds {}",
-                        bname,
-                        s.name,
-                        range_str(violation.extent),
-                        range_str(violation.bound),
-                    )
-                });
+                        "subregion block \"{}::{}\"",
+                        subblock.path().display(),
+                        subblock.name()
+                    ),
+                ));
             }
         }
     }
     Ok(())
 }
 
-fn check_no_function_overlap(symgen: &SymGen) -> Result<(), String> {
+fn check_no_overlap(symgen: &SymGen) -> Result<(), String> {
     type Extent = (Uint, Uint);
     struct ExtentsByVersion<'a> {
         versioned: Option<VersionDep<Vec<(Extent, &'a str)>>>,
@@ -389,6 +584,10 @@ fn check_no_function_overlap(symgen: &SymGen) -> Result<(), String> {
                 versioned: None,
                 unversioned: None,
             }
+        }
+        fn get_ext_endpoints(addr: Uint, len: Option<Uint>) -> Extent {
+            // Every object is considered to have a length of at least 1
+            (addr, addr + cmp::max(1, len.unwrap_or(1)))
         }
         fn append(&mut self, vers: Option<Version>, ext: Extent, name: &'a str) {
             match vers {
@@ -417,10 +616,9 @@ fn check_no_function_overlap(symgen: &SymGen) -> Result<(), String> {
                 MaybeVersionDep::ByVersion(s_exts) => {
                     for (vers, (addrs, len)) in s_exts.iter() {
                         for &addr in addrs.iter() {
-                            // Every symbol is considered to have a length of at least 1
                             self.append(
                                 Some(vers.clone()),
-                                (addr, addr + cmp::max(1, len.unwrap_or(1))),
+                                Self::get_ext_endpoints(addr, *len),
                                 &symbol.name,
                             )
                         }
@@ -429,13 +627,29 @@ fn check_no_function_overlap(symgen: &SymGen) -> Result<(), String> {
                 MaybeVersionDep::Common((addrs, len)) => {
                     // Version expansion wasn't possible, assume unversioned
                     for &addr in addrs.iter() {
-                        // Every symbol is considered to have a length of at least 1
-                        self.append(
-                            None,
-                            (addr, addr + cmp::max(1, len.unwrap_or(1))),
-                            &symbol.name,
-                        )
+                        self.append(None, Self::get_ext_endpoints(addr, len), &symbol.name)
                     }
+                }
+            }
+        }
+        fn append_block(&mut self, bname: &'a str, block: &'a Block) {
+            match block.extent() {
+                MaybeVersionDep::ByVersion(exts) => {
+                    for (vers, &(addr, len)) in exts.iter() {
+                        // Need to map versions to the internal ordinal space since foreign blocks
+                        // can each have their own, possibly incompatible ordinal space.
+                        let native_vers = self
+                            .versioned
+                            .as_ref()
+                            .and_then(|versioned| versioned.find_native_version(vers))
+                            .unwrap_or(vers)
+                            .clone();
+                        self.append(Some(native_vers), Self::get_ext_endpoints(addr, len), bname)
+                    }
+                }
+                MaybeVersionDep::Common((addr, len)) => {
+                    // Version expansion wasn't possible, assume unversioned
+                    self.append(None, Self::get_ext_endpoints(addr, len), bname)
                 }
             }
         }
@@ -463,23 +677,97 @@ fn check_no_function_overlap(symgen: &SymGen) -> Result<(), String> {
             Ok(())
         }
         fn check_for_self_overlap(&mut self, bname: &str, ext_type: &str) -> Result<(), String> {
-            // Compare adjacent extents for overlaps
             if let Some(exts_by_vers) = self.versioned.as_mut() {
                 for (vers, exts) in exts_by_vers.iter_mut() {
-                    if let Some(err_stem) =
-                        ExtentsByVersion::check_exts_for_self_overlap(exts, ext_type).err()
+                    if let Some(err_stem) = Self::check_exts_for_self_overlap(exts, ext_type).err()
                     {
                         return Err(format!("block \"{}\" [{}]: {}", bname, vers, err_stem));
                     }
                 }
             }
             if let Some(exts) = self.unversioned.as_mut() {
-                if let Some(err_stem) =
-                    ExtentsByVersion::check_exts_for_self_overlap(exts, ext_type).err()
+                if let Some(err_stem) = Self::check_exts_for_self_overlap(exts, ext_type).err() {
+                    return Err(format!("block \"{}\": {}", bname, err_stem));
+                }
+            }
+            Ok(())
+        }
+        fn check_exts_for_mutual_overlap(
+            exts1: &mut Vec<(Extent, &str)>,
+            exts2: &mut Vec<(Extent, &str)>,
+            ext_type1: &str,
+            ext_type2: &str,
+        ) -> Result<(), String> {
+            exts1.sort_unstable();
+            exts2.sort_unstable();
+
+            let (mut iter1, mut iter2) = (exts1.iter(), exts2.iter());
+            let (mut next1, mut next2) = (iter1.next(), iter2.next());
+            while let (Some(val1), Some(val2)) = (next1, next2) {
+                let ((start1, end1), name1) = val1;
+                let ((start2, end2), name2) = val2;
+                if start2 >= end1 {
+                    next1 = iter1.next();
+                } else if start1 >= end2 {
+                    next2 = iter2.next();
+                } else {
+                    return Err(format!(
+                        "{} \"{}\" ({:#X}-{:#X}) overlaps with {} \"{}\" ({:#X}-{:#X})",
+                        ext_type2,
+                        name2,
+                        start2,
+                        end2 - 1,
+                        ext_type1,
+                        name1,
+                        start1,
+                        end1 - 1,
+                    ));
+                }
+            }
+            Ok(())
+        }
+        fn check_for_overlap_with(
+            &mut self,
+            other: &mut ExtentsByVersion,
+            bname: &str,
+            ext_type_self: &str,
+            ext_type_other: &str,
+        ) -> Result<(), String> {
+            if let (Some(exts_by_vers), Some(other_exts_by_vers)) =
+                (self.versioned.as_mut(), other.versioned.as_mut())
+            {
+                for (vers, exts) in exts_by_vers.iter_mut() {
+                    // Need to use get_mut() since self and other could have different
+                    // version ordinal spaces
+                    if let Some(other_exts) = other_exts_by_vers.get_mut(vers) {
+                        if let Some(err_stem) = Self::check_exts_for_mutual_overlap(
+                            exts,
+                            other_exts,
+                            ext_type_self,
+                            ext_type_other,
+                        )
+                        .err()
+                        {
+                            return Err(format!("block \"{}\" [{}]: {}", bname, vers, err_stem));
+                        }
+                    }
+                }
+            }
+            if let (Some(exts), Some(other_exts)) =
+                (self.unversioned.as_mut(), other.unversioned.as_mut())
+            {
+                if let Some(err_stem) = Self::check_exts_for_mutual_overlap(
+                    exts,
+                    other_exts,
+                    ext_type_self,
+                    ext_type_other,
+                )
+                .err()
                 {
                     return Err(format!("block \"{}\": {}", bname, err_stem));
                 }
             }
+
             Ok(())
         }
     }
@@ -503,8 +791,34 @@ fn check_no_function_overlap(symgen: &SymGen) -> Result<(), String> {
             extents_by_vers.append_symbol(s, versions);
         }
 
-        // Compare adjacent extents for overlaps
+        // Compare function extents among themselves for overlaps
         extents_by_vers.check_for_self_overlap(&bname.val, "functions")?;
+
+        let cursor = block.cursor(&bname.val, Path::new(""));
+        if cursor.has_subregions() {
+            // Gather all data extents
+            for s in block.data.iter() {
+                extents_by_vers.append_symbol(s, versions);
+            }
+
+            // Gather all subregion extents
+            let mut subregion_extents_by_vers = ExtentsByVersion::new();
+            for subblock in cursor.subblocks() {
+                // For subregions, each subblock has its own version list, so use that for Common
+                // expansion rather than the parent block's version list
+                subregion_extents_by_vers.append_block(subblock.name(), subblock.block());
+            }
+
+            // Compare subregion extents among themselves for overlaps
+            subregion_extents_by_vers.check_for_self_overlap(&bname.val, "subregions")?;
+            // Compare subregion extents with function/data extents for overlaps
+            subregion_extents_by_vers.check_for_overlap_with(
+                &mut extents_by_vers,
+                &bname.val,
+                "subregion",
+                "symbol",
+            )?;
+        }
     }
     Ok(())
 }
@@ -532,11 +846,11 @@ where
             "Found invalid {} names:\n{}",
             symbol_type,
             bad_names
-                .iter()
+                .into_iter()
                 .map(|(bname, names)| {
-                    let mut names: Vec<_> = names.iter().collect();
-                    names.sort();
-                    format!("- block \"{}\": {:?}", bname, names)
+                    let mut names: Vec<_> = names.into_iter().collect();
+                    names.sort_unstable();
+                    format!("- block \"{}\": [{}]", bname, names.join(", "))
                 })
                 .collect::<Vec<_>>()
                 .join("\n")
@@ -554,8 +868,10 @@ fn check_data_names(symgen: &SymGen, conv: NamingConvention) -> Result<(), Strin
 
 /// Validates a given `input_file` under the specified `checks`.
 ///
-/// Returns a [`Vec<CheckResult>`] corresponding to `checks` if all checks were run without
-/// encountering any fatal errors.
+/// In `recursive` mode, subregion files are also validated.
+///
+/// Returns a [`Vec<(PathBuf, CheckResult)>`] with the results of all checks on all the files
+/// validated, if all checks were run without encountering any fatal errors.
 ///
 /// # Examples
 /// ```ignore
@@ -565,20 +881,65 @@ fn check_data_names(symgen: &SymGen, conv: NamingConvention) -> Result<(), Strin
 ///         Check::ExplicitVersions,
 ///         Check::FunctionNames(NamingConvention::SnakeCase),
 ///     ],
+///     true,
 /// )
 /// .expect("Fatal error occurred");
 /// ```
 pub fn run_checks<P: AsRef<Path>>(
     input_file: P,
     checks: &[Check],
-) -> Result<Vec<CheckResult>, Box<dyn Error>> {
-    let f = File::open(input_file)?;
-    let contents = SymGen::read(&f)?;
-    Ok(checks.iter().map(|chk| chk.run(&contents)).collect())
+    recursive: bool,
+) -> Result<Vec<(PathBuf, CheckResult)>, Box<dyn Error>> {
+    /// For returning either a [`Once`] iterator or an [`Empty`] iterator, while still allowing
+    /// static dispatch.
+    enum OnceOrEmpty<T> {
+        Once(iter::Once<T>),
+        Empty(iter::Empty<T>),
+    }
+    impl<T> Iterator for OnceOrEmpty<T> {
+        type Item = T;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match self {
+                Self::Once(o) => o.next(),
+                Self::Empty(e) => e.next(),
+            }
+        }
+    }
+
+    let input_file = input_file.as_ref();
+    let mut contents = {
+        let f = File::open(input_file)?;
+        SymGen::read(&f)?
+    };
+    if recursive {
+        contents.resolve_subregions(Subregion::subregion_dir(input_file), |p| File::open(p))?;
+    }
+    Ok(checks
+        .iter()
+        .flat_map(|chk| {
+            let check_results = contents
+                .cursor(input_file)
+                .dtraverse()
+                .map(move |cursor| (cursor.path().to_owned(), chk.run(cursor.symgen())));
+            if let (Check::UniqueSymbols, true) =
+                (chk, contents.cursor(input_file).has_subregions())
+            {
+                // Recursive UniqueSymbols is a special case.
+                // Add a cross-subregion uniqueness check that spans all subregions
+                check_results.chain(OnceOrEmpty::Once(iter::once((
+                    input_file.to_owned(),
+                    Check::UniqueSymbolsAcrossSubregions.run(&contents),
+                ))))
+            } else {
+                check_results.chain(OnceOrEmpty::Empty(iter::empty()))
+            }
+        })
+        .collect())
 }
 
 /// Prints check results similar to `cargo test` output.
-fn print_report(results: &[(String, CheckResult)]) -> io::Result<()> {
+fn print_report(results: &[(PathBuf, CheckResult)]) -> io::Result<()> {
     let mut stdout = StandardStream::stdout(ColorChoice::Always);
     let mut print_colored_report = || -> io::Result<()> {
         let mut color = ColorSpec::new();
@@ -586,7 +947,7 @@ fn print_report(results: &[(String, CheckResult)]) -> io::Result<()> {
         // Results list
         for (name, r) in results {
             stdout.reset()?;
-            write!(&mut stdout, "check {}::{} ... ", name, r.check)?;
+            write!(&mut stdout, "check {}::{} ... ", name.display(), r.check)?;
             if r.succeeded {
                 stdout.set_color(color.set_fg(Some(Color::Green)))?;
                 writeln!(&mut stdout, "ok")?;
@@ -606,7 +967,7 @@ fn print_report(results: &[(String, CheckResult)]) -> io::Result<()> {
             writeln!(&mut stdout, "failures:")?;
             writeln!(&mut stdout)?;
             for (name, r) in results.iter().filter(|(_, r)| !r.succeeded) {
-                writeln!(&mut stdout, "---- [{}] {} ----", name, r.check)?;
+                writeln!(&mut stdout, "---- [{}] {} ----", name.display(), r.check)?;
                 if let Some(msg) = &r.details {
                     writeln!(&mut stdout, "{}", msg)?;
                 }
@@ -640,6 +1001,8 @@ fn print_report(results: &[(String, CheckResult)]) -> io::Result<()> {
 /// Validates a given set of `input_files` under the specified `checks`, and prints a summary of
 /// the results.
 ///
+/// In `recursive` mode, subregion files of the given input files are also validated.
+///
 /// If all checks were run without encountering a fatal error, returns `true` if all checks passed
 /// and `false` otherwise.
 ///
@@ -651,24 +1014,26 @@ fn print_report(results: &[(String, CheckResult)]) -> io::Result<()> {
 ///         Check::ExplicitVersions,
 ///         Check::FunctionNames(NamingConvention::SnakeCase),
 ///     ],
+///     true,
 /// )
 /// .expect("Fatal error occurred");
 /// ```
-pub fn run_and_print_checks<I, P>(input_files: I, checks: &[Check]) -> Result<bool, Box<dyn Error>>
+pub fn run_and_print_checks<I, P>(
+    input_files: I,
+    checks: &[Check],
+    recursive: bool,
+) -> Result<bool, Box<dyn Error>>
 where
     P: AsRef<Path>,
     I: AsRef<[P]>,
 {
     let input_files = input_files.as_ref();
+    // At least this many check results, but there could be more in recursive mode
     let mut results = Vec::with_capacity(input_files.len() * checks.len());
     let mut errors = Vec::with_capacity(input_files.len());
     for input_file in input_files {
-        match run_checks(input_file, checks) {
-            Ok(result) => results.extend(
-                result
-                    .into_iter()
-                    .map(|r| (input_file.as_ref().to_string_lossy().into_owned(), r)),
-            ),
+        match run_checks(input_file, checks, recursive) {
+            Ok(result) => results.extend(result.into_iter()),
             Err(e) => errors.push((input_file.as_ref().to_string_lossy().into_owned(), e)),
         }
     }
@@ -688,6 +1053,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::super::data_formats::symgen_yml::test_utils;
     use super::*;
 
     #[cfg(test)]
@@ -798,16 +1164,99 @@ mod tests {
                     v1: 0x1000
                     v2: 0x2000
                   description: foo bar baz
-        "
+            "
             .as_bytes(),
         )
         .expect("Read failed")
+    }
+
+    fn get_test_symgen_with_subregions() -> SymGen {
+        test_utils::get_symgen_with_subregions(
+            r"
+            main:
+              versions:
+                - v1
+                - v2
+                - v3
+              address:
+                v1: 0x2000000
+                v2: 0x2000000
+                v3: 0x2000000
+              length:
+                v1: 0x100000
+                v2: 0x100000
+                v3: 0x100000
+              subregions:
+                - sub1.yml
+                - sub2.yml
+              functions: []
+              data: []
+            ",
+            &[
+                (
+                    "sub1.yml",
+                    r"
+                    sub1:
+                      versions:
+                        - v3
+                        - v1
+                      address:
+                        v3: 0x2000000
+                        v1: 0x2000000
+                      length:
+                        v3: 0x100
+                        v1: 0x100
+                      functions:
+                        - name: sub1_fn
+                          address:
+                            v3: 0x2000000
+                            v1: 0x2000000
+                      data: []
+                    ",
+                ),
+                (
+                    "sub2.yml",
+                    r"
+                    sub2:
+                      versions:
+                        - v2
+                      address:
+                        v2: 0x20FFF00
+                      length:
+                        v2: 0x100
+                      functions: []
+                      data:
+                        - name: sub2_data
+                          address:
+                            v2: 0x20FFF80
+                          length:
+                            v2: 0x80
+                    ",
+                ),
+            ],
+        )
     }
 
     fn get_main_block(symgen: &mut SymGen) -> &mut Block {
         symgen
             .get_mut(&symgen.block_key("main").expect("No block \"main\"").clone())
             .unwrap()
+    }
+
+    fn get_subregion_block(symgen: &mut SymGen, i: usize) -> &mut Block {
+        let subregion = get_main_block(symgen)
+            .subregions
+            .as_mut()
+            .expect("No subregions")
+            .get_mut(i)
+            .expect("Invalid index")
+            .contents
+            .as_mut()
+            .expect("Subregion has no contents");
+        subregion
+            .blocks_mut()
+            .next()
+            .expect("Subregion has no blocks")
     }
 
     #[test]
@@ -822,13 +1271,24 @@ mod tests {
     }
 
     #[test]
-    fn test_complete_versions_list() {
+    fn test_complete_version_list() {
         let mut symgen = get_test_symgen();
         assert!(check_complete_version_list(&symgen).is_ok());
 
         let block = get_main_block(&mut symgen);
         // Delete the block version list
         block.versions = None;
+        assert!(check_complete_version_list(&symgen).is_err());
+    }
+
+    #[test]
+    fn test_complete_version_list_with_subregions() {
+        let mut symgen = get_test_symgen_with_subregions();
+        assert!(check_complete_version_list(&symgen).is_ok());
+
+        let block = get_main_block(&mut symgen);
+        // Delete one of the versions
+        block.versions.as_mut().unwrap().pop();
         assert!(check_complete_version_list(&symgen).is_err());
     }
 
@@ -841,6 +1301,38 @@ mod tests {
         // Copy the function symbols to the data symbols so they clash
         block.data = block.functions.clone();
         assert!(check_unique_symbols(&symgen).is_err());
+    }
+
+    #[test]
+    fn test_unique_subregions() {
+        let mut symgen = get_test_symgen_with_subregions();
+        assert!(check_unique_symbols(&symgen).is_ok());
+
+        let block = get_main_block(&mut symgen);
+        // Add a duplicate subregion
+        let subregion = Subregion {
+            name: block.subregions.as_ref().unwrap()[0].name.clone(),
+            contents: None,
+        };
+        block.subregions.as_mut().unwrap().push(subregion);
+        assert!(check_unique_symbols(&symgen).is_err());
+    }
+
+    #[test]
+    fn test_unique_symbols_across_subregions() {
+        let mut symgen = get_test_symgen_with_subregions();
+        assert!(check_unique_symbols_across_subregions(&symgen).is_ok());
+
+        // Insert a copy of a subregion's symbol into the main block
+        let symbol = get_subregion_block(&mut symgen, 0)
+            .functions
+            .iter()
+            .next()
+            .expect("subregion block has no functions")
+            .clone();
+        let block = get_main_block(&mut symgen);
+        block.functions.push(symbol);
+        assert!(check_unique_symbols_across_subregions(&symgen).is_err());
     }
 
     #[test]
@@ -857,9 +1349,20 @@ mod tests {
     }
 
     #[test]
-    fn test_no_function_overlap() {
+    fn test_in_bounds_subregions() {
+        let mut symgen = get_test_symgen_with_subregions();
+        assert!(check_in_bounds_symbols(&symgen).is_ok());
+
+        let block = get_main_block(&mut symgen);
+        // Shrink the main block so the sub2 subregion ends up out of bounds
+        *block.length.get_mut(Some(&"v2".into())).unwrap() -= 0x80;
+        assert!(check_in_bounds_symbols(&symgen).is_err());
+    }
+
+    #[test]
+    fn test_no_overlap() {
         let mut symgen = get_test_symgen();
-        assert!(check_no_function_overlap(&symgen).is_ok());
+        assert!(check_no_overlap(&symgen).is_ok());
 
         let block = get_main_block(&mut symgen);
         // Swap the address of the second function to match the first, causing an overlap
@@ -885,11 +1388,11 @@ mod tests {
             .unwrap()
             .clone();
         block.functions = [function, overlapping].into();
-        assert!(check_no_function_overlap(&symgen).is_err());
+        assert!(check_no_overlap(&symgen).is_err());
     }
 
     #[test]
-    fn test_no_function_overlap_common_with_version_list() {
+    fn test_no_overlap_common_with_version_list() {
         let mut symgen = SymGen::read(
             r"
             main:
@@ -914,7 +1417,7 @@ mod tests {
         )
         .expect("Read failed");
 
-        assert!(check_no_function_overlap(&symgen).is_ok());
+        assert!(check_no_overlap(&symgen).is_ok());
 
         let block = get_main_block(&mut symgen);
         // Swap the address of the first function to match one of the versions in the second,
@@ -938,11 +1441,11 @@ mod tests {
             .unwrap()
             .clone();
         block.functions = [function, overlapping].into();
-        assert!(check_no_function_overlap(&symgen).is_err());
+        assert!(check_no_overlap(&symgen).is_err());
     }
 
     #[test]
-    fn test_no_function_overlap_common_no_version_list() {
+    fn test_no_overlap_common_no_version_list() {
         let mut symgen = SymGen::read(
             r"
             main:
@@ -962,7 +1465,7 @@ mod tests {
         )
         .expect("Read failed");
 
-        assert!(check_no_function_overlap(&symgen).is_ok());
+        assert!(check_no_overlap(&symgen).is_ok());
 
         let block = get_main_block(&mut symgen);
         // Swap the address of the second function to match the first, causing an overlap
@@ -981,7 +1484,27 @@ mod tests {
         let addr = overlapping.address.get_mut_native(None).unwrap();
         *addr = function.address.get_native(None).unwrap().clone();
         block.functions = [function, overlapping].into();
-        assert!(check_no_function_overlap(&symgen).is_err());
+        assert!(check_no_overlap(&symgen).is_err());
+    }
+
+    #[test]
+    fn test_no_overlap_with_subregions() {
+        let mut symgen = get_test_symgen_with_subregions();
+        assert!(check_no_overlap(&symgen).is_ok());
+
+        // Add a symbol to the main block that overlaps with a subregion symbol
+        let address = *get_subregion_block(&mut symgen, 0)
+            .address
+            .get(Some(&"v1".into()))
+            .unwrap();
+        let block = get_main_block(&mut symgen);
+        block.functions.push(Symbol {
+            name: String::from("main_fn"),
+            address: MaybeVersionDep::ByVersion([("v1".into(), [address].into())].into()),
+            length: None,
+            description: None,
+        });
+        assert!(check_no_overlap(&symgen).is_err());
     }
 
     #[test]

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -632,6 +632,7 @@ where
 mod tests {
     use super::*;
 
+    #[cfg(test)]
     mod naming_convention_tests {
         use super::*;
 

--- a/src/data_formats/symgen_yml.rs
+++ b/src/data_formats/symgen_yml.rs
@@ -8,6 +8,14 @@
 //! A [`Symbol`] represents one or more memory regions containing an identifiable chunk of
 //! instructions or data.
 //!
+//! Optionally, each [`Block`] can also contain a list of [`Subregion`]s. A [`Subregion`]
+//! represents a nested [`SymGen`], which has one or more of its own named [`Block`]s, that is
+//! contained within the parent [`Block`]. In a `resymgen` YAML file, a [`Subregion`] is
+//! represented as a file name. If the `resymgen` YAML file has the file path
+//! `/path/to/parent.yml`, and one of its blocks has a subregion with the name `sub.yml`, then
+//! this subregion name references a corresponding subregion file (which is itself a `resymgen`
+//! YAML file) with the file path `/path/to/parent/sub.yml`.
+//!
 //! # Example
 //! ```yml
 //! main:
@@ -21,6 +29,9 @@
 //!     v1: 0x100000
 //!     v2: 0x100000
 //!   description: The main memory region
+//!   subregions:
+//!     - sub1.yml
+//!     - sub2.yml
 //!   functions:
 //!     - name: function1
 //!       address:

--- a/src/data_formats/symgen_yml/bounds.rs
+++ b/src/data_formats/symgen_yml/bounds.rs
@@ -33,61 +33,88 @@ fn bounds_check(
     true
 }
 
-/// Checks that the possibly version-dependent extents of a symbol are contained within their
+/// An type that can be checked against a range bound (addr, Option<len>) and potentially returns
+/// a [`BoundViolation`].
+trait Bounded {
+    fn check_against_bound(
+        &self,
+        bound: (Uint, Option<Uint>),
+        version: Option<&Version>,
+    ) -> Option<BoundViolation>;
+}
+
+impl Bounded for (Linkable, Option<Uint>) {
+    fn check_against_bound(
+        &self,
+        bound: (Uint, Option<Uint>),
+        version: Option<&Version>,
+    ) -> Option<BoundViolation> {
+        for &addr in self.0.iter() {
+            let extent = (addr, self.1);
+            if !bounds_check(extent, bound) {
+                return Some(BoundViolation {
+                    version: version.cloned(),
+                    bound,
+                    extent,
+                });
+            }
+        }
+        None
+    }
+}
+
+impl Bounded for (Uint, Option<Uint>) {
+    fn check_against_bound(
+        &self,
+        bound: (Uint, Option<Uint>),
+        version: Option<&Version>,
+    ) -> Option<BoundViolation> {
+        if !bounds_check(*self, bound) {
+            Some(BoundViolation {
+                version: version.cloned(),
+                bound,
+                extent: *self,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Checks that the possibly version-dependent extents provided are contained within their
 /// respective, possibly version-dependent bounds.
-fn symbol_extents_in_bounds(
+fn extents_in_bounds<B: Bounded>(
     bounds: &MaybeVersionDep<(Uint, Option<Uint>)>,
-    extents: &MaybeVersionDep<(Linkable, Option<Uint>)>,
+    extents: &MaybeVersionDep<B>,
 ) -> Option<BoundViolation> {
     match extents {
         MaybeVersionDep::ByVersion(ext) => {
             // By-version extents are the easy case: just check each version against the
             // corresponding bound if present
-            for (vers, (addrs, opt_len)) in ext.iter() {
-                if let Some(bound) = bounds.get(Some(vers)) {
-                    for addr in addrs.iter() {
-                        let single_ext = (*addr, *opt_len);
-                        if !bounds_check(single_ext, *bound) {
-                            return Some(BoundViolation {
-                                version: Some(vers.clone()),
-                                bound: *bound,
-                                extent: single_ext,
-                            });
-                        }
+            for (vers, extent) in ext.iter() {
+                if let Some(&bound) = bounds.get(Some(vers)) {
+                    if let Some(violation) = extent.check_against_bound(bound, Some(vers)) {
+                        return Some(violation);
                     }
                 }
             }
         }
-        MaybeVersionDep::Common((addrs, opt_len)) => {
+        MaybeVersionDep::Common(extent) => {
             // Common extents means it wasn't version-expanded, or the version list was None.
             // Check this extent against the bounds for every version (this is possible if a
             // block omits a version list but still has inferred versions based on the
             // address/length fields).
             match bounds {
                 MaybeVersionDep::ByVersion(bound_by_vers) => {
-                    for (vers, bound) in bound_by_vers.iter() {
-                        for addr in addrs.iter() {
-                            let single_ext = (*addr, *opt_len);
-                            if !bounds_check(single_ext, *bound) {
-                                return Some(BoundViolation {
-                                    version: Some(vers.clone()),
-                                    bound: *bound,
-                                    extent: single_ext,
-                                });
-                            }
+                    for (vers, &bound) in bound_by_vers.iter() {
+                        if let Some(violation) = extent.check_against_bound(bound, Some(vers)) {
+                            return Some(violation);
                         }
                     }
                 }
                 MaybeVersionDep::Common(bound) => {
-                    for addr in addrs.iter() {
-                        let single_ext = (*addr, *opt_len);
-                        if !bounds_check(single_ext, *bound) {
-                            return Some(BoundViolation {
-                                version: None,
-                                bound: *bound,
-                                extent: single_ext,
-                            });
-                        }
+                    if let Some(violation) = extent.check_against_bound(*bound, None) {
+                        return Some(violation);
                     }
                 }
             }
@@ -102,18 +129,34 @@ fn symbol_extents_in_bounds(
 /// If `symbol` is not explicitly version-dependent, and `all_versions` is provided, the check
 /// will be done for every given version.
 ///
-/// Returns [`None`] on success, or a [`BoundViolation`] if bound is found to be violated.
+/// Returns [`None`] on success, or a [`BoundViolation`] if the bound is found to be violated.
 pub fn symbol_in_bounds(
     bounds: &MaybeVersionDep<(Uint, Option<Uint>)>,
     symbol: &Symbol,
     all_versions: &Option<Vec<Version>>,
 ) -> Option<BoundViolation> {
-    symbol_extents_in_bounds(bounds, &symbol.extents(all_versions.as_deref()))
+    extents_in_bounds(bounds, &symbol.extents(all_versions.as_deref()))
+}
+
+/// Checks that a `block` falls within the given `bounds` (as an offset and an optional length)
+/// for the matching versions.
+///
+/// Returns [`None`] on success, or a [`BoundViolation`] if the bound is found to be violated.
+pub fn block_in_bounds(
+    bounds: &MaybeVersionDep<(Uint, Option<Uint>)>,
+    block: &Block,
+) -> Option<BoundViolation> {
+    extents_in_bounds(bounds, &block.extent())
 }
 
 /// Checks that `symbol` falls within the bounds of `block`.
-pub fn block_contains(block: &Block, symbol: &Symbol) -> bool {
+pub fn block_contains_symbol(block: &Block, symbol: &Symbol) -> bool {
     symbol_in_bounds(&block.extent(), symbol, &block.versions).is_none()
+}
+
+/// Checks that `other` falls within the bounds of `block`.
+pub fn block_contains_block(block: &Block, other: &Block) -> bool {
+    block_in_bounds(&block.extent(), other).is_none()
 }
 
 #[cfg(test)]
@@ -158,35 +201,23 @@ mod tests {
         let cases: [(VersionDep<_>, VersionDep<_>, bool); 3] = [
             (
                 [("v1".into(), (0, Some(100))), ("v2".into(), (0, Some(100)))].into(),
-                [
-                    ("v1".into(), (0.into(), Some(100))),
-                    ("v2".into(), (0.into(), Some(100))),
-                ]
-                .into(),
+                [("v1".into(), (0, Some(100))), ("v2".into(), (0, Some(100)))].into(),
                 true,
             ),
             (
                 [("v1".into(), (0, Some(100))), ("v2".into(), (0, Some(100)))].into(),
-                [
-                    ("v1".into(), (0.into(), Some(150))),
-                    ("v2".into(), (0.into(), Some(100))),
-                ]
-                .into(),
+                [("v1".into(), (0, Some(150))), ("v2".into(), (0, Some(100)))].into(),
                 false,
             ),
             (
                 [("v2".into(), (0, Some(100)))].into(),
-                [
-                    ("v1".into(), (0.into(), Some(150))),
-                    ("v2".into(), (0.into(), Some(100))),
-                ]
-                .into(),
+                [("v1".into(), (0, Some(150))), ("v2".into(), (0, Some(100)))].into(),
                 true,
             ),
         ];
         for case in cases {
             assert_eq!(
-                symbol_extents_in_bounds(
+                extents_in_bounds(
                     &MaybeVersionDep::ByVersion(case.0.into()),
                     &MaybeVersionDep::ByVersion(case.1.into())
                 )
@@ -206,8 +237,8 @@ mod tests {
                 ]
                 .into(),
                 [
-                    (("v1", 1).into(), (0.into(), Some(100))),
-                    (("v2", 2).into(), (0.into(), Some(100))),
+                    (("v1", 1).into(), (0, Some(100))),
+                    (("v2", 2).into(), (0, Some(100))),
                 ]
                 .into(),
                 true,
@@ -219,8 +250,8 @@ mod tests {
                 ]
                 .into(),
                 [
-                    (("v1", 1).into(), (0.into(), Some(150))),
-                    (("v2", 2).into(), (0.into(), Some(100))),
+                    (("v1", 1).into(), (0, Some(150))),
+                    (("v2", 2).into(), (0, Some(100))),
                 ]
                 .into(),
                 false,
@@ -228,8 +259,8 @@ mod tests {
             (
                 [(("v2", 0).into(), (0, Some(100)))].into(),
                 [
-                    (("v1", 1).into(), (0.into(), Some(150))),
-                    (("v2", 2).into(), (0.into(), Some(100))),
+                    (("v1", 1).into(), (0, Some(150))),
+                    (("v2", 2).into(), (0, Some(100))),
                 ]
                 .into(),
                 true,
@@ -237,7 +268,7 @@ mod tests {
         ];
         for case in cases {
             assert_eq!(
-                symbol_extents_in_bounds(
+                extents_in_bounds(
                     &MaybeVersionDep::ByVersion(case.0.into()),
                     &MaybeVersionDep::ByVersion(case.1.into())
                 )
@@ -252,23 +283,23 @@ mod tests {
         let cases: [(VersionDep<_>, _, bool); 3] = [
             (
                 [("v1".into(), (0, Some(100))), ("v2".into(), (0, Some(100)))].into(),
-                (0.into(), Some(100)),
+                (0, Some(100)),
                 true,
             ),
             (
                 [("v1".into(), (0, Some(50))), ("v2".into(), (0, Some(100)))].into(),
-                (0.into(), Some(100)),
+                (0, Some(100)),
                 false,
             ),
             (
                 [("v1".into(), (0, Some(100))), ("v2".into(), (0, Some(50)))].into(),
-                (0.into(), Some(100)),
+                (0, Some(100)),
                 false,
             ),
         ];
         for case in cases {
             assert_eq!(
-                symbol_extents_in_bounds(
+                extents_in_bounds(
                     &MaybeVersionDep::ByVersion(case.0.into()),
                     &MaybeVersionDep::Common(case.1)
                 )
@@ -283,35 +314,23 @@ mod tests {
         let cases: [(_, VersionDep<_>, bool); 3] = [
             (
                 (0, Some(100)),
-                [
-                    ("v1".into(), (0.into(), Some(100))),
-                    ("v2".into(), (0.into(), Some(100))),
-                ]
-                .into(),
+                [("v1".into(), (0, Some(100))), ("v2".into(), (0, Some(100)))].into(),
                 true,
             ),
             (
                 (0, Some(100)),
-                [
-                    ("v1".into(), (0.into(), Some(150))),
-                    ("v2".into(), (0.into(), Some(100))),
-                ]
-                .into(),
+                [("v1".into(), (0, Some(150))), ("v2".into(), (0, Some(100)))].into(),
                 false,
             ),
             (
                 (0, Some(100)),
-                [
-                    ("v1".into(), (0.into(), Some(100))),
-                    ("v2".into(), (0.into(), Some(150))),
-                ]
-                .into(),
+                [("v1".into(), (0, Some(100))), ("v2".into(), (0, Some(150)))].into(),
                 false,
             ),
         ];
         for case in cases {
             assert_eq!(
-                symbol_extents_in_bounds(
+                extents_in_bounds(
                     &MaybeVersionDep::Common(case.0),
                     &MaybeVersionDep::ByVersion(case.1.into())
                 )
@@ -324,12 +343,37 @@ mod tests {
     #[test]
     fn test_common_bounds_and_extents() {
         let cases = [
-            ((0, Some(100)), (0.into(), Some(100)), true),
-            ((0, Some(100)), (0.into(), Some(150)), false),
+            ((0, Some(100)), (0, Some(100)), true),
+            ((0, Some(100)), (0, Some(150)), false),
         ];
         for case in cases {
             assert_eq!(
-                symbol_extents_in_bounds(
+                extents_in_bounds(
+                    &MaybeVersionDep::Common(case.0),
+                    &MaybeVersionDep::Common(case.1)
+                )
+                .is_none(),
+                case.2
+            );
+        }
+    }
+
+    #[test]
+    fn test_extents_with_linkable() {
+        let cases = [
+            ((0, Some(100)), (Linkable::from([0]), Some(100)), true),
+            ((0, Some(100)), (Linkable::from([0]), Some(150)), false),
+            (
+                (0, Some(100)),
+                (Linkable::from([0, 10, 50]), Some(50)),
+                true,
+            ),
+            ((0, Some(100)), (Linkable::from([0, 60]), Some(50)), false),
+            ((0, Some(100)), (Linkable::from([100, 0]), Some(50)), false),
+        ];
+        for case in cases {
+            assert_eq!(
+                extents_in_bounds(
                     &MaybeVersionDep::Common(case.0),
                     &MaybeVersionDep::Common(case.1)
                 )

--- a/src/data_formats/symgen_yml/merge.rs
+++ b/src/data_formats/symgen_yml/merge.rs
@@ -636,7 +636,7 @@ impl SymGen {
             // In subregion or no block name, so try to infer the block based on the symbol address
             let mut block_matches: BlockMatches<InferBlockMatch<_>> = BlockMatches::None;
             for (bname, block) in self.iter_mut() {
-                if bounds::block_contains(block, &to_add.symbol) {
+                if bounds::block_contains_symbol(block, &to_add.symbol) {
                     block_matches.add((subregion_path, &bname.val, block));
                 }
             }

--- a/src/data_formats/symgen_yml/symgen.rs
+++ b/src/data_formats/symgen_yml/symgen.rs
@@ -462,7 +462,7 @@ impl Sort for Block {
 ///
 /// At its core, a [`SymGen`] is just a mapping between block names and [`Block`]s, along with
 /// convenient methods for manipulating the data within those [`Block`]s.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct SymGen(BTreeMap<OrdString, Block>);
 
 impl SymGen {

--- a/src/data_formats/symgen_yml/symgen.rs
+++ b/src/data_formats/symgen_yml/symgen.rs
@@ -5,8 +5,9 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Display, Formatter};
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::ops::Deref;
+use std::path::{Path, PathBuf};
 use std::slice::SliceIndex;
 
 use regex::{Captures, Regex};
@@ -14,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_yaml;
 use syn::{self, LitStr};
 
-use super::error::{Error, Result};
+use super::error::{Error, Result, SubregionError};
 use super::types::*;
 
 /// Specifies how integers should be formatted during serialization.
@@ -290,6 +291,9 @@ impl SymbolList {
     pub fn push(&mut self, value: Symbol) {
         self.0.push(value)
     }
+    pub fn append(&mut self, other: &mut SymbolList) {
+        self.0.append(&mut other.0)
+    }
 }
 
 impl Deref for SymbolList {
@@ -346,6 +350,9 @@ pub struct Block {
     pub description: Option<String>,
 
     // Symbols
+    /// List of subregions.
+    #[serde(skip_serializing_if = "option_vec_is_empty")]
+    pub subregions: Option<Vec<Subregion>>,
     /// List of function symbols.
     pub functions: SymbolList,
     /// List of data symbols.
@@ -375,6 +382,53 @@ impl Block {
         // Init symbols
         self.functions.init(&ctx);
         self.data.init(&ctx);
+    }
+    /// Recursively resolves the contents of all [`Subregion`]s in the [`Block`].
+    ///
+    /// [`Subregion`]s are read from files using `file_opener`, with file paths based on the root
+    /// directory specified by `dir_path`.
+    pub fn resolve_subregions<P, R, F>(&mut self, dir_path: P, file_opener: F) -> Result<()>
+    where
+        P: AsRef<Path>,
+        R: Read,
+        F: Fn(&Path) -> io::Result<R> + Copy,
+    {
+        if let Some(subregions) = &mut self.subregions {
+            for s in subregions.iter_mut() {
+                s.resolve(&dir_path, file_opener)?;
+                // Recursively resolve
+                let subdir_path = dir_path.as_ref().join(Subregion::subregion_dir(&s.name));
+                // Explicitly block symlinks, which could lead to infinite recursion.
+                // If the path itself is invalid, just carry on and let file_opener deal with it.
+                // Note that the documentation on is_symlink() is a bit ambiguous, but this method
+                // (at least on Unix) will still follow symlinks on the path to get to the file,
+                // it just won't follow the file's link if the file itself is a symlink.
+                if subdir_path.is_symlink() {
+                    return Err(Error::Subregion(SubregionError::Symlink(subdir_path)));
+                }
+                s.contents
+                    .as_mut()
+                    .expect("subregion not resolved after Subregion::resolve()")
+                    .resolve_subregions(&subdir_path, file_opener)?;
+            }
+        }
+        Ok(())
+    }
+    /// Moves all symbols within [`Subregion`]s into the [`Block`]'s main symbol lists, destroying
+    /// the [`Subregion`]s in the process.
+    pub fn collapse_subregions(&mut self) {
+        if let Some(subregions) = self.subregions.take() {
+            for s in subregions {
+                if let Some(mut symgen) = s.contents {
+                    // Recursively collapse
+                    symgen.collapse_subregions();
+                    for blocks in symgen.blocks_mut() {
+                        self.functions.append(&mut blocks.functions);
+                        self.data.append(&mut blocks.data);
+                    }
+                }
+            }
+        }
     }
     /// Gets the extent occupied by the [`Block`], possibly by version, represented as
     /// address-length pairs.
@@ -460,6 +514,14 @@ impl Ord for Block {
 
 impl Sort for Block {
     fn sort(&mut self) {
+        if let Some(subregions) = &mut self.subregions {
+            subregions.sort();
+            for s in subregions {
+                if let Some(contents) = &mut s.contents {
+                    contents.sort();
+                }
+            }
+        }
         self.functions.sort();
         self.data.sort();
     }
@@ -707,6 +769,30 @@ impl SymGen {
         String::from_utf8(bytes).map_err(Error::FromUtf8)
     }
 
+    /// Recursively resolves the contents of all [`Subregion`]s in all [`Block`]s within the
+    /// [`SymGen`].
+    ///
+    /// [`Subregion`]s are read from files using `file_opener`, with file paths based on the root
+    /// directory specified by `dir_path`.
+    pub fn resolve_subregions<P, R, F>(&mut self, dir_path: P, file_opener: F) -> Result<()>
+    where
+        P: AsRef<Path>,
+        R: Read,
+        F: Fn(&Path) -> io::Result<R> + Copy,
+    {
+        for block in self.0.values_mut() {
+            block.resolve_subregions(&dir_path, file_opener)?;
+        }
+        Ok(())
+    }
+    /// Moves all symbols within [`Subregion`]s into their parent [`Block`]s' main symbol lists,
+    /// destroying the [`Subregion`]s in the process.
+    pub fn collapse_subregions(&mut self) {
+        for block in self.0.values_mut() {
+            block.collapse_subregions();
+        }
+    }
+
     /// Expands the versions of all the addresses and lengths contained within the [`SymGen`]
     /// (in all the contained [`Block`]s).
     ///
@@ -808,6 +894,130 @@ impl Sort for SymGen {
         for block in self.0.values_mut() {
             block.sort();
         }
+    }
+}
+
+/// A subsidiary [`SymGen`] (a collection of named [`Block`]s) nested within a parent [`Block`].
+///
+/// A minimal [`Subregion`] consists of just a file name, which may or may not correspond to a
+/// valid file. A [`Subregion`] can be "resolved" by associating a concrete [`SymGen`] with it,
+/// typically by reading the contents of a file corresponding to the [`Subregion`]'s name.
+/// The contents of a resolved [`Subregion`] are logically grouped together, but are ultimately
+/// owned by the parent [`Block`].
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Subregion {
+    pub name: PathBuf,
+    // This doesn't actually need to be a Box to compile, but it's more space-efficient for the
+    // common case of an unresolved subregion. It also allows for the null pointer optimization.
+    #[serde(skip)]
+    pub contents: Option<Box<SymGen>>,
+}
+
+impl Subregion {
+    /// Get the canonical directory containing the subregion files for a given parent file path.
+    pub fn subregion_dir<P: AsRef<Path>>(filepath: P) -> PathBuf {
+        filepath.as_ref().with_extension("")
+    }
+
+    /// Whether this [`Subregion`] is associated with a concrete [`SymGen`].
+    pub fn is_resolved(&self) -> bool {
+        self.contents.is_some()
+    }
+
+    /// Resolve this [`Subregion`] with the contents of a file.
+    ///
+    /// The file is read using `file_opener`, with the file path derived from the directory
+    /// specified by `dir_path` and the [`Subregion`]'s name.
+    pub fn resolve<P, R, F>(&mut self, dir_path: P, file_opener: F) -> Result<()>
+    where
+        P: AsRef<Path>,
+        R: Read,
+        F: Fn(&Path) -> io::Result<R> + Copy,
+    {
+        if self.name.components().count() != 1 {
+            return Err(Error::Subregion(SubregionError::InvalidPath(
+                self.name.clone(),
+            )));
+        }
+        let filepath = dir_path.as_ref().join(&self.name);
+        let rdr = file_opener(&filepath).map_err(|e| {
+            Error::Subregion(SubregionError::SymGen((
+                filepath.clone(),
+                Box::new(Error::Io(e)),
+            )))
+        })?;
+        self.contents = Some(Box::new(SymGen::read(rdr).map_err(|e| {
+            Error::Subregion(SubregionError::SymGen((filepath.clone(), Box::new(e))))
+        })?));
+        Ok(())
+    }
+    /// Unresolves this [`Subregion`] by discarding its contents, if any.
+    pub fn unresolve(&mut self) {
+        self.contents = None;
+    }
+}
+
+impl<P> From<P> for Subregion
+where
+    P: AsRef<Path>,
+{
+    fn from(val: P) -> Self {
+        // unresolved subregion
+        Subregion {
+            name: val.as_ref().to_owned(),
+            contents: None,
+        }
+    }
+}
+
+impl<P> PartialEq<P> for Subregion
+where
+    P: AsRef<Path>,
+{
+    fn eq(&self, other: &P) -> bool {
+        self.name == other.as_ref()
+    }
+}
+
+impl PartialOrd for Subregion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Subregion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+#[cfg(test)]
+pub mod test_utils {
+    use super::*;
+    use std::collections::HashMap;
+    use std::io;
+    use std::path::{Path, PathBuf};
+
+    pub fn get_symgen_with_subregions<P: AsRef<Path>>(
+        root: &str,
+        subregions: &[(P, &str)],
+    ) -> SymGen {
+        let mut symgen = SymGen::read(root.as_bytes()).expect("Failed to read SymGen");
+        let root_dir = Path::new(file!());
+        let file_map: HashMap<PathBuf, String> = subregions
+            .iter()
+            .map(|(p, s)| (root_dir.join(p.as_ref()), s.to_string()))
+            .collect();
+        symgen
+            .resolve_subregions(root_dir, |p| {
+                file_map
+                    .get(p)
+                    .map(|s| s.as_bytes())
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, p.to_string_lossy()))
+            })
+            .expect("Failed to resolve subregions");
+        symgen
     }
 }
 
@@ -1213,6 +1423,7 @@ mod tests {
                 address: addresses.clone(),
                 length: addresses.clone(),
                 description: None,
+                subregions: None,
                 functions: symbols.clone(),
                 data: symbols.clone(),
             };
@@ -1223,8 +1434,14 @@ mod tests {
 
         #[test]
         fn test_init_sort() {
-            let block = get_sorted_block();
+            let mut block = get_sorted_block();
+            // Add some subregions manually
+            block.subregions = Some(vec!["subregion2".into(), "subregion1".into()]);
+            block.sort();
+
             let (_, final_versions, _, final_addresses, _, final_symbols) = get_block_data();
+            let mut final_subregions = block.subregions.clone().unwrap();
+            final_subregions.sort();
             assert_eq!(
                 &block,
                 &Block {
@@ -1232,6 +1449,7 @@ mod tests {
                     address: final_addresses.clone(),
                     length: final_addresses.clone(),
                     description: None,
+                    subregions: Some(final_subregions.clone()),
                     functions: final_symbols.clone(),
                     data: final_symbols.clone(),
                 }
@@ -1281,6 +1499,7 @@ mod tests {
                     address,
                     length,
                     description,
+                    subregions: None,
                     functions: expanded_symbols.clone(),
                     data: expanded_symbols.clone(),
                 }
@@ -1455,6 +1674,7 @@ other:
                                 [(("v1", 0).into(), 0x100000), (("v2", 1).into(), 0x100004)].into(),
                             ),
                             description: Some("foo".to_string()),
+                            subregions: None,
                             functions: [
                                 Symbol {
                                     name: "fn1".to_string(),
@@ -1506,6 +1726,7 @@ other:
                             address: MaybeVersionDep::Common(0x2100000),
                             length: MaybeVersionDep::Common(0x100000),
                             description: None,
+                            subregions: None,
                             functions: [Symbol {
                                 name: "fn3".to_string(),
                                 address: MaybeVersionDep::Common(0x2100000.into()),
@@ -1590,6 +1811,7 @@ other:
                                 .into(),
                             ),
                             description: Some("foo".to_string()),
+                            subregions: None,
                             functions: [
                                 Symbol {
                                     name: "fn1".to_string(),
@@ -1641,6 +1863,7 @@ other:
                             address: MaybeVersionDep::Common(0x2100000FFFF),
                             length: MaybeVersionDep::Common(0x100000FFFF),
                             description: None,
+                            subregions: None,
                             functions: [Symbol {
                                 name: "fn3".to_string(),
                                 address: MaybeVersionDep::Common(0x2100000FFFF.into()),
@@ -1786,6 +2009,262 @@ other:
                 assert_eq!(data_iter.next().as_ref(), Some(e));
             }
             assert_eq!(data_iter.next(), None);
+        }
+    }
+
+    #[cfg(test)]
+    mod subregion_tests {
+        use super::*;
+
+        #[test]
+        fn test_subregion_dir() {
+            assert_eq!(Subregion::subregion_dir("test.yml"), Path::new("test"));
+            assert_eq!(
+                Subregion::subregion_dir("path/to/test.yml"),
+                Path::new("path/to/test")
+            );
+            assert_eq!(
+                Subregion::subregion_dir("/abs/path/to/test.yml"),
+                Path::new("/abs/path/to/test")
+            );
+        }
+
+        fn get_basic_subregion<P: AsRef<Path>>(name: P) -> (Subregion, String) {
+            let text = format!(
+                r#"{}:
+                address: 0x0
+                length: 0x100
+                functions: []
+                data: []
+                "#,
+                Subregion::subregion_dir(&name).display()
+            );
+            let sub = Subregion {
+                name: name.as_ref().to_owned(),
+                contents: Some(Box::new(
+                    SymGen::read(text.as_bytes()).expect("Failed to read SymGen"),
+                )),
+            };
+            (sub, text)
+        }
+
+        fn get_parent_subregion<P: AsRef<Path>>(
+            name: P,
+            subregions: &[(P, Subregion)],
+        ) -> (Subregion, String) {
+            let text = format!(
+                r#"{}:
+                address: 0x0
+                length: 0x100
+                subregions: {:?}
+                functions: []
+                data: []
+                "#,
+                Subregion::subregion_dir(&name).display(),
+                subregions
+                    .iter()
+                    .map(|(p, _)| p.as_ref().display())
+                    .collect::<Vec<_>>()
+            );
+            let mut sub = Subregion {
+                name: name.as_ref().to_owned(),
+                contents: Some(Box::new(
+                    SymGen::read(text.as_bytes()).expect("Failed to read SymGen"),
+                )),
+            };
+            sub.contents
+                .as_mut()
+                .unwrap()
+                .blocks_mut()
+                .next()
+                .unwrap()
+                .subregions = Some(subregions.iter().map(|(_, s)| s.clone()).collect());
+            (sub, text)
+        }
+
+        #[test]
+        fn test_resolve() {
+            let name = "sub.yml";
+            let (resolved, text) = get_basic_subregion(name);
+            let mut subregion = Subregion::from(name);
+            assert!(!subregion.is_resolved());
+            subregion
+                .resolve("", |_| Ok(text.as_bytes()))
+                .expect("Failed to resolve subregion");
+            assert!(subregion.is_resolved());
+            assert_eq!(&subregion, &resolved);
+        }
+
+        #[test]
+        fn test_invalid_path() {
+            let mut subregion = Subregion::from("dir/sub.yml");
+            let res = subregion.resolve("", |_| Ok("".as_bytes()));
+            assert!(matches!(
+                res,
+                Err(Error::Subregion(SubregionError::InvalidPath(_)))
+            ));
+        }
+
+        #[test]
+        fn test_recursive_resolve_subregions() {
+            let (name1, name2, name3) = ("sub1.yml", "sub2.yml", "sub3.yml");
+            let mut symgen = SymGen::read(
+                format!(
+                    r#"main:
+                    address: 0x0
+                    length: 0x100
+                    subregions:
+                      - {}
+                      - {}
+                    functions: []
+                    data: []
+                    "#,
+                    name1, name2
+                )
+                .as_bytes(),
+            )
+            .expect("Failed to read SymGen");
+            let (sub1, text1) = get_basic_subregion(name1);
+            let (sub3, text3) = get_basic_subregion(name3);
+            let (sub2, text2) = get_parent_subregion(name2, &[(name3, sub3)]);
+            // Use this source file path as the root_dir in order to ensure that none of the test
+            // subregion paths are actually real, and thus that the recursive symlink check will
+            // never be set off. Technically this depends on the working directory when the test
+            // binary is run, but this should be a good enough safeguard...
+            let root_dir = Path::new(file!());
+            let file_map: HashMap<PathBuf, String> = [
+                (root_dir.join(name1), text1),
+                (root_dir.join(name2), text2),
+                (
+                    root_dir.join(Subregion::subregion_dir(name2)).join(name3),
+                    text3,
+                ),
+            ]
+            .into();
+
+            symgen
+                .resolve_subregions(root_dir, |p| {
+                    file_map
+                        .get(p)
+                        .map(|s| s.as_bytes())
+                        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, p.to_string_lossy()))
+                })
+                .expect("Failed to resolve subregions");
+
+            let block = symgen.blocks().next().unwrap();
+            let block_subregions: Vec<&Subregion> = block
+                .subregions
+                .as_ref()
+                .expect("Block has no subregions?")
+                .iter()
+                .collect();
+            assert_eq!(block_subregions[0], &sub1);
+            assert_eq!(block_subregions[1], &sub2);
+        }
+
+        #[test]
+        fn test_recursive_collapse_subregions() {
+            let (name1, name2, name3) = ("sub1.yml", "sub2.yml", "sub3.yml");
+            let mut symgen = SymGen::read(
+                format!(
+                    r#"main:
+                    address: 0x0
+                    length: 0x100
+                    subregions:
+                      - {}
+                      - {}
+                    functions:
+                      - name: fn0
+                        address: 0x0
+                    data: []
+                    "#,
+                    name1, name2
+                )
+                .as_bytes(),
+            )
+            .expect("Failed to read SymGen");
+            let text1 = r#"sub1:
+                address: 0x0
+                length: 0x100
+                functions: []
+                data:
+                  - name: data1
+                    address: 0x10
+                    length: 0x4
+                "#;
+            let text2 = r#"sub2:
+                address: 0x0
+                length: 0x100
+                subregions:
+                  - sub3.yml
+                functions:
+                  - name: fn2
+                    address: 0x8
+                data:
+                  - name: data2
+                    address: 0x20
+                    length: 0x4
+                "#;
+            let text3 = r#"sub3:
+                address: 0x0
+                length: 0x100
+                functions:
+                  - name: fn3
+                    address: 0xC
+                data:
+                  - name: data3
+                    address: 0x30
+                    length: 0x4
+                "#;
+
+            let collapsed_symgen = SymGen::read(
+                r#"main:
+                address: 0x0
+                length: 0x100
+                functions:
+                  - name: fn0
+                    address: 0x0
+                  - name: fn2
+                    address: 0x8
+                  - name: fn3
+                    address: 0xC
+                data:
+                  - name: data1
+                    address: 0x10
+                    length: 0x4
+                  - name: data2
+                    address: 0x20
+                    length: 0x4
+                  - name: data3
+                    address: 0x30
+                    length: 0x4
+                "#
+                .as_bytes(),
+            )
+            .expect("Failed to read SymGen");
+
+            let root_dir = Path::new(file!());
+            let file_map: HashMap<PathBuf, String> = [
+                (root_dir.join(name1), text1.to_owned()),
+                (root_dir.join(name2), text2.to_owned()),
+                (
+                    root_dir.join(Subregion::subregion_dir(name2)).join(name3),
+                    text3.to_owned(),
+                ),
+            ]
+            .into();
+
+            symgen
+                .resolve_subregions(root_dir, |p| {
+                    file_map
+                        .get(p)
+                        .map(|s| s.as_bytes())
+                        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, p.to_string_lossy()))
+                })
+                .expect("Failed to resolve subregions");
+
+            symgen.collapse_subregions();
+            assert_eq!(&symgen, &collapsed_symgen);
         }
     }
 }

--- a/src/data_formats/symgen_yml/symgen.rs
+++ b/src/data_formats/symgen_yml/symgen.rs
@@ -315,6 +315,13 @@ impl Sort for SymbolList {
     }
 }
 
+fn option_vec_is_empty<T>(opt: &Option<Vec<T>>) -> bool {
+    match opt {
+        None => true,
+        Some(v) => v.is_empty(),
+    }
+}
+
 /// A contiguous block of [`Symbol`]s in a `resymgen` symbol table, with some metadata.
 ///
 /// Like its consituent [`Symbol`]s, a [`Block`] contains an address, a length, and a description.
@@ -328,7 +335,7 @@ impl Sort for SymbolList {
 pub struct Block {
     // Metadata
     /// List of [`Version`]s relevant to the block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "option_vec_is_empty")]
     pub versions: Option<Vec<Version>>,
     /// The starting address of the block in memory.
     pub address: MaybeVersionDep<Uint>,

--- a/src/data_formats/symgen_yml/symgen.rs
+++ b/src/data_formats/symgen_yml/symgen.rs
@@ -1194,6 +1194,7 @@ mod tests {
         }
     }
 
+    #[cfg(test)]
     mod block_tests {
         use super::*;
 
@@ -1380,6 +1381,7 @@ mod tests {
         }
     }
 
+    #[cfg(test)]
     mod symgen_tests {
         use super::*;
 

--- a/src/data_formats/symgen_yml/symgen.rs
+++ b/src/data_formats/symgen_yml/symgen.rs
@@ -1,5 +1,8 @@
 //! Defines the `resymgen` YAML format and its programmatic representation, the [`SymGen`] struct.
 
+pub mod cursor;
+pub use cursor::{BlockCursor, SymGenCursor};
+
 use std::any;
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -498,6 +501,11 @@ impl Block {
         let version = self.version(version_name);
         self.data.iter().realize(version)
     }
+
+    /// Returns a [`BlockCursor`] for this [`Block`] with the given block name and file path.
+    pub fn cursor<'s, 'p>(&'s self, name: &'s str, path: &'p Path) -> BlockCursor<'s, 'p> {
+        BlockCursor::new(self, name, Cow::Borrowed(path))
+    }
 }
 
 impl PartialOrd for Block {
@@ -868,6 +876,11 @@ impl SymGen {
     pub fn data_realized(&self, version_name: &str) -> impl Iterator<Item = RealizedSymbol> + '_ {
         let v = String::from(version_name);
         self.blocks().flat_map(move |b| b.data_realized(&v))
+    }
+
+    /// Returns a [`SymGenCursor`] for this [`SymGen`] with the given file path.
+    pub fn cursor<'s, 'p>(&'s self, path: &'p Path) -> SymGenCursor<'s, 'p> {
+        SymGenCursor::new(self, Cow::Borrowed(path))
     }
 }
 

--- a/src/data_formats/symgen_yml/symgen/cursor.rs
+++ b/src/data_formats/symgen_yml/symgen/cursor.rs
@@ -1,0 +1,709 @@
+//! Cursors for convenient immutable access to [`SymGen`]s and [`Block`]s with recursive subregions.
+
+use std::borrow::Cow;
+use std::collections::{HashSet, VecDeque};
+use std::path::Path;
+use std::rc::Rc;
+
+use super::{Block, OrdString, Subregion, SymGen};
+
+/// A cursor into a [`SymGen`] that allows traversal into nested blocks and subregions while
+/// keeping track of associated nested file paths.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SymGenCursor<'s, 'p> {
+    symgen: &'s SymGen,
+    path: Rc<Cow<'p, Path>>,
+}
+
+impl<'s, 'p> SymGenCursor<'s, 'p> {
+    /// Creates a new [`SymGenCursor`] for the given [`SymGen`] and path.
+    pub fn new(symgen: &'s SymGen, path: Cow<'p, Path>) -> Self {
+        SymGenCursor {
+            symgen,
+            path: Rc::new(path),
+        }
+    }
+    /// Gets the underlying [`SymGen`] associated with this cursor.
+    pub fn symgen(&self) -> &'s SymGen {
+        self.symgen
+    }
+    /// Gets the underlying path associated with this cursor.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn block_cursor(&self, name: &'s str, block: &'s Block) -> BlockCursor<'s, 'p> {
+        BlockCursor {
+            block,
+            name,
+            path: Rc::clone(&self.path),
+        }
+    }
+    /// Gets a [`BlockCursor`] for the [`Block`] associated with `key`, if present.
+    ///
+    /// This function is similar to `SymGen::get`, except it returns a [`BlockCursor`] rather
+    /// than a [`Block`] reference.
+    pub fn get(&self, key: &'s OrdString) -> Option<BlockCursor<'s, 'p>> {
+        self.symgen
+            .get(key)
+            .map(|block| self.block_cursor(&key.val, block))
+    }
+    /// Returns an [`Iterator`] over [`BlockCursor`]s for each [`Block`] in the [`SymGen`].
+    ///
+    /// This function is similar to `SymGen::blocks`, except it returns an iterator over
+    /// [`BlockCursor`]s rather than [`Block`] references.
+    pub fn blocks(&self) -> impl Iterator<Item = BlockCursor<'s, 'p>> + '_ {
+        self.symgen
+            .iter()
+            .map(move |(bname, block)| self.block_cursor(&bname.val, block))
+    }
+
+    /// Returns an [`Iterator`] over [`SymGenCursor`]s for each resolved [`Subregion`] within any
+    /// of the [`Block`]s in the [`SymGen`].
+    ///
+    /// If multiple [`Block`]s contain a [`Subregion`] with the same path, the iterator will only
+    /// yield a cursor for the first instance of the [`Subregion`].
+    pub fn subregions(&self) -> impl Iterator<Item = SymGenCursor<'s, 'p>> + '_ {
+        let mut paths_seen: HashSet<Rc<Cow<'p, Path>>> = [Rc::clone(&self.path)].into();
+        self.symgen
+            .blocks()
+            .flat_map(|block| block.subregions.as_deref().unwrap_or_default().iter())
+            .filter_map(move |subregion| {
+                if let Some(symgen) = &subregion.contents {
+                    let path = Rc::new(Cow::Owned(
+                        Subregion::subregion_dir(self.path()).join(&subregion.name),
+                    ));
+                    if paths_seen.insert(Rc::clone(&path)) {
+                        return Some(SymGenCursor { symgen, path });
+                    }
+                }
+                None
+            })
+    }
+    /// Whether or not the [`SymGen`] has any [`Block`]s containing at least one resolved
+    /// [`Subregion`].
+    pub fn has_subregions(&self) -> bool {
+        self.symgen
+            .blocks()
+            .flat_map(|block| block.subregions.as_deref().unwrap_or_default().iter())
+            .any(|subregion| subregion.contents.is_some())
+    }
+    /// Returns an [`Iterator`] over [`SymGenCursor`]s for all [`SymGen`]s nested within this
+    /// cursor's [`SymGen`] (i.e., in subregions), including this cursor itself.
+    ///
+    /// Traversal is performed in breadth-first order.
+    pub fn btraverse(self) -> SymGenBTraverser<'s, 'p> {
+        SymGenBTraverser {
+            queue: VecDeque::from([self]),
+        }
+    }
+    /// Returns an [`Iterator`] over [`SymGenCursor`]s for all [`SymGen`]s nested within this
+    /// cursor's [`SymGen`] (i.e., in subregions), including this cursor itself.
+    ///
+    /// Traversal is performed in depth-first order. Note that if order is not important, `btraverse` should be preferred over `dtraverse`, as it is slightly more efficient.
+    pub fn dtraverse(self) -> SymGenDTraverser<'s, 'p> {
+        SymGenDTraverser { stack: vec![self] }
+    }
+}
+
+/// Performs breadth-first traversal over a nested hierarchy of [`SymGen`]s.
+pub struct SymGenBTraverser<'s, 'p> {
+    queue: VecDeque<SymGenCursor<'s, 'p>>,
+}
+
+impl<'s, 'p> Iterator for SymGenBTraverser<'s, 'p> {
+    type Item = SymGenCursor<'s, 'p>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.queue.pop_front().map(|cursor| {
+            self.queue.extend(cursor.subregions());
+            cursor
+        })
+    }
+}
+
+/// Performs depth-first traversal over a nested hierarchy of [`SymGen`]s.
+pub struct SymGenDTraverser<'s, 'p> {
+    stack: Vec<SymGenCursor<'s, 'p>>,
+}
+
+impl<'s, 'p> Iterator for SymGenDTraverser<'s, 'p> {
+    type Item = SymGenCursor<'s, 'p>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.stack.pop().map(|cursor| {
+            let subregions: Vec<_> = cursor.subregions().collect();
+            self.stack.reserve(subregions.len());
+            self.stack.extend(subregions.into_iter().rev());
+            cursor
+        })
+    }
+}
+
+/// A cursor into a [`Block`] that allows traversal into nested subregions and blocks while
+/// keeping track of associated block names and nested file paths.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct BlockCursor<'s, 'p> {
+    block: &'s Block,
+    name: &'s str,
+    path: Rc<Cow<'p, Path>>,
+}
+
+impl<'s, 'p> BlockCursor<'s, 'p> {
+    /// Creates a new [`BlockCursor`] for the given [`Block`], block name, and path.
+    pub fn new(block: &'s Block, name: &'s str, path: Cow<'p, Path>) -> Self {
+        BlockCursor {
+            block,
+            name,
+            path: Rc::new(path),
+        }
+    }
+    /// Gets the underlying [`Block`] associated with this cursor.
+    pub fn block(&self) -> &'s Block {
+        self.block
+    }
+    /// Gets the underlying block name associated with this cursor.
+    pub fn name(&self) -> &'s str {
+        self.name
+    }
+    /// Gets the underlying path associated with this cursor.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns an [`Iterator`] over [`SymGenCursor`]s for each resolved [`Subregion`] in the
+    /// [`Block`].
+    pub fn subregions(&self) -> impl Iterator<Item = SymGenCursor<'s, 'p>> + '_ {
+        self.block
+            .subregions
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(move |subregion| {
+                subregion.contents.as_ref().map(|symgen| {
+                    SymGenCursor::new(
+                        symgen,
+                        Cow::Owned(Subregion::subregion_dir(self.path()).join(&subregion.name)),
+                    )
+                })
+            })
+    }
+    /// Whether or not the [`Block`] contains at least one resolved [`Subregion`].
+    pub fn has_subregions(&self) -> bool {
+        self.block
+            .subregions
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .any(|subregion| subregion.contents.is_some())
+    }
+
+    /// Returns an [`Iterator`] over [`BlockCursor`]s for [`Block`]s within all resolved
+    /// [`Subregion`]s in the [`Block`].
+    pub fn subblocks(&self) -> impl Iterator<Item = BlockCursor<'s, 'p>> + '_ {
+        self.block
+            .subregions
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(move |subregion| {
+                subregion.contents.as_ref().map(|symgen| {
+                    let path = Rc::new(Cow::Owned(
+                        Subregion::subregion_dir(self.path()).join(&subregion.name),
+                    ));
+                    symgen.iter().map(move |(bname, block)| BlockCursor {
+                        block,
+                        name: &bname.val,
+                        path: Rc::clone(&path),
+                    })
+                })
+            })
+            .flatten()
+    }
+    /// Returns an [`Iterator`] over [`BlockCursor`]s for all [`Block`]s nested within this
+    /// cursor's [`Block`] (i.e., in subregions), including this cursor itself.
+    ///
+    /// Traversal is performed in breadth-first order.
+    pub fn btraverse(self) -> BlockBTraverser<'s, 'p> {
+        BlockBTraverser {
+            queue: VecDeque::from([self]),
+        }
+    }
+    /// Returns an [`Iterator`] over [`BlockCursor`]s for all [`Block`]s nested within this
+    /// cursor's [`Block`] (i.e., in subregions), including this cursor itself.
+    ///
+    /// Traversal is performed in depth-first order. Note that if order is not important, `btraverse` should be preferred over `dtraverse`, as it is slightly more efficient.
+    pub fn dtraverse(self) -> BlockDTraverser<'s, 'p> {
+        BlockDTraverser { stack: vec![self] }
+    }
+}
+
+/// Performs breadth-first traversal over a nested hierarchy of [`Block`]s.
+pub struct BlockBTraverser<'s, 'p> {
+    queue: VecDeque<BlockCursor<'s, 'p>>,
+}
+
+impl<'s, 'p> Iterator for BlockBTraverser<'s, 'p> {
+    type Item = BlockCursor<'s, 'p>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.queue.pop_front().map(|cursor| {
+            self.queue.extend(cursor.subblocks());
+            cursor
+        })
+    }
+}
+
+/// Performs depth-first traversal over a nested hierarchy of [`Block`]s.
+pub struct BlockDTraverser<'s, 'p> {
+    stack: Vec<BlockCursor<'s, 'p>>,
+}
+
+impl<'s, 'p> Iterator for BlockDTraverser<'s, 'p> {
+    type Item = BlockCursor<'s, 'p>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.stack.pop().map(|cursor| {
+            let subblocks: Vec<_> = cursor.subblocks().collect();
+            self.stack.reserve(subblocks.len());
+            self.stack.extend(subblocks.into_iter().rev());
+            cursor
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_utils;
+    use super::*;
+
+    fn get_subregion<'s>(symgen: &'s SymGen, block_name: &str, subregion_idx: usize) -> &'s SymGen {
+        symgen
+            .get(symgen.block_key(block_name).unwrap())
+            .unwrap()
+            .subregions
+            .as_ref()
+            .unwrap()[subregion_idx]
+            .contents
+            .as_ref()
+            .unwrap()
+            .as_ref()
+    }
+
+    fn get_block<'s>(symgen: &'s SymGen, block_name: &str) -> &'s Block {
+        symgen.get(symgen.block_key(block_name).unwrap()).unwrap()
+    }
+
+    fn get_test_symgen() -> SymGen {
+        test_utils::get_symgen_with_subregions(
+            r#"main:
+            address: 0x0
+            length: 0x100
+            subregions:
+              - sub1.yml
+              - sub2.yml
+            functions:
+              - name: main_fn
+                address: 0x80
+            data: []
+            "#,
+            &[
+                (
+                    "sub1.yml",
+                    r#"sub1:
+                    address: 0x40
+                    length: 0x40
+                    subregions:
+                      - sub3.yml
+                      - sub4.yml
+                    functions:
+                      - name: sub1_fn
+                        address: 0x40
+                    data: []
+                    "#,
+                ),
+                (
+                    "sub1/sub3.yml",
+                    r#"sub3:
+                    address: 0x60
+                    length: 0x20
+                    functions:
+                      - name: sub3_fn
+                        address: 0x64
+                    data:
+                      - name: sub3_data
+                        address: 0x60
+                        length: 0x4
+                    "#,
+                ),
+                (
+                    "sub1/sub4.yml",
+                    r#"sub4:
+                    address: 0x50
+                    length: 0x10
+                    functions:
+                      - name: sub4_fn
+                        address: 0x50
+                    data: []
+                    "#,
+                ),
+                (
+                    "sub2.yml",
+                    r#"
+                    sub2a:
+                      address: 0x0
+                      length: 0x40
+                      functions: []
+                      data:
+                        - name: sub2_data
+                          address: 0x0
+                          length: 0x4
+
+                    sub2b:
+                      address: 0xFC
+                      length: 0x4
+                      functions:
+                        - name: sub2_fn
+                          address: 0xFC
+                      data: []
+                    "#,
+                ),
+            ],
+        )
+    }
+
+    fn get_test_subregions(symgen: &SymGen) -> (&SymGen, &SymGen, &SymGen, &SymGen) {
+        let sub1 = get_subregion(&symgen, "main", 0);
+        let sub2 = get_subregion(&symgen, "main", 1);
+        let sub3 = get_subregion(&sub1, "sub1", 0);
+        let sub4 = get_subregion(&sub1, "sub1", 1);
+        (sub1, sub2, sub3, sub4)
+    }
+
+    fn get_test_blocks(symgen: &SymGen) -> (&Block, &Block, &Block, &Block, &Block, &Block) {
+        let (sub1_yml, sub2_yml, sub3_yml, sub4_yml) = get_test_subregions(symgen);
+        let main = get_block(symgen, "main");
+        let sub1 = get_block(sub1_yml, "sub1");
+        let sub2a = get_block(sub2_yml, "sub2a");
+        let sub2b = get_block(sub2_yml, "sub2b");
+        let sub3 = get_block(sub3_yml, "sub3");
+        let sub4 = get_block(sub4_yml, "sub4");
+        (main, sub1, sub2a, sub2b, sub3, sub4)
+    }
+
+    #[test]
+    fn test_symgen_and_block_cursors() {
+        let main = get_test_symgen();
+        let (sub1, sub2, sub3, sub4) = get_test_subregions(&main);
+        let scursor_main = main.cursor(Path::new("main.yml"));
+
+        // main.yml contents
+        assert_eq!(scursor_main.path(), Path::new("main.yml"));
+        assert_eq!(scursor_main.symgen(), &main);
+        let mut blocks_main = scursor_main.blocks();
+        let bcursor_main = blocks_main.next().unwrap();
+        assert!(blocks_main.next().is_none());
+
+        // main.yml::main contents
+        assert_eq!(bcursor_main.name(), "main");
+        assert_eq!(bcursor_main.path(), Path::new("main.yml"));
+        let mut subregions_main = bcursor_main.subregions();
+        let scursor_sub1 = subregions_main.next().unwrap();
+        let scursor_sub2 = subregions_main.next().unwrap();
+        assert!(subregions_main.next().is_none());
+
+        // main/sub1.yml contents
+        assert_eq!(scursor_sub1.path(), Path::new("main/sub1.yml"));
+        assert_eq!(scursor_sub1.symgen(), sub1);
+        let mut blocks_sub1 = scursor_sub1.blocks();
+        let bcursor_sub1 = blocks_sub1.next().unwrap();
+        assert!(blocks_sub1.next().is_none());
+
+        // main/sub1.yml::sub1 contents
+        assert_eq!(bcursor_sub1.name(), "sub1");
+        let mut subregions_sub1 = bcursor_sub1.subregions();
+        let scursor_sub3 = subregions_sub1.next().unwrap();
+        let scursor_sub4 = subregions_sub1.next().unwrap();
+        assert!(subregions_sub1.next().is_none());
+
+        // main/sub1/sub3.yml contents
+        assert_eq!(scursor_sub3.path(), Path::new("main/sub1/sub3.yml"));
+        assert_eq!(scursor_sub3.symgen(), sub3);
+        let mut blocks_sub3 = scursor_sub3.blocks();
+        let bcursor_sub3 = blocks_sub3.next().unwrap();
+        assert!(blocks_sub3.next().is_none());
+
+        // main/sub1/sub3.yml::sub3 contents
+        assert_eq!(bcursor_sub3.name(), "sub3");
+        assert!(bcursor_sub3.subregions().next().is_none());
+
+        // main/sub1/sub4.yml contents
+        assert_eq!(scursor_sub4.path(), Path::new("main/sub1/sub4.yml"));
+        assert_eq!(scursor_sub4.symgen(), sub4);
+        let mut blocks_sub4 = scursor_sub4.blocks();
+        let bcursor_sub4 = blocks_sub4.next().unwrap();
+        assert!(blocks_sub4.next().is_none());
+
+        // main/sub1/sub3.yml::sub4 contents
+        assert_eq!(bcursor_sub4.name(), "sub4");
+        assert!(bcursor_sub4.subregions().next().is_none());
+
+        // main/sub2.yml contents
+        assert_eq!(scursor_sub2.path(), Path::new("main/sub2.yml"));
+        assert_eq!(scursor_sub2.symgen(), sub2);
+        let mut blocks_sub2 = scursor_sub2.blocks();
+        let bcursor_sub2a = blocks_sub2.next().unwrap();
+        let bcursor_sub2b = blocks_sub2.next().unwrap();
+        assert!(blocks_sub2.next().is_none());
+
+        // main/sub2.yml::sub2a contents
+        assert_eq!(bcursor_sub2a.name(), "sub2a");
+        assert!(bcursor_sub2a.subregions().next().is_none());
+
+        // main/sub2.yml::sub2b contents
+        assert_eq!(bcursor_sub2b.name(), "sub2b");
+        assert!(bcursor_sub2b.subregions().next().is_none());
+    }
+
+    #[test]
+    fn test_symgen_cursor_subregions() {
+        let main = get_test_symgen();
+        let (sub1, sub2, sub3, sub4) = get_test_subregions(&main);
+        let cursor_main = main.cursor(Path::new("main.yml"));
+
+        // main.yml contents
+        assert_eq!(cursor_main.path(), Path::new("main.yml"));
+        assert_eq!(cursor_main.symgen(), &main);
+        let mut subregions_main = cursor_main.subregions();
+        let cursor_sub1 = subregions_main.next().unwrap();
+        let cursor_sub2 = subregions_main.next().unwrap();
+        assert!(subregions_main.next().is_none());
+
+        // main/sub1.yml contents
+        assert_eq!(cursor_sub1.path(), Path::new("main/sub1.yml"));
+        assert_eq!(cursor_sub1.symgen(), sub1);
+        let mut subregions_sub1 = cursor_sub1.subregions();
+        let cursor_sub3 = subregions_sub1.next().unwrap();
+        let cursor_sub4 = subregions_sub1.next().unwrap();
+        assert!(subregions_sub1.next().is_none());
+
+        // main/sub1/sub3.yml contents
+        assert_eq!(cursor_sub3.path(), Path::new("main/sub1/sub3.yml"));
+        assert_eq!(cursor_sub3.symgen(), sub3);
+        assert!(cursor_sub3.subregions().next().is_none());
+
+        // main/sub1/sub4.yml contents
+        assert_eq!(cursor_sub4.path(), Path::new("main/sub1/sub4.yml"));
+        assert_eq!(cursor_sub4.symgen(), sub4);
+        assert!(cursor_sub4.subregions().next().is_none());
+
+        // main/sub2.yml contents
+        assert_eq!(cursor_sub2.path(), Path::new("main/sub2.yml"));
+        assert_eq!(cursor_sub2.symgen(), sub2);
+        assert!(cursor_sub2.subregions().next().is_none());
+    }
+
+    #[test]
+    fn test_symgen_cursor_subregions_dedup() {
+        let main = test_utils::get_symgen_with_subregions(
+            r#"
+            main1:
+              address: 0x0
+              length: 0x100
+              subregions:
+                - sub1.yml
+              functions:
+                - name: main_fn
+                  address: 0x80
+              data: []
+            main2:
+              address: 0x0
+              length: 0x100
+              subregions:
+                - sub1.yml
+              functions: []
+              data:
+                - name: main_data
+                  address: 0x80
+                  length: 0x10
+            "#,
+            &[(
+                "sub1.yml",
+                r#"sub1:
+                    address: 0x0
+                    length: 0x40
+                    functions: []
+                    data:
+                      - name: sub1_data
+                        address: 0x0
+                        length: 0x4
+                    "#,
+            )],
+        );
+        let sub1 = get_subregion(&main, "main1", 0);
+        let cursor_main = main.cursor(Path::new("main.yml"));
+
+        // main.yml contents
+        assert_eq!(cursor_main.path(), Path::new("main.yml"));
+        assert_eq!(cursor_main.symgen(), &main);
+        let mut subregions_main = cursor_main.subregions();
+        let cursor_sub1 = subregions_main.next().unwrap();
+        assert!(subregions_main.next().is_none());
+
+        // sub1.yml contents
+        assert_eq!(cursor_sub1.path(), Path::new("main/sub1.yml"));
+        assert_eq!(cursor_sub1.symgen(), sub1);
+        assert!(cursor_sub1.subregions().next().is_none());
+    }
+
+    #[test]
+    fn test_symgen_cursor_has_subregions() {
+        let main = get_test_symgen();
+        let (_, _, sub3, _) = get_test_subregions(&main);
+
+        assert!(main.cursor(Path::new("main.yml")).has_subregions());
+        assert!(!sub3.cursor(Path::new("")).has_subregions());
+    }
+
+    #[test]
+    fn test_block_cursor_has_subregions() {
+        let symgen = get_test_symgen();
+        let (main, _, sub2a, _, _, _) = get_test_blocks(&symgen);
+
+        assert!(main.cursor("main", Path::new("main.yml")).has_subregions());
+        assert!(!sub2a.cursor("", Path::new("")).has_subregions());
+    }
+
+    #[test]
+    fn test_block_cursor_subblocks() {
+        let symgen = get_test_symgen();
+        let (main, sub1, sub2a, sub2b, sub3, sub4) = get_test_blocks(&symgen);
+        let cursor_symgen = symgen.cursor(Path::new("main.yml"));
+        let cursor_main = cursor_symgen
+            .get(cursor_symgen.symgen().block_key("main").unwrap())
+            .unwrap();
+
+        // main contents
+        assert_eq!(cursor_main.path(), Path::new("main.yml"));
+        assert_eq!(cursor_main.block(), main);
+        let mut subblocks_main = cursor_main.subblocks();
+        let cursor_sub1 = subblocks_main.next().unwrap();
+        let cursor_sub2a = subblocks_main.next().unwrap();
+        let cursor_sub2b = subblocks_main.next().unwrap();
+        assert!(subblocks_main.next().is_none());
+
+        // sub1 contents
+        assert_eq!(cursor_sub1.path(), Path::new("main/sub1.yml"));
+        assert_eq!(cursor_sub1.block(), sub1);
+        let mut subblocks_sub1 = cursor_sub1.subblocks();
+        let cursor_sub3 = subblocks_sub1.next().unwrap();
+        let cursor_sub4 = subblocks_sub1.next().unwrap();
+        assert!(subblocks_sub1.next().is_none());
+
+        // sub3 contents
+        assert_eq!(cursor_sub3.path(), Path::new("main/sub1/sub3.yml"));
+        assert_eq!(cursor_sub3.block(), sub3);
+        assert!(cursor_sub3.subblocks().next().is_none());
+
+        // sub4 contents
+        assert_eq!(cursor_sub4.path(), Path::new("main/sub1/sub4.yml"));
+        assert_eq!(cursor_sub4.block(), sub4);
+        assert!(cursor_sub4.subblocks().next().is_none());
+
+        // sub2a contents
+        assert_eq!(cursor_sub2a.path(), Path::new("main/sub2.yml"));
+        assert_eq!(cursor_sub2a.block(), sub2a);
+        assert!(cursor_sub2a.subblocks().next().is_none());
+
+        // sub2b contents
+        assert_eq!(cursor_sub2b.path(), Path::new("main/sub2.yml"));
+        assert_eq!(cursor_sub2b.block(), sub2b);
+        assert!(cursor_sub2b.subblocks().next().is_none());
+    }
+
+    #[test]
+    fn test_symgen_cursor_btraverse() {
+        let main = get_test_symgen();
+        let (sub1, sub2, sub3, sub4) = get_test_subregions(&main);
+        let cursor_main = main.cursor(Path::new("main.yml"));
+        let expected = [
+            ("main.yml", &main),
+            ("main/sub1.yml", sub1),
+            ("main/sub2.yml", sub2),
+            ("main/sub1/sub3.yml", sub3),
+            ("main/sub1/sub4.yml", sub4),
+        ];
+
+        for (cursor, exp) in cursor_main.btraverse().zip(expected.iter()) {
+            assert_eq!(cursor.path(), Path::new(exp.0));
+            assert_eq!(cursor.symgen(), exp.1);
+        }
+    }
+
+    #[test]
+    fn test_symgen_cursor_dtraverse() {
+        let main = get_test_symgen();
+        let (sub1, sub2, sub3, sub4) = get_test_subregions(&main);
+        let cursor_main = main.cursor(Path::new("main.yml"));
+        let expected = [
+            ("main.yml", &main),
+            ("main/sub1.yml", sub1),
+            ("main/sub1/sub3.yml", sub3),
+            ("main/sub1/sub4.yml", sub4),
+            ("main/sub2.yml", sub2),
+        ];
+
+        for (cursor, exp) in cursor_main.dtraverse().zip(expected.iter()) {
+            assert_eq!(cursor.path(), Path::new(exp.0));
+            assert_eq!(cursor.symgen(), exp.1);
+        }
+    }
+
+    #[test]
+    fn test_block_cursor_btraverse() {
+        let symgen = get_test_symgen();
+        let (main, sub1, sub2a, sub2b, sub3, sub4) = get_test_blocks(&symgen);
+        let cursor_symgen = symgen.cursor(Path::new("main.yml"));
+        let cursor_main = cursor_symgen
+            .get(cursor_symgen.symgen().block_key("main").unwrap())
+            .unwrap();
+        let expected = [
+            ("main.yml", "main", main),
+            ("main/sub1.yml", "sub1", sub1),
+            ("main/sub2.yml", "sub2a", sub2a),
+            ("main/sub2.yml", "sub2b", sub2b),
+            ("main/sub1/sub3.yml", "sub3", sub3),
+            ("main/sub1/sub4.yml", "sub4", sub4),
+        ];
+
+        for (cursor, exp) in cursor_main.btraverse().zip(expected.iter()) {
+            assert_eq!(cursor.path(), Path::new(exp.0));
+            assert_eq!(cursor.name(), exp.1);
+            assert_eq!(cursor.block(), exp.2);
+        }
+    }
+
+    #[test]
+    fn test_block_cursor_dtraverse() {
+        let symgen = get_test_symgen();
+        let (main, sub1, sub2a, sub2b, sub3, sub4) = get_test_blocks(&symgen);
+        let cursor_symgen = symgen.cursor(Path::new("main.yml"));
+        let cursor_main = cursor_symgen
+            .get(cursor_symgen.symgen().block_key("main").unwrap())
+            .unwrap();
+        let expected = [
+            ("main.yml", "main", main),
+            ("main/sub1.yml", "sub1", sub1),
+            ("main/sub1/sub3.yml", "sub3", sub3),
+            ("main/sub1/sub4.yml", "sub4", sub4),
+            ("main/sub2.yml", "sub2a", sub2a),
+            ("main/sub2.yml", "sub2b", sub2b),
+        ];
+
+        for (cursor, exp) in cursor_main.dtraverse().zip(expected.iter()) {
+            assert_eq!(cursor.path(), Path::new(exp.0));
+            assert_eq!(cursor.name(), exp.1);
+            assert_eq!(cursor.block(), exp.2);
+        }
+    }
+}

--- a/src/data_formats/symgen_yml/types.rs
+++ b/src/data_formats/symgen_yml/types.rs
@@ -835,6 +835,7 @@ mod tests {
         }
     }
 
+    #[cfg(test)]
     mod maybe_version_dep_tests {
         use super::*;
 

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -1,70 +1,88 @@
 //! Formatting `resymgen` YAML files. Implements the `fmt` command.
 
 use std::error::Error;
+use std::fmt::Display;
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::Path;
 
 use similar::TextDiff;
-use tempfile::NamedTempFile;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-use super::data_formats::symgen_yml::{IntFormat, SymGen};
+use super::data_formats::symgen_yml::{IntFormat, Sort, Subregion, SymGen};
 use super::util;
 
-/// Formats a given `input_file`, using to the given `int_format`.
+/// Formats a given `input_file` using the given `int_format`.
+///
+/// In `recursive` mode, subregion files are also formatted.
 ///
 /// # Examples
 /// ```ignore
-/// format_check_file("/path/to/symbols.yml", IntFormat::Hexadecimal).expect("Format failed");
+/// format_file("/path/to/symbols.yml", false, IntFormat::Hexadecimal).expect("Format failed");
 /// ```
 pub fn format_file<P: AsRef<Path>>(
     input_file: P,
+    recursive: bool,
     int_format: IntFormat,
 ) -> Result<(), Box<dyn Error>> {
-    let contents = {
-        let f = File::open(input_file.as_ref())?;
-        SymGen::read_sorted(&f)?
+    let input_file = input_file.as_ref();
+    let mut contents = {
+        let f = File::open(input_file)?;
+        SymGen::read(&f)?
     };
-    // Write to a tempfile first, then replace the old one atomically.
-    let f_new = NamedTempFile::new()?;
-    contents.write(&f_new, int_format)?;
-    util::persist_named_temp_file_safe(f_new, input_file.as_ref())?;
-    Ok(())
+    if recursive {
+        contents.resolve_subregions(Subregion::subregion_dir(input_file), |p| File::open(p))?;
+    }
+    contents.sort();
+    util::symgen_write_recursive(&contents, input_file, int_format)
 }
 
 /// Checks the format of a given `input_file`, subject to the given `int_format`.
+///
+/// In `recursive` mode, subregion files are also checked.
 ///
 /// On success, returns `true`. On failure, returns `false` and prints a diff.
 ///
 /// # Examples
 /// ```ignore
-/// let succeeded = format_check_file("/path/to/symbols.yml", IntFormat::Hexadecimal)
+/// let succeeded = format_check_file("/path/to/symbols.yml", false, IntFormat::Hexadecimal)
 ///     .expect("Format check failed");
 /// ```
 pub fn format_check_file<P: AsRef<Path>>(
     input_file: P,
+    recursive: bool,
     int_format: IntFormat,
 ) -> Result<bool, Box<dyn Error>> {
-    // Need to read to string in order to diff
-    let text = fs::read_to_string(input_file.as_ref())?;
-    let contents = SymGen::read_sorted(text.as_bytes())?;
-    let formatted_text = contents.write_to_str(int_format)?;
-    if text == formatted_text {
-        Ok(true)
-    } else {
-        print_format_diff(
-            &text,
-            &formatted_text,
-            &format!("{}", input_file.as_ref().display()),
-        )?;
-        Ok(false)
+    let input_file = input_file.as_ref();
+    let mut contents = {
+        let f = File::open(input_file)?;
+        SymGen::read(&f)?
+    };
+    if recursive {
+        contents.resolve_subregions(Subregion::subregion_dir(input_file), |p| File::open(p))?;
     }
+    contents.sort();
+
+    let mut success = true;
+    // Depth-first traversal is more intuitive for reporting formatting issues
+    for cursor in contents.cursor(input_file).dtraverse() {
+        // It's unfortunate we're reading the same file twice, but it's simpler than trying to
+        // resolve subregions manually, and less memory intensive than caching. If this ever
+        // becomes a performance issue, it can be optimized.
+        let text = fs::read_to_string(cursor.path())?;
+        let formatted_text = cursor.symgen().write_to_str(int_format)?;
+        if text != formatted_text {
+            print_format_diff(&text, &formatted_text, cursor.path().display())?;
+            // Keep going to check any other subregion files, but fail the check as a whole
+            success = false;
+        }
+    }
+    Ok(success)
 }
 
 /// Prints a diff between a file and its formatted version in unified diff format.
-/// The title string is printed as part of the diff header.
-fn print_format_diff(old: &str, new: &str, title: &str) -> io::Result<()> {
+/// The title is printed as part of the diff header.
+fn print_format_diff<D: Display>(old: &str, new: &str, title: D) -> io::Result<()> {
     let mut stderr = StandardStream::stderr(ColorChoice::Always);
     let mut print_colored_diff = || -> io::Result<()> {
         let diff = TextDiff::from_lines(old, new)


### PR DESCRIPTION
Fixes #37. This implements the `subregions` field on blocks as proposed.

These changes are almost fully backwards compatible. The only breaking change is the renaming of one of the `resymgen check` options from `--no-function-overlap` to `--no-overlap`.