### PR TITLE
Added more statuses and dungeon version loading info

### DIFF
--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -576,7 +576,7 @@ struct unk_dungeon_init {
     // 0xAC: Controls which version of the dungeon to load. Gets copied into
     // dungeon::dungeon_game_version_id. Uncertain when the game decides to load the
     // Time/Darkness version of dungeons.
-    enum game dungeon_game_version_id;
+    enum game_id dungeon_game_version_id;
     undefined field_0xB0;
     undefined field_0xB1;
     undefined field_0xB2;

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -576,7 +576,7 @@ struct unk_dungeon_init {
     // 0xAC: Controls which version of the dungeon to load. Gets copied into
     // dungeon::dungeon_game_version_id. Uncertain when the game decides to load the
     // Time/Darkness version of dungeons.
-    uint32_t dungeon_game_version_id;
+    enum game dungeon_game_version_id;
     undefined field_0xB0;
     undefined field_0xB1;
     undefined field_0xB2;

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -573,10 +573,10 @@ struct unk_dungeon_init {
     undefined field_0xA9;
     undefined field_0xAA;
     undefined field_0xAB;
-    undefined field_0xAC;
-    undefined field_0xAD;
-    undefined field_0xAE;
-    undefined field_0xAF;
+    // 0xAC: Controls which version of the dungeon to load. Gets copied into
+    // dungeon::dungeon_game_version_id. Uncertain when the game decides to load the
+    // Time/Darkness version of dungeons.
+    uint32_t dungeon_game_version_id;
     undefined field_0xB0;
     undefined field_0xB1;
     undefined field_0xB2;

--- a/headers/types/dungeon_mode/dungeon.h
+++ b/headers/types/dungeon_mode/dungeon.h
@@ -53,7 +53,6 @@ struct dungeon {
     uint8_t speed_boost_counter;
     // 0x20: Total amount of floors summed by all the previous dungeons in its group
     uint16_t number_preceding_floors;
-    // 0x22: 
     undefined field_0x22;
     undefined field_0x23;
     undefined field_0x24;
@@ -1514,7 +1513,7 @@ struct dungeon {
     undefined field_0x12b1d;
     undefined field_0x12b1e;
     undefined field_0x12b1f;
-    // 0x12B20: Probably counts how many sprites or monster entries the fixed room wants 
+    // 0x12B20: Probably counts how many sprites or monster entries the fixed room wants
     // loaded.
     uint32_t fixed_room_monster_sprite_counter;
     // 0x12B24: Whether or not the kecleon shop spawn chance be boosted for the floor
@@ -1563,7 +1562,7 @@ struct dungeon {
     struct entity* illuminate_spawn_entity;
     // 0x1990C: Stores statuses::statuses_unique_id for the monster poitned to by
     // dungeon::snatch_monster?
-    undefined snatch_status_unique_id;;
+    undefined snatch_status_unique_id;
     undefined field_0x1990d;
     undefined field_0x1990e;
     undefined field_0x1990f;

--- a/headers/types/dungeon_mode/dungeon.h
+++ b/headers/types/dungeon_mode/dungeon.h
@@ -682,7 +682,7 @@ struct dungeon {
     // the move table and the check to load waza_p2.bin is later, waza_p2.bin can be deleted
     // without causing the game to crash as the data from waza_p.bin is still loaded because
     // it's not overwritten by loading waza_p2.bin
-    enum game dungeon_game_version_id;
+    enum game_id dungeon_game_version_id;
     // 0x7D0: Pointer to spawn list? Uncertain which spawn list?
     undefined field_0x7d0;
     undefined field_0x7d1;

--- a/headers/types/dungeon_mode/dungeon.h
+++ b/headers/types/dungeon_mode/dungeon.h
@@ -682,7 +682,7 @@ struct dungeon {
     // the move table and the check to load waza_p2.bin is later, waza_p2.bin can be deleted
     // without causing the game to crash as the data from waza_p.bin is still loaded because
     // it's not overwritten by loading waza_p2.bin
-    enum game dungeon_game_version_id;
+    struct game_32 dungeon_game_version_id;
     // 0x7D0: Pointer to spawn list? Uncertain which spawn list?
     undefined field_0x7d0;
     undefined field_0x7d1;

--- a/headers/types/dungeon_mode/dungeon.h
+++ b/headers/types/dungeon_mode/dungeon.h
@@ -1386,8 +1386,8 @@ struct dungeon {
     // since they get initialized together.
     uint16_t unknown_array_0x12A92[9];
     // 0x12AA4: Pointer to data about the fixed room such as width and height. Gets set after
-    // oading the data for a fixed room when generating a floor. Gets set back to null when
-    // done generating a floor. 
+    // loading the data for a fixed room when generating a floor. Gets set back to null when
+    // done generating a floor.
     undefined* unk_fixed_room_pointer;
     // 0x12AA8: This flag is set by the move 0x191 ("Trapper") which is the effect
     // of the Trapper Orb. If true, the game will try to spawn a trap.

--- a/headers/types/dungeon_mode/dungeon.h
+++ b/headers/types/dungeon_mode/dungeon.h
@@ -640,7 +640,7 @@ struct dungeon {
     // it gets loaded after loading the dungeon floor monster spawn entries. Maybe for monsters
     // that need a specific item to spawn?
     struct monster_id_16 some_monster_sprite_to_load;
-    uint8_t some_monster_level; // The level for dungeon::some_monster_sprite_to_load?
+    uint8_t some_monster_level; // 0x7AA: The level for dungeon::some_monster_sprite_to_load?
     undefined field_0x7ab;
     // 0x7AC: Second number in the default LCG sequence, used for computing the actual dungeon PRNG
     // seed
@@ -1134,13 +1134,12 @@ struct dungeon {
     undefined field_0x3e2a;
     undefined field_0x3e2b;
     // 0x3E2C: Appears to be a counter that is saved into statuses::unique_id so that every
-    // monster has a different id for tracking statuses such as leech seed and the abilities
-    // storm drain and lightning rod.
-    // bond. Initalized to 0x400 (1024)
+    // monster has a different id for tracking statuses such as Leech Seed and Destiny Bond, and the
+    // abilities Storm Drain and Lightning Rod. Initialized to 0x400 (1024)
     uint32_t monster_unique_id_counter;
     // 0x3E30: Appears to to be a counter that is used for both attacker and defender to figure
     // out which pair of wrapper and wrapped are connected. This number is saved into
-    // statuses::wrap_pair_unique_id. Initalized to 0xA (10)
+    // statuses::wrap_pair_unique_id. Initialized to 0xA (10)
     uint32_t monster_unique_wrap_counter;
     bool plus_is_active[2];  // 0x3E34: A monster on the {enemy, team} side has the ability Plus
     bool minus_is_active[2]; // 0x3E36: A monster on the {enemy, team} side has the ability Minus
@@ -1199,6 +1198,7 @@ struct dungeon {
     int fixed_room_max_y; // 0xCD30: inclusive?
     // 0xCD34: Width of the generated fixed room?
     uint16_t fixed_room_width;
+    // 0xCD36: Height of the generated fixed room?
     uint16_t fixed_room_height;
     struct weather_id_8 weather; // 0xCD38: current weather
     // 0xCD39: Default weather on the floor that will be reverted to if the current weather is
@@ -1536,8 +1536,7 @@ struct dungeon {
     struct entity* snatch_monster;
     // 0x19908: Pointer to the entity to be spawned by the effect of Illuminate
     struct entity* illuminate_spawn_entity;
-    // 0x1990C: Stores statuses::unique_id for the monster pointed to by
-    // dungeon::snatch_monster.
+    // 0x1990C: Stores statuses::unique_id for the monster pointed to by dungeon::snatch_monster.
     uint32_t snatch_status_unique_id;
     // 0x19910: Spawn genid of the monster to be spawned by the effect of Illuminate
     uint16_t illuminate_spawn_genid;
@@ -1550,9 +1549,9 @@ struct dungeon {
     // 0x1A21C: Data about the map, the camera and the touchscreen numbers
     struct display_data display_data;
     struct minimap_display_data minimap_display_data; // 0x1A264: Data used to display the minimap
-    // 0x286B0: Initalized to 0xFF, then set to a copy of dungeon::group_id
+    // 0x286B0: Initialized to 0xFF, then set to a copy of dungeon::group_id
     struct dungeon_group_id_8 group_id_copy;
-    // 0x286B1: Initalized to 0xFF, then set to a copy of dungeon::0x74B
+    // 0x286B1: Initialized to 0xFF, then set to a copy of dungeon::0x74B
     undefined field_0x286b1;
     struct floor_properties floor_properties; // 0x286B2: Properties about the current floor
     undefined field_0x286d2;

--- a/headers/types/dungeon_mode/dungeon.h
+++ b/headers/types/dungeon_mode/dungeon.h
@@ -682,8 +682,7 @@ struct dungeon {
     // the move table and the check to load waza_p2.bin is later, waza_p2.bin can be deleted
     // without causing the game to crash as the data from waza_p.bin is still loaded because
     // it's not overwritten by loading waza_p2.bin
-    // 0 = Sky, 1 = Time, 2 = Darkness
-    uint32_t dungeon_game_version_id;
+    enum game dungeon_game_version_id;
     // 0x7D0: Pointer to spawn list? Uncertain which spawn list?
     undefined field_0x7d0;
     undefined field_0x7d1;
@@ -1119,11 +1118,11 @@ struct dungeon {
     // 0x3B74: Unknown array, likely one entry per monster species
     uint8_t unknown_array_0x3B74[600];
     // 0x3DCC: Appears to be a table that holds the statuses::statuses_unique_id value for
-    // the monsters. Maybe just for convenience to avoid loading it from all monsters?
-    uint32_t monster_statuses_unique_id[20];
+    // the monsters. Maybe just for convenience to avoid loading it from every monster?
+    uint32_t monster_unique_id[20];
     // 0x3E1C: Appears to be be an index inside dungeon::active_monsters_unique_statuses_ids.
     // Uncertain what this index is used for.
-    uint32_t statuses_unique_id_index;
+    uint32_t unique_id_index;
     // 0x3E20: Number of valid monster spawn entries (see spawn_entries).
     int monster_spawn_entries_length;
     undefined field_0x3e24;
@@ -1134,13 +1133,14 @@ struct dungeon {
     undefined field_0x3e29;
     undefined field_0x3e2a;
     undefined field_0x3e2b;
-    // 0x3E2C: Appears to be a counter that is saved into statuses::statuses_unique_id so that
-    // every monster has a different id for tracking statuses such as leech seed and destiny
-    // bond.
-    uint32_t monster_unique_statuses_id_counter;
+    // 0x3E2C: Appears to be a counter that is saved into statuses::unique_id so that every
+    // monster has a different id for tracking statuses such as leech seed and the abilities
+    // storm drain and lightning rod.
+    // bond. Initalized to 0x400 (1024)
+    uint32_t monster_unique_id_counter;
     // 0x3E30: Appears to to be a counter that is used for both attacker and defender to figure
     // out which pair of wrapper and wrapped are connected. This number is saved into
-    // statuses::wrap_pair_unique_id. Initalized to 0xA (10)?
+    // statuses::wrap_pair_unique_id. Initalized to 0xA (10)
     uint32_t monster_unique_wrap_counter;
     bool plus_is_active[2];  // 0x3E34: A monster on the {enemy, team} side has the ability Plus
     bool minus_is_active[2]; // 0x3E36: A monster on the {enemy, team} side has the ability Minus
@@ -1192,7 +1192,7 @@ struct dungeon {
     int kecleon_shop_min_y; // 0xCD18: inclusive
     int kecleon_shop_max_x; // 0xCD1C: inclusive
     int kecleon_shop_max_y; // 0xCD20: inclusive
-    // Cordinates for a non full floor fixed room? Uncertain if max values are inclusive.
+    // Coordinates for a non full floor fixed room? Uncertain if max values are inclusive.
     int fixed_room_min_x; // 0xCD24: inclusive
     int fixed_room_min_y; // 0xCD28: inclusive
     int fixed_room_max_x; // 0xCD2C: inclusive?
@@ -1524,48 +1524,21 @@ struct dungeon {
     undefined field_0x12b26;
     undefined field_0x12b27;
     struct entity_table entity_table; // 0x12B28: Table of all entities in the dungeon
-    undefined field_0x198e4;
-    undefined field_0x198e5;
-    undefined field_0x198e6;
-    undefined field_0x198e7;
-    undefined field_0x198e8;
-    undefined field_0x198e9;
-    undefined field_0x198ea;
-    undefined field_0x198eb;
-    undefined field_0x198ec;
-    undefined field_0x198ed;
-    undefined field_0x198ee;
-    undefined field_0x198ef;
-    undefined field_0x198f0;
-    undefined field_0x198f1;
-    undefined field_0x198f2;
-    undefined field_0x198f3;
-    undefined field_0x198f4;
-    undefined field_0x198f5;
-    undefined field_0x198f6;
-    undefined field_0x198f7;
-    undefined field_0x198f8;
-    undefined field_0x198f9;
-    undefined field_0x198fa;
-    undefined field_0x198fb;
-    undefined field_0x198fc;
-    undefined field_0x198fd;
-    undefined field_0x198fe;
-    undefined field_0x198ff;
-    undefined field_0x19900;
-    undefined field_0x19901;
-    undefined field_0x19902;
-    undefined field_0x19903;
-    // 0x19904: Pointer to the monster that will snatch the effect of a move?
+    undefined4 field_0x198e4;
+    undefined4 field_0x198e8;
+    undefined4 field_0x198ec;
+    undefined4 field_0x198f0;
+    undefined4 field_0x198f4;
+    undefined4 field_0x198f8;
+    undefined4 field_0x198fc;
+    undefined4 field_0x19900;
+    // 0x19904: Pointer to the monster that will snatch the effect of a move.
     struct entity* snatch_monster;
     // 0x19908: Pointer to the entity to be spawned by the effect of Illuminate
     struct entity* illuminate_spawn_entity;
-    // 0x1990C: Stores statuses::statuses_unique_id for the monster poitned to by
-    // dungeon::snatch_monster?
-    undefined snatch_status_unique_id;
-    undefined field_0x1990d;
-    undefined field_0x1990e;
-    undefined field_0x1990f;
+    // 0x1990C: Stores statuses::unique_id for the monster pointed to by
+    // dungeon::snatch_monster.
+    uint32_t snatch_status_unique_id;
     // 0x19910: Spawn genid of the monster to be spawned by the effect of Illuminate
     uint16_t illuminate_spawn_genid;
     undefined field_0x19912;

--- a/headers/types/dungeon_mode/dungeon.h
+++ b/headers/types/dungeon_mode/dungeon.h
@@ -682,7 +682,7 @@ struct dungeon {
     // the move table and the check to load waza_p2.bin is later, waza_p2.bin can be deleted
     // without causing the game to crash as the data from waza_p.bin is still loaded because
     // it's not overwritten by loading waza_p2.bin
-    struct game_32 dungeon_game_version_id;
+    enum game dungeon_game_version_id;
     // 0x7D0: Pointer to spawn list? Uncertain which spawn list?
     undefined field_0x7d0;
     undefined field_0x7d1;

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -1341,7 +1341,7 @@ struct mission_destination_info {
     // (e.g., Chambers, Challenge Letters, etc.)
     struct fixed_room_id_8 fixed_room_id;
     // 0x17: Related to missions where you have to obtain an item? Possibly related to the item
-    // being picked up and/or destroyed? 
+    // being picked up and/or destroyed?
     bool unk_mission_item_tracker1;
     undefined field_0x18;
     undefined field_0x19;

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -151,7 +151,7 @@ struct statuses {
     undefined field_0x3a;
     // 0x3B: Used to track the statuses::statuses_unique_id of the relevant monster for
     // statuses like Leech Seed and Destiny bond.
-    uint32_t statuses_applier_id
+    uint32_t statuses_applier_id;
     // 0x3F: Index into entity_table_hdr::monster_slot_ptrs in the dungeon that the user
     // (drainer) is held.
     uint8_t leech_seed_source_monster_index;

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -1341,7 +1341,7 @@ struct mission_destination_info {
     // (e.g., Chambers, Challenge Letters, etc.)
     struct fixed_room_id_8 fixed_room_id;
     // 0x17: Related to missions where you have to obtain an item? Possibly related to the item
-    // being picked up and/or destroyed?
+    // being picked up or destroyed? 
     bool unk_mission_item_tracker1;
     undefined field_0x18;
     undefined field_0x19;

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -92,12 +92,11 @@ struct statuses {
     undefined field_0x4;
     undefined field_0x5;
     undefined field_0x6;
-    // 0x7: Accessed when setting statuses::leech_seed and compared against values in
-    // dungeon::0x3DCC (this value is probably an array). This value is saved to
-    // statuses:0x3B for Destiny Bond and Leech Seed.
-    uint32_t field_0x7;
-    // 0xB: Pointer to the monster being wrapped around/wrapped by
-    struct entity* wrapped_opponent;
+    // 0x7: Unique number saved into statuses::statuses_applier_id to connect the applier
+    // of status conditions such as leech seed and destiny bond.
+    uint32_t statuses_unique_id;
+    // 0xB: Unique number between the wrapped and wrapping target to connect them.
+    uint32_t wrap_pair_unique_id;
     // 0xF: Tracks the damage taken to deal when bide status ends. Max 0x3E7 (999).
     uint32_t bide_damage_tally;
     struct monster_behavior_8 monster_behavior; // 0x13
@@ -150,9 +149,9 @@ struct statuses {
     undefined field_0x38;
     undefined field_0x39;
     undefined field_0x3a;
-    // 0x3B: Leech seed related tracker. Set to the value in statuses:0x7 after finding
-    // statuses::leech_seed_source_monster_index.
-    uint32_t unk_leech_seed_tracker;
+    // 0x3B: Used to track the statuses::statuses_unique_id of the relevant monster for
+    // statuses like Leech Seed and Destiny bond.
+    uint32_t statuses_applier_id
     // 0x3F: Index into entity_table_hdr::monster_slot_ptrs in the dungeon that the user
     // (drainer) is held.
     uint8_t leech_seed_source_monster_index;
@@ -1341,10 +1340,14 @@ struct mission_destination_info {
     // 0x16: Fixed room ID of the destination floor, if relevant
     // (e.g., Chambers, Challenge Letters, etc.)
     struct fixed_room_id_8 fixed_room_id;
-    undefined field_0x17;
+    // 0x17: Related to missions where you have to obtain an item? Possibly related to the item
+    // being picked up and/or destroyed?
+    bool unk_mission_item_tracker1;
     undefined field_0x18;
     undefined field_0x19;
-    undefined field_0x1a;
+    // 0x1A: Related to missions where you have to obtain an item? Possibly related to the item
+    // being picked up or destroyed? 
+    bool unk_mission_item_tracker2;
     // 0x1B: Will be set after the target enemy has been defeated.
     // If there are minions, this flag applies just to the main outlaw.
     bool target_enemy_is_defeated;

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -1341,12 +1341,12 @@ struct mission_destination_info {
     // (e.g., Chambers, Challenge Letters, etc.)
     struct fixed_room_id_8 fixed_room_id;
     // 0x17: Related to missions where you have to obtain an item? Possibly related to the item
-    // being picked up or destroyed? 
+    // being picked up and/or destroyed? 
     bool unk_mission_item_tracker1;
     undefined field_0x18;
     undefined field_0x19;
     // 0x1A: Related to missions where you have to obtain an item? Possibly related to the item
-    // being picked up or destroyed? 
+    // being picked up and/or destroyed?
     bool unk_mission_item_tracker2;
     // 0x1B: Will be set after the target enemy has been defeated.
     // If there are minions, this flag applies just to the main outlaw.

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -152,7 +152,7 @@ struct statuses {
     undefined field_0x39;
     undefined field_0x3a;
     // 0x3B: Used to track the statuses::statuses_unique_id of the relevant monster for
-    // statuses like Leech Seed and Destiny bond.
+    // statuses like Leech Seed and Destiny Bond.
     uint32_t statuses_applier_id;
     // 0x3F: Index into entity_table_hdr::monster_slot_ptrs in the dungeon that the user
     // (drainer) is held.

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -92,9 +92,11 @@ struct statuses {
     undefined field_0x4;
     undefined field_0x5;
     undefined field_0x6;
-    // 0x7: Unique number saved into statuses::statuses_applier_id to connect the applier
-    // of status conditions such as leech seed and destiny bond.
-    uint32_t statuses_unique_id;
+    // 0x7: Unique number given to the monster when spawning to differentiate it from other
+    // monsters and to properly keep track of a monster. Likely used because a monster could be
+    // spawned into the same slot as an old monster and using a pointer alone could cause some
+    // issues. Used for Leech Seed, Destiny Bond, Storm Drain, Lightning Rod (probably more).
+    uint32_t unique_id;
     // 0xB: Unique number between the wrapped and wrapping target to connect them.
     uint32_t wrap_pair_unique_id;
     // 0xF: Tracks the damage taken to deal when bide status ends. Max 0x3E7 (999).

--- a/headers/types/dungeon_mode/dungeon_mode_common.h
+++ b/headers/types/dungeon_mode/dungeon_mode_common.h
@@ -14,7 +14,13 @@ struct item {
     bool f_unpaid : 1;  // Picked up from a Kecleon Shop but not paid for yet
     bool f_sticky : 1;  // Sticky
     bool f_set : 1;     // Usable by L+R
-    uint8_t flags_unk5 : 3;
+    uint8_t flag_unk5 : 1;
+    // For stolen items to recover from outlaws (has red X)? Could be for other items for other
+    // types of missions? (Uncertain)
+    bool f_unk_mission_item : 1;
+    // For items that have been placed into a Kecleon shop, but the player hasn't been paid for
+    // yet? (Uncertain)
+    uint8_t f_unsold_in_shop : 1;    
 
     // 0x1: For bag items. 0 for none, 1 if held by the leader, 2 for the second party member, etc.
     uint8_t held_by;

--- a/headers/types/dungeon_mode/dungeon_mode_common.h
+++ b/headers/types/dungeon_mode/dungeon_mode_common.h
@@ -20,8 +20,7 @@ struct item {
     bool f_unk_mission_item : 1;
     // For items that have been placed into a Kecleon shop, but the player hasn't been paid for
     // yet? (Uncertain)
-    uint8_t f_unsold_in_shop : 1;    
-
+    uint8_t f_unsold_in_shop : 1;
     // 0x1: For bag items. 0 for none, 1 if held by the leader, 2 for the second party member, etc.
     uint8_t held_by;
     // 0x2: Only for stackable items. Will be 0 if unapplicable. For Poké, this is an "amount code"

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -1259,4 +1259,16 @@ enum gen_item_stickiness {
     GEN_ITEM_STICKY_NEVER = 2,
 };
 
+// This is usually stored as a 32-bit integer
+#pragma pack(push, 4)
+ENUM_32_BIT(action);
+#pragma pack(pop)
+
+// Used to determine which version of a dungeon to load.
+enum game {
+    GAME_SKY = 0,
+    GAME_TIME = 1,
+    GAME_DARKNESS = 2,
+};
+
 #endif

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -1260,7 +1260,7 @@ enum gen_item_stickiness {
 };
 
 // Used to determine which version of a dungeon to load.
-enum game {
+enum game_id {
     GAME_SKY = 0,
     GAME_TIME = 1,
     GAME_DARKNESS = 2,

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -1259,11 +1259,6 @@ enum gen_item_stickiness {
     GEN_ITEM_STICKY_NEVER = 2,
 };
 
-// This is usually stored as a 32-bit integer
-#pragma pack(push, 4)
-ENUM_32_BIT(action);
-#pragma pack(pop)
-
 // Used to determine which version of a dungeon to load.
 enum game {
     GAME_SKY = 0,


### PR DESCRIPTION
Added more information about statuses that have to track another target and how the game handles generating dungeons from other versions of the game.

In case someone wanted to review the changes for dungeon::0x7CC, I have listed a few addresses (NA) that can be reviewed.
HiddenStairs fail - 0x02342DB0
MappaFileLoading - 0x022E705C
Poke/Money - 0x0234734C
ExclusiveItem - 0x023462E4/0x02346298
Waza_P2 - 0x022FBF3C/0x022FBF14

