### PR TITLE
Minor usability tweaks for resymgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resymgen"
 description = "Generates symbol tables for reverse engineering applications from a YAML specification"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["UsernameFodder <usernamefodder@gmail.com>"]
 edition = "2018"
 rust-version = "1.58"

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -654,7 +654,7 @@ fn check_no_overlap(symgen: &SymGen) -> Result<(), String> {
             }
         }
         fn check_exts_for_self_overlap(
-            exts: &mut Vec<(Extent, &str)>,
+            exts: &mut [(Extent, &str)],
             ext_type: &str,
         ) -> Result<(), String> {
             exts.sort_unstable();
@@ -693,8 +693,8 @@ fn check_no_overlap(symgen: &SymGen) -> Result<(), String> {
             Ok(())
         }
         fn check_exts_for_mutual_overlap(
-            exts1: &mut Vec<(Extent, &str)>,
-            exts2: &mut Vec<(Extent, &str)>,
+            exts1: &mut [(Extent, &str)],
+            exts2: &mut [(Extent, &str)],
             ext_type1: &str,
             ext_type2: &str,
         ) -> Result<(), String> {
@@ -991,11 +991,8 @@ fn print_report(results: &[(PathBuf, CheckResult)]) -> io::Result<()> {
     };
     let res = print_colored_report();
     // Always try to clean up color settings before returning
-    if let Err(e) = stdout.reset() {
-        Err(e)
-    } else {
-        res
-    }
+    stdout.reset()?; // throw away Ok() output
+    res
 }
 
 /// Validates a given set of `input_files` under the specified `checks`, and prints a summary of

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -131,9 +131,6 @@ fn print_format_diff<D: Display>(old: &str, new: &str, title: D) -> io::Result<(
     };
     let res = print_colored_diff();
     // Always try to clean up color settings before returning
-    if let Err(e) = stderr.reset() {
-        Err(e)
-    } else {
-        res
-    }
+    stderr.reset()?; // throw away Ok() output
+    res
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -19,11 +19,22 @@ fn output_file_name(base: &Path, version: &str, format: &OutFormat) -> PathBuf {
     let output_stem = match base.file_stem() {
         Some(s) => {
             let mut stem = s.to_os_string();
-            stem.push("_");
-            stem.push(version);
+            if !version.is_empty() {
+                // Append the version as a suffix if it exists
+                stem.push("_");
+                stem.push(version);
+            }
             stem
         }
-        None => version.into(), // path is empty or invalid; fall back to just the version
+        None => {
+            // path is empty or invalid; fall back to just the version
+            if !version.is_empty() {
+                version.into()
+            } else {
+                // no path or version; use the format extension as the output stem...
+                format.extension().into()
+            }
+        }
     };
     base.with_file_name(output_stem)
         .with_extension(format.extension())
@@ -52,15 +63,51 @@ fn generate_symbols<P: AsRef<Path>>(
     Ok(())
 }
 
-/// Gets a list of all version names explicitly specified by blocks within a SymGen.
+/// Gets a list of all version names within a SymGen.
+/// 1. If a version list is explicitly specified by blocks, use those.
+/// 2. If a block does not explicitly specify a version list, infer it
+/// based on the addresses it contains.
+/// 3. If blocks with symbols exist but none has an explicit version, return
+/// a vector containing a single empty string ("").
 fn all_version_names(symgen: &SymGen) -> Vec<&str> {
     let mut vers = BTreeSet::new();
+    let mut symgen_has_symbols: bool = false;
+    let mut versions_inferred_from_symbols: bool = false;
     for b in symgen.blocks() {
         if let Some(v) = &b.versions {
+            // Explicit version list
             for name in v.iter().map(|v| v.name()) {
                 vers.insert(name);
             }
+        } else {
+            // Inferred version list
+            for name in b.address.versions().map(|v| v.name()) {
+                vers.insert(name);
+            }
+            for s in b.iter() {
+                symgen_has_symbols = true;
+                for name in s.address.versions().map(|v| v.name()) {
+                    versions_inferred_from_symbols = true;
+                    vers.insert(name);
+                }
+            }
         }
+    }
+    if symgen_has_symbols && vers.is_empty() {
+        // Special case: symbols exist but all are Common
+        return vec![""];
+    } else if versions_inferred_from_symbols && !vers.is_empty() {
+        // XXX: A non-empty version list was inferred from symbol contents. Unfortunately, this
+        // won't actually give the desired generation output for blocks without an explicit
+        // version list, since the version-realization step during generation won't work properly
+        // without one. Warn the user of this, and tell them to use the --complete-version-list
+        // check to enforce an explicit version list on all blocks.
+        eprintln!(
+            "Warning: Detected one or more blocks containing by-version symbol addresses, but \
+            without an explicit version list. Proceeding with inferred version list, but the \
+            generated output might be incomplete. Use `check --complete-version-list` to enforce \
+            explicit version lists on all blocks."
+        );
     }
     vers.into_iter().collect()
 }
@@ -188,6 +235,8 @@ mod tests {
                 "/foo/bar/baz_JP.sym",
             ),
             (("", "NA", OutFormat::Sym), "NA.sym"),
+            (("out/", "", OutFormat::Ghidra), "out.ghidra"),
+            (("", "", OutFormat::Sym), "sym.sym"),
         ];
         for ((base, version, format), exp) in cases {
             assert_eq!(
@@ -222,6 +271,62 @@ mod tests {
         .expect("Read failed");
 
         assert_eq!(all_version_names(&s), vec!["v1", "v2", "v3"]);
+    }
+
+    #[test]
+    fn test_all_version_names_inferred() {
+        let s = SymGen::read(
+            r"
+            main:
+              address:
+                v0: 0x2000000
+              length: 0x1000
+              functions:
+                - name: fn1
+                  address:
+                    v1: 0x2000000
+                    v3: 0x2000000
+              data: []
+            other:
+              address: 0x2100000
+              length: 0x1000
+              functions: []
+              data:
+                - name: data1
+                  address:
+                    v2: 0x2100000
+            "
+            .as_bytes(),
+        )
+        .expect("Read failed");
+
+        assert_eq!(all_version_names(&s), vec!["v0", "v1", "v2", "v3"]);
+    }
+
+    #[test]
+    fn test_all_version_names_common() {
+        let s = SymGen::read(
+            r"
+            main:
+              address: 0x2000000
+              length: 0x1000
+              functions:
+                - name: fn1
+                  address: 0x2000000
+              data: []
+            other:
+              address: 0x2100000
+              length: 0x1000
+              functions: []
+              data:
+                - name: data1
+                  address: 0x2100000
+            "
+            .as_bytes(),
+        )
+        .expect("Read failed");
+
+        assert_eq!(all_version_names(&s), vec![""]);
     }
 
     #[test]


### PR DESCRIPTION
Improve the usability of `resymgen gen` with unversioned addresses. Also add some warning messages in places where unexpected behavior could occur.