### PR TITLE
Reword some documentation to be clearer

### DIFF
--- a/docs/ghidra-setup.md
+++ b/docs/ghidra-setup.md
@@ -1,7 +1,7 @@
 # Setting up Ghidra for _Pokémon Mystery Dungeon: Explorers of Sky_
 Properly setting up a Ghidra environment for _Explorers of Sky_ can be tricky if you don't do it right. This guide walks you through the whole process, assuming you've already installed Ghidra and just have an EoS ROM file.
 
-Steps in this guide were originally written for Ghidra 10.1.1, but shouldn't vary significantly between Ghidra versions. There's one exception: **Ghidra 10.2 had a bug that broke the ARMv5 disassembler, so don't use it.**. However, the bug was fixed in Ghidra 10.2.1, so using this version or later should be fine.
+Steps in this guide were originally written for Ghidra 10.1.1, but shouldn't vary significantly between Ghidra versions. There's one exception: **Ghidra 10.2 had a bug that broke the ARMv5 disassembler, so don't use it.** However, the bug was fixed in Ghidra 10.2.1, so using this version or later should be fine.
 
 Note: There is an easy-to-use Ghidra extension for loading Nintendo DS ROMs called [NTRGhidra](https://github.com/pedro-javierf/NTRGhidra). With NTRGhidra installed, you can just load the ROM (i.e., the `.nds` file) directly, then skip to the [Run analyzers](#run-analyzers) section. However, NTRGhidra loads all overlays at once, which reduces the quality of Ghidra's auto-analysis, particularly with cross-overlay branching. For this reason, the setup described below is still preferred when analyzing overlays in depth.
 

--- a/docs/using-debug-info.md
+++ b/docs/using-debug-info.md
@@ -28,7 +28,9 @@ If you used [NTRGhidra](https://github.com/pedro-javierf/NTRGhidra) to set up yo
 
    ![ImportSymbolsScript.py](images/ghidra-import-symbols-script.png)
 
-4. When you run the script, it will open a file picker window. Run the import script on each of the `.ghidra` files in the `pmdsky-debug` archive (pick the version subdirectory that matches your ROM) that correspond to a binary you've loaded into the Ghidra program. Alternatively, you can concatenate the contents of all the relevant `.ghidra` files into a single, combined `.ghidra` file and just run the import script once on that file. For example, a combined `.ghidra` file for a North American ROM might look like this:
+4. When you run the script, it will open a file picker window. Run the import script on each of the `.ghidra` files in the `pmdsky-debug` archive that correspond to a binary you've loaded into the Ghidra program (pick the version subdirectory that matches your ROM). **Do _not_ blanket-load every single file**, as this will cause incorrect symbols to be applied (due to [overlays](overlays.md)), which is difficult to correct later.
+
+   Alternatively, you can concatenate the contents of all the relevant `.ghidra` files into a single, combined `.ghidra` file and just run the import script once on that file. For example, a combined `.ghidra` file for a North American ROM might look like this:
 
    ![Example Ghidra symbol table](images/ghidra-symbol-file.png)
 
@@ -48,7 +50,7 @@ If you used [NTRGhidra](https://github.com/pedro-javierf/NTRGhidra) to set up yo
 
        ![Create New Script](images/ghidra-create-new-script.png)
 
-4. Search for the "import_symbols_json.py" script you just added and run it. When you run the script, it will open a file picker window. Run the import script on each of the `.json` files in the `pmdsky-debug` archive (pick the version subdirectory that matches your ROM) that correspond to a binary you've loaded into the Ghidra program.
+4. Search for the "import_symbols_json.py" script you just added and run it. When you run the script, it will open a file picker window. Run the import script on each of the `.json` files in the `pmdsky-debug` archive that correspond to a binary you've loaded into the Ghidra program (pick the version subdirectory that matches your ROM). **Do _not_ blanket-load every single file**, as this will cause incorrect symbols to be applied (due to [overlays](overlays.md)), which is difficult to correct later.
 5. You should now see symbol names and descriptions in the code listing and the decompiler:
 
    ![Symbol names and descriptions in Ghidra](images/ghidra-symbols-with-descriptions.png)


### PR DESCRIPTION
The steps describing symbol imports don't make it very obvious that you shouldn't blanket-load every single overlay file at once. Rearrange things and add warnings to make this slightly more difficult to miss.