### PR TITLE
Document random movement chance

### DIFF
--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -524,7 +524,7 @@ bool IsMoneyAllowed(enum dungeon_id dungeon_id);
 int8_t GetMaxRescueAttempts(enum dungeon_id dungeon_id);
 bool IsRecruitingAllowed(enum dungeon_id dungeon_id);
 bool GetLeaderChangeFlag(enum dungeon_id dungeon_id);
-int GetUnknownDungeonOption(enum dungeon_id dungeon_id);
+int GetRandomMovementChance(enum dungeon_id dungeon_id);
 bool CanEnemyEvolve(enum dungeon_id dungeon_id);
 int GetMaxMembersAllowed(enum dungeon_id dungeon_id);
 bool IsIqEnabled(enum dungeon_id dungeon_id);

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -1332,7 +1332,7 @@ struct dungeon_restriction {
     uint8_t max_party_size;    // 0x6: Maximum number of team members that can enter the dungeon
     undefined field_0x7;
     uint16_t turn_limit_per_floor; // 0x8: Number of turns per floor before the wind blows you out
-    // 0x9: Chance of setting the monster::random_movement field to 1 when spawning an enemy
+    // 0xA: Chance of setting the monster::random_movement field to 1 when spawning an enemy
     uint8_t random_movement_chance;
     undefined field_0xb;
 };

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -354,10 +354,9 @@ struct monster {
     struct tactic_id_8 tactic; // 0xA8
     struct statuses statuses;  // 0xA9
     undefined field_0x11f;
-    undefined field_0x120;
-    undefined field_0x121;
-    undefined field_0x122;
-    undefined field_0x123;
+    // 0x120: If zero, when the monster is standing in a room, the AI will make it head towards a
+    // random exit. If nonzero, the monster will instead move in a random direction every turn.
+    int random_movement;
     struct move moves[4]; // 0x124
     uint8_t move_flags;   // 0x144: 1-byte bitfield
     undefined field_0x145;
@@ -1333,7 +1332,8 @@ struct dungeon_restriction {
     uint8_t max_party_size;    // 0x6: Maximum number of team members that can enter the dungeon
     undefined field_0x7;
     uint16_t turn_limit_per_floor; // 0x8: Number of turns per floor before the wind blows you out
-    undefined field_0xa;
+    // 0x9: Chance of setting the monster::random_movement field to 1 when spawning an enemy
+    uint8_t random_movement_chance;
     undefined field_0xb;
 };
 ASSERT_SIZE(struct dungeon_restriction, 12);

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -5220,16 +5220,16 @@ arm9:
         
         r0: dungeon id
         return: True if the restrictions of the current dungeon allow changing leaders, false otherwise.
-    - name: GetUnknownDungeonOption
+    - name: GetRandomMovementChance
       address:
         EU: 0x2051720
         NA: 0x20513E8
         JP: 0x2051738
       description: |-
-        Note: unverified, ported from Irdkwia's notes
+        Returns dungeon_restriction::random_movement_chance for the specified dungeon ID.
         
         r0: dungeon ID
-        return: ?
+        return: Random movement chance
     - name: CanEnemyEvolve
       address:
         EU: 0x2051738


### PR DESCRIPTION
Adds details for one of the previously unknown dungeon restrictions. Thanks to @AnonymousRandomPerson for pointing out the fact that this field is the same as a flag used in RRT and providing an explanation on how it works.