### PR TITLE
Info dump 28/66: Moves and effects

### DIFF
--- a/headers/data/overlay10.h
+++ b/headers/data/overlay10.h
@@ -148,6 +148,7 @@ extern int WATER_SPOUT_DAMAGE_MULT_TABLE[4];
 extern int WRING_OUT_DAMAGE_MULT_TABLE[4];
 extern int ERUPTION_DAMAGE_MULT_TABLE[4];
 extern int WEATHER_BALL_DAMAGE_MULT_TABLE[8];
+extern struct item_id_16 EAT_ITEM_EFFECT_IGNORE_LIST[36];
 extern struct castform_weather_attributes CASTFORM_WEATHER_ATTRIBUTE_TABLE[8];
 extern struct type_matchup_combinator_table TYPE_MATCHUP_COMBINATOR_TABLE;
 extern int OFFENSIVE_STAT_STAGE_MULTIPLIERS[21];

--- a/headers/data/overlay29.h
+++ b/headers/data/overlay29.h
@@ -76,6 +76,7 @@ extern struct fx64 DAMAGE_FORMULA_MAX_BASE;
 extern struct fx64 WONDER_GUARD_MULTIPLIER;
 extern struct fx64 DAMAGE_FORMULA_MIN_BASE;
 extern struct damage_negating_exclusive_eff_entry TYPE_DAMAGE_NEGATING_EXCLUSIVE_ITEM_EFFECTS[28];
+extern struct two_turn_move_and_status TWO_TURN_MOVES_AND_STATUSES[22];
 extern int32_t SPATK_STAT_IDX;
 extern int32_t ATK_STAT_IDX;
 extern int32_t ROLLOUT_DAMAGE_MULT_TABLE[10];

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -22,6 +22,8 @@ struct tile* GetTileAtEntity(struct entity* entity);
 struct entity* SpawnTrap(enum trap_id trap_id, struct position* position, uint8_t team,
                          uint8_t flags);
 struct entity* SpawnItemEntity(struct position* position);
+bool ShouldDisplayEntityMessages(struct entity* entity, undefined param_2);
+bool ShouldDisplayEntityMessagesWrapper(struct entity* entity);
 bool CanSeeTarget(struct entity* user, struct entity* target);
 bool CanTargetEntity(struct entity* user, struct entity* target);
 bool CanTargetPosition(struct entity* monster, struct position* position);
@@ -41,6 +43,7 @@ void ShowPpRestoreEffect(struct entity* entity);
 void PlayEffectAnimation0x1A9(struct entity* entity);
 void PlayEffectAnimation0x18E(struct entity* entity);
 void LoadMappaFileAttributes(int quick_saved, int param_2, undefined* special_process);
+int MonsterSpawnListPartialCopy(struct monster_spawn_entry* buffer, int current_buffer_entries);
 bool IsOnMonsterSpawnList(enum monster_id monster_id);
 enum monster_id GetMonsterIdToSpawn(int spawn_weight);
 uint8_t GetMonsterLevelToSpawn(enum monster_id monster_id);
@@ -78,7 +81,7 @@ void TrySwitchPlace(struct entity* user, struct entity* target);
 void ClearMonsterActionFields(struct action_data* monster_action);
 void SetMonsterActionFields(struct action_data* monster_action, struct action_16 action_id);
 void SetActionPassTurnOrWalk(struct action_data* monster_action, enum monster_id monster_id);
-enum action GetItemAction(int item_id);
+enum action GetItemAction(enum item_id item_id);
 void AddDungeonSubMenuOption(int action_id, bool enabled);
 void DisableDungeonSubMenuOption(int action_id);
 void SetActionRegularAttack(struct action_data* monster_action, enum direction_id direction);
@@ -134,6 +137,7 @@ bool TeamLeaderIqSkillIsEnabled(enum iq_skill_id iq_skill);
 int CountMovesOutOfPp(struct entity* entity);
 bool HasSuperEffectiveMoveAgainstUser(struct entity* user, struct entity* target,
                                       bool ignore_moves_with_max_ginseng_not_99);
+bool TryEatItem(struct entity* user, struct entity* target);
 bool CheckSpawnThreshold(enum monster_id monster_id);
 bool HasLowHealth(struct entity* entity);
 bool AreEntitiesAdjacent(struct entity* first, struct entity* second);
