### PR TITLE
Update ghidra-setup.md with note on Ghidra 10.2.1.

### DIFF
--- a/docs/ghidra-setup.md
+++ b/docs/ghidra-setup.md
@@ -1,7 +1,7 @@
 # Setting up Ghidra for _Pokémon Mystery Dungeon: Explorers of Sky_
 Properly setting up a Ghidra environment for _Explorers of Sky_ can be tricky if you don't do it right. This guide walks you through the whole process, assuming you've already installed Ghidra and just have an EoS ROM file.
 
-Steps in this guide were originally written for Ghidra 10.1.1, but shouldn't vary significantly between Ghidra versions. There's one exception: **Ghidra 10.2 is currently broken, so don't use it.** This note will be updated when a new Ghidra version is released that fixes the issue.
+Steps in this guide were originally written for Ghidra 10.1.1, but shouldn't vary significantly between Ghidra versions. There's one exception: **Ghidra 10.2 had a bug that broke the ARMv5 disassembler, so don't use it.**. However, the bug was fixed in Ghidra 10.2.1, so using this version or later should be fine.
 
 Note: There is an easy-to-use Ghidra extension for loading Nintendo DS ROMs called [NTRGhidra](https://github.com/pedro-javierf/NTRGhidra). With NTRGhidra installed, you can just load the ROM (i.e., the `.nds` file) directly, then skip to the [Run analyzers](#run-analyzers) section. However, NTRGhidra loads all overlays at once, which reduces the quality of Ghidra's auto-analysis, particularly with cross-overlay branching. For this reason, the setup described below is still preferred when analyzing overlays in depth.
 


### PR DESCRIPTION
The ARMv5 disassembler bug from 10.2 was fixed in 10.2.1 (GP-2812). Add a note to the Ghidra setup doc about this.

Closes #86.