### PR TITLE
Fix size of the random movement chance restriction

### DIFF
--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -524,7 +524,7 @@ bool IsMoneyAllowed(enum dungeon_id dungeon_id);
 int8_t GetMaxRescueAttempts(enum dungeon_id dungeon_id);
 bool IsRecruitingAllowed(enum dungeon_id dungeon_id);
 bool GetLeaderChangeFlag(enum dungeon_id dungeon_id);
-int GetRandomMovementChance(enum dungeon_id dungeon_id);
+int16_t GetRandomMovementChance(enum dungeon_id dungeon_id);
 bool CanEnemyEvolve(enum dungeon_id dungeon_id);
 int GetMaxMembersAllowed(enum dungeon_id dungeon_id);
 bool IsIqEnabled(enum dungeon_id dungeon_id);

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -1333,8 +1333,7 @@ struct dungeon_restriction {
     undefined field_0x7;
     uint16_t turn_limit_per_floor; // 0x8: Number of turns per floor before the wind blows you out
     // 0xA: Chance of setting the monster::random_movement field to 1 when spawning an enemy
-    uint8_t random_movement_chance;
-    undefined field_0xb;
+    int16_t random_movement_chance;
 };
 ASSERT_SIZE(struct dungeon_restriction, 12);
 


### PR DESCRIPTION
Just checked the ASM again, it's actually a signed 2-byte value.