### PR TITLE
Improve symbol_check.py

### DIFF
--- a/headers/Makefile
+++ b/headers/Makefile
@@ -38,3 +38,7 @@ format-check:
 .PHONY: symbol-check
 symbol-check:
 	./symbol_check.py
+
+.PHONY: symbol-check-extra
+symbol-check-extra:
+	./symbol_check.py --extra-symbols


### PR DESCRIPTION
- Add an --extra-symbols flag to print out symbols that exist in the symbol tables but not the C headers, and an associated symbol-check-extra target in the Makefile.
- Add a --verbose flag for verbose output.
- Slightly improve output to specify the symbol type (functions/data)