@@ -319,6 +323,8 @@ void RevealEnemies(struct entity* user, struct entity* target);
 bool TryInflictLeechSeedStatus(struct entity* user, struct entity* target, bool log_failure,
                                bool check_only);
 void TryInflictDestinyBond(struct entity* user, struct entity* target);
+void TryInvisify(struct entity* user, struct entity* target);
+void TryTransform(struct entity* user, struct entity* target);
 bool IsBlinded(struct entity* entity, bool check_held_item);
 void RestoreMovePP(struct entity* user, struct entity* target, int pp, bool suppress_logs);
 void SetReflectDamageCountdownTo4(struct entity* entity);
@@ -345,6 +351,8 @@ void ApplyItemEffect(undefined4 param_1, undefined4 param_2, undefined4 param_3,
 void ViolentSeedBoost(struct entity* attacker, struct entity* defender);
 void ApplyGummiBoostsDungeonMode(struct entity* user, struct entity* target,
                                  enum type_id gummi_type, int random_stat_boost);
+bool CanMonsterUseItem(struct entity* entity, struct item* item);
+bool ShouldTryEatItem(enum item_id item_id);
 int GetMaxPpWrapper(struct move* move);
 bool MoveIsNotPhysical(enum move_id move_id);
 bool CategoryIsNotPhysical(enum move_category category_id);
@@ -354,9 +362,11 @@ void TryExplosion(struct entity* user, struct entity* target, struct position* p
                   undefined param_4, undefined param_5, union damage_source damage_source);
 void TryWarp(struct entity* user, struct entity* target, enum warp_type warp_type,
              struct position position);
+int GetMoveRangeDistance(struct entity* user, struct move* move, bool check_two_turn_moves);
 bool MoveHitCheck(struct entity* attacker, struct entity* defender, struct move* move,
                   bool use_second_accuracy, bool never_miss_self);
 bool IsHyperBeamVariant(struct move* move);
+bool IsChargingTwoTurnMove(struct entity* user, struct move* move);
 bool HasMaxGinsengBoost99(struct move* move);
 bool TwoTurnMoveForcedMiss(struct entity* target, struct move* move);
 bool DungeonRandOutcomeUserTargetInteraction(struct entity* user, struct entity* target,

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -1735,6 +1735,13 @@ struct damage_negating_exclusive_eff_entry {
 };
 ASSERT_SIZE(struct damage_negating_exclusive_eff_entry, 8);
 
+// Represents a two-turn move and its corresponding status_two_turn_id value
+struct two_turn_move_and_status {
+    struct move_id_16 move;
+    struct status_two_turn_id_16 status;
+};
+ASSERT_SIZE(struct two_turn_move_and_status, 4);
+
 // Separate this out into its own file because it's massive
 #include "dungeon.h"
 

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -256,6 +256,29 @@ enum status_id {
     STATUS_STAIR_SPOTTER = 101,  // Can locate stairs
 };
 
+// Values for the two-turn move status group
+// Corresponds to values 28 to 40 in the status_id enum
+enum status_two_turn_id {
+    STATUS_TWO_TURN_BIDE = 1,
+    STATUS_TWO_TURN_SOLARBEAM = 2,
+    STATUS_TWO_TURN_SKY_ATTACK = 3,
+    STATUS_TWO_TURN_RAZOR_WIND = 4,
+    STATUS_TWO_TURN_FOCUS_PUNCH = 5,
+    STATUS_TWO_TURN_SKULL_BASH = 6,
+    STATUS_TWO_TURN_FLYING = 7,
+    STATUS_TWO_TURN_BOUNCING = 8,
+    STATUS_TWO_TURN_DIVING = 9,
+    STATUS_TWO_TURN_DIGGING = 10,
+    STATUS_TWO_TURN_CHARGING = 11,
+    STATUS_TWO_TURN_ENRAGED = 12,
+    STATUS_TWO_TURN_SHADOW_FORCE = 13,
+};
+
+// This is usually stored as a 16-bit integer
+#pragma pack(push, 2)
+ENUM_16_BIT(status_two_turn_id);
+#pragma pack(pop)
+
 // Tactic ID. These are usually encoded as bitvectors.
 enum tactic_id {
     TACTIC_LETS_GO_TOGETHER = 0,

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -1173,6 +1173,14 @@ overlay10:
         Maps each weather type (by index, see enum weather_id) to the corresponding Weather Ball damage multiplier, where each entry is a binary fixed-point number with 8 fraction bits.
         
         type: int[8]
+    - name: EAT_ITEM_EFFECT_IGNORE_LIST
+      address:
+        EU: 0x22C54CC
+        NA: 0x22C4B74
+      length:
+        EU: 0x48
+        NA: 0x48
+      description: List of item IDs that should be ignored by the ShouldTryEatItem function. The last entry is null.
     - name: CASTFORM_WEATHER_ATTRIBUTE_TABLE
       address:
         EU: 0x22C55C4

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -105,6 +105,7 @@ overlay29:
           - 0x2320664
           - 0x2320BE4
           - 0x23211CC
+          - 0x2321EA0
           - 0x2326088
           - 0x232F280
           - 0x23349EC
@@ -301,6 +302,27 @@ overlay29:
         
         r0: position
         return: entity pointer for the newly added item, or null on failure
+    - name: ShouldDisplayEntityMessages
+      address:
+        EU: 0x22E2EB4
+        NA: 0x22E2574
+      description: |-
+        Checks if messages that involve a certain entity should be displayed or supressed.
+        
+        For example, it returns false if the entity is an invisible enemy.
+        
+        r0: Entity pointer
+        r1: ?
+        return: True if messages involving the entity should be displayed, false if they should be supressed.
+    - name: ShouldDisplayEntityMessagesWrapper
+      address:
+        EU: 0x22E306C
+        NA: 0x22E272C
+      description: |-
+        Calls ShouldDisplayEntityMessages with r1 = 0
+        
+        r0: Entity pointer
+        return: True if messages involving the entity should be displayed, false if they should be supressed.
     - name: CanSeeTarget
       address:
         EU: 0x22E308C
@@ -532,6 +554,18 @@ overlay29:
         r0: quick_saved
         r1: ???
         r2: special_process
+    - name: MonsterSpawnListPartialCopy
+      address:
+        EU: 0x22E8610
+        NA: 0x22E7C60
+      description: |-
+        Copies all entries in the floor's monster spawn list that have a sprite size >= 6 to the specified buffer.
+        
+        The parameter in r1 can be used to specify how many entries are already present in the buffer. Entries added by this function will be placed after those, and the total returned in r1 will account for existing entries as well.
+        
+        r0: (output) Buffer where the result will be stored
+        r1: Current amount of entries in the buffer
+        return: New amount of entries in the buffer
     - name: IsOnMonsterSpawnList
       address:
         EU: 0x22E86FC
@@ -1488,6 +1522,19 @@ overlay29:
         r1: Target
         r2: If true, moves with a max Ginseng boost != 99 will be ignored
         return: True if the target has at least one super effective move against the user, false otherwise.
+    - name: TryEatItem
+      address:
+        EU: 0x22FBC20
+        NA: 0x22BF214
+      description: |-
+        The user attempts to eat an item from the target.
+        
+        The function tries to eat the target's held item first. If that's not possible and the target is part of the team, it attempts to eat a random edible item from the bag instead.
+        Fun fact: The code used to select the random bag item that will be eaten is poorly coded. As a result, there's a small chance of the first edible item in the bag being picked instead of a random one. The exact chance of this happening is (N/B)^B, where N is the amount of non-edible items in the bag and B is the total amount of items in the bag.
+        
+        r0: User
+        r1: Target
+        return: True if the attempt was successful
     - name: CheckSpawnThreshold
       address:
         EU: 0x22FBFF8
@@ -3138,6 +3185,28 @@ overlay29:
         
         r0: user entity pointer
         r1: target entity pointer
+    - name: TryInvisify
+      address:
+        EU: 0x2316FDC
+        NA: 0x231657C
+      description: |-
+        Attempts to turn the target invisible.
+        
+        The user pointer is only used when calling LogMessage functions.
+        
+        r0: user entity pointer
+        r1: target entity pointer
+    - name: TryTransform
+      address:
+        EU: 0x2317C7C
+        NA: 0x231721C
+      description: |-
+        Attempts to transform the target into the species of a random monster contained in the list returned by MonsterSpawnListPartialCopy.
+        
+        The user pointer is only used when calling LogMessage functions.
+        
+        r0: user entity pointer
+        r1: target entity pointer
     - name: IsBlinded
       address:
         EU: 0x2318244
@@ -3359,6 +3428,30 @@ overlay29:
         r1: target entity pointer
         r2: Gummi type ID
         r3: Stat boost amount, if a random stat boost occurs
+    - name: CanMonsterUseItem
+      address:
+        EU: 0x231DF0C
+        NA: 0x231D4A4
+      description: |-
+        Checks whether a monster can use a certain item.
+        
+        Returns false if the item is sticky, or if the monster is under the STATUS_MUZZLED status and the item is edible.
+        Also prints failure messages if required.
+        
+        r0: Monster entity pointer
+        r1: Item pointer
+        return: True if the monster can use the item, false otherwise
+    - name: ShouldTryEatItem
+      address:
+        EU: 0x231F3F8
+        NA: 0x231E990
+      description: |-
+        Checks if a given item should be eaten by the TryEatItem effect.
+        
+        Returns false if the ID is lower than 0x45, greater than 0x8A or if it's listed in the EAT_ITEM_EFFECT_IGNORE_LIST array.
+        
+        r0: Item ID
+        return: True if the item should be eaten by TryEatItem.
     - name: GetMaxPpWrapper
       address:
         EU: 0x231F458
@@ -3440,6 +3533,20 @@ overlay29:
         r1: target entity pointer
         r2: warp type
         r3: position (if warp type is position-based)
+    - name: GetMoveRangeDistance
+      address:
+        EU: 0x2322D0C
+        NA: 0x23222A4
+      description: |-
+        Returns the maximum reach distance of a move, based on its AI range value.
+        
+        If the move doesn't have an AI range value of RANGE_FRONT_10, RANGE_FRONT_WITH_CORNER_CUTTING or RANGE_FRONT_2_WITH_CORNER_CUTTING, returns 0.
+        If r2 is true, the move is a two-turn move and the user isn't charging said move, returns 0.
+        
+        r0: User entity pointer
+        r1: Move pointer
+        r2: True to perform the two-turn move check
+        return: Maximum reach distance of the move, in tiles.
     - name: MoveHitCheck
       address:
         EU: 0x23246B0
@@ -3466,6 +3573,16 @@ overlay29:
         
         r0: move
         return: bool
+    - name: IsChargingTwoTurnMove
+      address:
+        EU: 0x232500C
+        NA: 0x23245A4
+      description: |-
+        Checks if a monster is currently charging the specified two-turn move.
+        
+        r0: User entity pointer
+        r1: Move pointer
+        return: True if the user is charging the specified two-turn move, false otherwise.
     - name: HasMaxGinsengBoost99
       address:
         EU: 0x2325200
@@ -6303,6 +6420,14 @@ overlay29:
         List of exclusive item effects that negate damage of a certain type, terminated by a TYPE_NEUTRAL entry.
         
         type: struct damage_negating_exclusive_eff_entry[28]
+    - name: TWO_TURN_MOVES_AND_STATUSES
+      address:
+        EU: 0x23536B8
+        NA: 0x2352AAC
+      length:
+        EU: 0x2C
+        NA: 0x2C
+      description: "List that matches two-turn move IDs to their corresponding status ID. The last entry is null."
     - name: SPATK_STAT_IDX
       address:
         EU: 0x23536F4

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -307,13 +307,13 @@ overlay29:
         EU: 0x22E2EB4
         NA: 0x22E2574
       description: |-
-        Checks if messages that involve a certain entity should be displayed or supressed.
+        Checks if messages that involve a certain entity should be displayed or suppressed.
         
         For example, it returns false if the entity is an invisible enemy.
         
         r0: Entity pointer
         r1: ?
-        return: True if messages involving the entity should be displayed, false if they should be supressed.
+        return: True if messages involving the entity should be displayed, false if they should be suppressed.
     - name: ShouldDisplayEntityMessagesWrapper
       address:
         EU: 0x22E306C
@@ -322,7 +322,7 @@ overlay29:
         Calls ShouldDisplayEntityMessages with r1 = 0
         
         r0: Entity pointer
-        return: True if messages involving the entity should be displayed, false if they should be supressed.
+        return: True if messages involving the entity should be displayed, false if they should be suppressed.
     - name: CanSeeTarget
       address:
         EU: 0x22E308C

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -1525,7 +1525,7 @@ overlay29:
     - name: TryEatItem
       address:
         EU: 0x22FBC20
-        NA: 0x22BF214
+        NA: 0x22FB214
       description: |-
         The user attempts to eat an item from the target.
         
@@ -6427,7 +6427,7 @@ overlay29:
       length:
         EU: 0x2C
         NA: 0x2C
-      description: "List that matches two-turn move IDs to their corresponding status ID. The last entry is null."
+      description: List that matches two-turn move IDs to their corresponding status ID. The last entry is null.
     - name: SPATK_STAT_IDX
       address:
         EU: 0x23536F4

--- a/symbols/overlay29/move_effects.yml
+++ b/symbols/overlay29/move_effects.yml
@@ -74,6 +74,7 @@ move_effects:
         return: whether the move was successfully used
     - name: DoMoveSleep
       address:
+        EU: 0x2326968
         NA: 0x2325F00
       description: |-
         Move effect: Put target enemies to sleep
@@ -684,6 +685,7 @@ move_effects:
         return: whether the move was successfully used
     - name: DoMoveCrunch
       address:
+        EU: 0x2327A9C
         NA: 0x2327034
       description: |-
         Move effect: Deal damage with a 20% chance (CRUNCH_LOWER_DEFENSE_CHANCE) of lowering the defender's defense.
@@ -708,6 +710,7 @@ move_effects:
         return: whether the move was successfully used
     - name: DoMoveDamageParalyze20
       address:
+        EU: 0x2327B88
         NA: 0x2327120
       description: |-
         Move effect: Deal damage with a 20% chance (THUNDER_PARALYZE_CHANCE) of paralyzing the defender.
@@ -1021,6 +1024,7 @@ move_effects:
         return: whether or not damage was dealt
     - name: DoMoveMeteorMash
       address:
+        EU: 0x23285C4
         NA: 0x2327B5C
         JP: 0x2328FE4
       description: |-
@@ -1254,6 +1258,7 @@ move_effects:
         return: whether the move was successfully used
     - name: DoMoveShadowBall
       address:
+        EU: 0x2328CB4
         NA: 0x2328248
       description: |-
         Move effect: Shadow Ball
@@ -1552,6 +1557,7 @@ move_effects:
         return: whether the move was successfully used
     - name: DoMoveWaterfall
       address:
+        EU: 0x2329A00
         NA: 0x2328F94
       description: |-
         Move effect: Waterfall
@@ -1871,6 +1877,7 @@ move_effects:
         return: whether the move was successfully used
     - name: DoMoveDamagePoison18
       address:
+        EU: 0x232A370
         NA: 0x2329904
       description: |-
         Move effect: Deal damage with an 18% chance (POISON_STING_POISON_CHANCE) to poison the defender.
@@ -2326,6 +2333,7 @@ move_effects:
         return: whether the move was successfully used
     - name: DoMoveDamageConfuse30
       address:
+        EU: 0x232B95C
         NA: 0x232AEF0
       description: |-
         Move effect: Deal damage with a 30% chance (DIZZY_PUNCH_CONFUSE_CHANCE) to confuse the defender.
@@ -2820,6 +2828,7 @@ move_effects:
         return: whether the move was successfully used
     - name: DoMoveDragonRage
       address:
+        EU: 0x232C9F8
         NA: 0x232BF88
       description: |-
         Move effect: Dragon Rage
@@ -3175,6 +3184,8 @@ move_effects:
         JP: 0x232E1D8
       description: |-
         Move effect: Invisify (item effect)
+        
+        This function sets r1 = r0 before calling TryInvisify, so the effect will always be applied to the user regardless of the move settings.
         
         r0: attacker pointer
         r1: defender pointer
@@ -3676,6 +3687,7 @@ move_effects:
         return: whether the move was successfully used
     - name: DoMoveDamageEatItem
       address:
+        EU: 0x232E454
         NA: 0x232D9E4
       description: |-
         Move effect: Deals damage, and eats any beneficial items the defender is holding.


### PR DESCRIPTION
Adds some symbols related to moves, move effects and item effects.
I also added the EU offset of some `DoMove___` functions I stumbled upon, but there's still a lot of EU offsets missing for those.

