### PR TITLE
Add JP/JP-ITCM metadata to arm9/itcm.yml

### DIFF
--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -5,18 +5,21 @@ arm9:
     - JP
     - EU-ITCM
     - NA-ITCM
+    - JP-ITCM
   address:
     EU: 0x2000000
     NA: 0x2000000
     JP: 0x2000000
     EU-ITCM: 0x1FF8000
     NA-ITCM: 0x1FF8000
+    JP-ITCM: 0x1FF8000
   length:
     EU: 0xB7D38
     NA: 0xB73F8
     JP: 0xB8CB8
     EU-ITCM: 0x4000
     NA-ITCM: 0x4000
+    JP-ITCM: 0x4060
   description: |-
     The main ARM9 binary.
     

--- a/symbols/arm9/itcm.yml
+++ b/symbols/arm9/itcm.yml
@@ -5,16 +5,21 @@ itcm:
     - JP
     - EU-ITCM
     - NA-ITCM
+    - JP-ITCM
   address:
     EU: 0x20B3CC0
     NA: 0x20B3380
+    JP: 0x20B4BE0
     EU-ITCM: 0x1FF8000
     NA-ITCM: 0x1FF8000
+    JP-ITCM: 0x1FF8000
   length:
     EU: 0x4000
     NA: 0x4000
+    JP: 0x4060
     EU-ITCM: 0x4000
     NA-ITCM: 0x4000
+    JP-ITCM: 0x4060
   description: |-
     The instruction TCM (tightly-coupled memory) and the corresponding region in the ARM9 binary.
     
@@ -31,6 +36,7 @@ itcm:
         JP: 0x20B6FD8
         EU-ITCM: 0x1FFA390
         NA-ITCM: 0x1FFA390
+        JP-ITCM: 0x1FFA3F8
       description: |-
         Calls ShouldMonsterRunAwayVariation. If the result is true, returns true. Otherwise, returns true only if the monster's behavior field is equal to monster_behavior::BEHAVIOR_FLEEING_OUTLAW.
         
@@ -44,6 +50,7 @@ itcm:
         JP: 0x20B700C
         EU-ITCM: 0x1FFA3C4
         NA-ITCM: 0x1FFA3C4
+        JP-ITCM: 0x1FFA42C
       description: |-
         Used by the AI to determine the direction in which a monster should move
         
@@ -56,6 +63,7 @@ itcm:
         JP: 0x20B7F10
         EU-ITCM: 0x1FFB2C8
         NA-ITCM: 0x1FFB2C8
+        JP-ITCM: 0x1FFB330
       description: |-
         Calculates the target position of an AI-controlled monster and stores it in the monster's ai_target_pos field
         
@@ -67,6 +75,7 @@ itcm:
         JP: 0x20B82A0
         EU-ITCM: 0x1FFB658
         NA-ITCM: 0x1FFB658
+        JP-ITCM: 0x1FFB6C0
       description: |-
         Determines if an AI-controlled monster will use a move and which one it will use
         
@@ -76,6 +85,7 @@ itcm:
       address:
         EU: 0x20B3CC0
         NA: 0x20B3380
+        JP: 0x20B4BE0
       length:
         EU: 0x40
         NA: 0x40


### PR DESCRIPTION
pmdsky-debug-py couldn't handle the lack of block-level metadata in this file after JP offsets were added to some of the functions. Add that metadata in.

Interestingly, the length of the JP ITCM region is slightly different from that of the EU/NA ITCM region.