### PR TITLE
Port overlay_0011 from Irdkwia's ASM.ods

### DIFF
--- a/headers/data/overlay11.h
+++ b/headers/data/overlay11.h
@@ -3,6 +3,7 @@
 
 extern struct script_opcode_table SCRIPT_OP_CODES;
 extern struct common_routine_table C_ROUTINES;
+extern char GROUND_WAN_FILES_TABLE[343][12];
 extern struct script_object OBJECTS[0]; // Length differs by version
 extern struct dungeon_id_16 RECRUITMENT_TABLE_LOCATIONS[22];
 extern int16_t RECRUITMENT_TABLE_LEVELS[22];
@@ -10,5 +11,10 @@ extern struct monster_id_16 RECRUITMENT_TABLE_SPECIES[22];
 extern struct level_tilemap_list_entry LEVEL_TILEMAP_LIST[81];
 extern struct overlay_load_entry OVERLAY11_OVERLAY_LOAD_TABLE[21];
 extern struct main_ground_data GROUND_STATE_PTRS;
+extern undefined SCRIPT_COMMAND_PARSING_DATA[32];
+extern char SCRIPT_OP_CODE_NAMES[0];    // Length might differ by version; needs verification
+extern char OVERLAY11_DEBUG_STRINGS[0]; // Length might differ by version; needs verification
+extern char C_ROUTINE_NAMES[0];         // Length might differ by version; needs verification
+extern struct ground_weather_entry GROUND_WEATHER_TABLE[12];
 
 #endif

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -17,6 +17,11 @@ void GroundMainNextDay(void);
 bool JumpToTitleScreen(int arg);
 bool ReturnToTitleScreen(uint32_t fade_duration);
 void ScriptSpecialProcess0x16(bool param_1);
+void LoadBackgroundAttributes(char* bg_attr_str, int bg_id);
+void LoadMapType10(void* buf, int map_id, undefined* dungeon_info_str, undefined4 additional_info);
+void LoadMapType11(void* buf, int map_id, undefined* dungeon_info_str, undefined4 additional_info);
+void GetSpecialLayoutBackground(int bg_id, undefined* dungeon_info_str, undefined4 additional_info,
+                                bool copy_fixed_room_layout);
 void StatusUpdate(void);
 
 #endif

--- a/headers/types/ground_mode/ground_mode.h
+++ b/headers/types/ground_mode/ground_mode.h
@@ -360,4 +360,10 @@ struct bar_item {
 };
 ASSERT_SIZE(struct bar_item, 22);
 
+struct ground_weather_entry {
+    int16_t field_0x0;
+    int16_t field_0x2;
+};
+ASSERT_SIZE(struct ground_weather_entry, 4);
+
 #endif

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -207,6 +207,52 @@ overlay11:
         Implements SPECIAL_PROC_0x16 (see ScriptSpecialProcessCall).
         
         r0: bool
+    - name: LoadBackgroundAttributes
+      address:
+        EU: 0x22EC480
+        NA: 0x22EBB40
+        JP: 0x22ED174
+      description: |-
+        Note: unverified, ported from Irdkwia's notes
+        
+        r0: [output] bg_attr_str
+        r1: bg_id
+    - name: LoadMapType10
+      address:
+        EU: 0x22ED664
+        NA: 0x22ECD24
+        JP: 0x22EE358
+      description: |-
+        Note: unverified, ported from Irdkwia's notes
+        
+        r0: [output] buffer_ptr
+        r1: map_id
+        r2: dungeon_info_str
+        r3: additional_info
+    - name: LoadMapType11
+      address:
+        EU: 0x22EDB84
+        NA: 0x22ED244
+        JP: 0x22EE878
+      description: |-
+        Note: unverified, ported from Irdkwia's notes
+        
+        r0: [output] buffer_ptr
+        r1: map_id
+        r2: dungeon_info_str
+        r3: additional_info
+    - name: GetSpecialLayoutBackground
+      address:
+        EU: 0x22F1F00
+        NA: 0x22F155C
+        JP: 0x22F2BA8
+      description: |-
+        Note: unverified, ported from Irdkwia's notes
+        
+        r0: bg_id
+        r1: dungeon_info_str
+        r2: additional_info
+        r3: copy_fixed_room_layout
     - name: SprintfStatic
       address:
         EU: 0x2309868
@@ -258,6 +304,17 @@ overlay11:
         These routines underpin the ExplorerScript coroutines you can call in the SkyTemple SSB debugger.
         
         type: struct common_routine_table
+    - name: GROUND_WAN_FILES_TABLE
+      address:
+        EU: 0x231E820
+        NA: 0x231DE40
+      length:
+        EU: 0x10BC
+        NA: 0x1014
+      description: |-
+        Note: unverified, ported from Irdkwia's notes
+        
+        type: char[343][12]
     - name: OBJECTS
       address:
         EU: 0x231F8DC
@@ -313,7 +370,10 @@ overlay11:
       length:
         EU: 0x288
         NA: 0x288
-      description: "type: struct level_tilemap_list_entry[81]"
+      description: |-
+        Irdkwia's notes: FIXED_FLOOR_GROUND_ASSOCIATION
+        
+        type: struct level_tilemap_list_entry[81]
     - name: OVERLAY11_OVERLAY_LOAD_TABLE
       address:
         EU: 0x2323B9C
@@ -352,3 +412,47 @@ overlay11:
         Host pointers to multiple structure used for performing an overworld scene
         
         type: struct main_ground_data
+    - name: OVERLAY11_UNKNOWN_TABLE__NA_2316A38
+      address:
+        NA: 0x2316A38
+      length:
+        NA: 0xA0
+      description: |-
+        Multiple entries are pointers to the string "script.c"
+        
+        Note: unverified, ported from Irdkwia's notes
+        
+        type: undefined4[40]
+    - name: SCRIPT_COMMAND_PARSING_DATA
+      address:
+        NA: 0x2316AD8
+      length:
+        NA: 0x20
+      description: Used by ScriptCommandParsing somehow
+    - name: SCRIPT_OP_CODE_NAMES
+      address:
+        NA: 0x2316AF8
+      length:
+        NA: 0x1B18
+      description: "Opcode name strings pointed to by entries in SCRIPT_OP_CODES (script_opcode::name)"
+    - name: OVERLAY11_DEBUG_STRINGS
+      address:
+        NA: 0x2319208
+      length:
+        NA: 0x8E4
+      description: Strings used with various debug printing functions throughout the overlay
+    - name: C_ROUTINE_NAMES
+      address:
+        NA: 0x2319AEC
+      length:
+        NA: 0x2D3C
+      description: "Common routine name strings pointed to by entries in C_ROUTINES (common_routine::name)"
+    - name: GROUND_WEATHER_TABLE
+      address:
+        NA: 0x231DE10
+      length:
+        NA: 0x30
+      description: |-
+        Note: unverified, ported from Irdkwia's notes
+        
+        type: struct ground_weather_entry[12]


### PR DESCRIPTION
This is the main ground mode overlay. Essentially a straight port, plus some verification of a few of the symbols by me.

Note: The data symbol now labeled as OVERLAY11_UNKNOWN_TABLE__NA_2316A38 was listed in Irdkwia's notes as having 20 (typo'd as 2) 8-byte entries, but from investigation, it seems like they're actually 4-byte entries. The type is now listed as undefined4[40].