### PR TITLE
Info dump 36-43/66: Many things

### DIFF
--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -108,6 +108,8 @@ void OpenPackFile(struct pack_file_opened* pack_file, const char* file_name);
 uint32_t GetFileLengthInPack(struct pack_file_opened* pack_file, uint32_t file_index);
 uint32_t LoadFileInPack(struct pack_file_opened* pack_file, void* output_buffer,
                         uint32_t file_index);
+void GetDungeonResultMsg(union damage_source damage_source_or_result, void* buffer, int buffer_size,
+                         undefined* param_4);
 union damage_source GetDamageSource(enum move_id, enum item_id);
 enum item_category GetItemCategoryVeneer(enum item_id item_id);
 enum move_id GetItemMoveId16(enum item_id item_id);
@@ -117,6 +119,7 @@ bool IsEdible(enum item_id item_id);
 bool IsHM(enum item_id item_id);
 bool IsGummi(enum item_id item_id);
 bool IsAuraBow(enum item_id item_id);
+bool IsChest(enum item_id item_id);
 void InitItem(struct item* item, enum item_id item_id, uint16_t quantity, bool sticky);
 void InitStandardItem(struct item* item, enum item_id item_id, bool sticky);
 int GetDisplayedBuyPrice(struct item* item);
@@ -188,6 +191,7 @@ bool SpecialProcAddItemToBag(struct bulk_item* item);
 bool AddItemToBagNoHeld(struct item* item);
 bool AddItemToBag(struct item* item, int held_by);
 bool ScriptSpecialProcess0x39(void);
+int CountNbItemsOfTypeInStorage(enum item_id item_id);
 int CountItemTypeInStorage(struct bulk_item* item);
 bool RemoveItemsTypeInStorage(struct bulk_item* item);
 bool AddItemToStorage(struct bulk_item* item);
@@ -348,6 +352,7 @@ int PreprocessStringFromMessageId(char* output, int output_size, int message_id,
 void InitPreprocessorArgs(struct preprocessor_args* args);
 char* SetStringAccuracy(char* s, int param_2);
 char* SetStringPower(char* s, int param_2);
+char* GetDungeonResultString(int string_number);
 void SetQuestionMarks(char* s);
 void StrcpySimple(char* dest, const char* src);
 void StrncpySimple(char* dest, const char* src, uint32_t n);
@@ -474,6 +479,10 @@ int GetNbPrecedingFloors(enum dungeon_id dungeon_id);
 int GetNbFloorsDungeonGroup(enum dungeon_id dungeon_id);
 void DungeonFloorToGroupFloor(struct dungeon_group_and_group_floor* out_group_data,
                               struct dungeon_floor_pair* dungeon_and_floor);
+enum mission_rank GetMissionRank(struct dungeon_floor_pair* dungeon_and_floor);
+int GetOutlawLevel(struct dungeon_floor_pair* dungeon_and_floor);
+int GetOutlawLeaderLevel(struct dungeon_floor_pair* dungeon_and_floor);
+int GetOutlawMinionLevel(struct dungeon_floor_pair* dungeon_and_floor);
 void AddGuestMonster(struct dungeon_init* dungeon_init_data, int guest_number,
                      struct guest_monster* guest_monster);
 int GetGroundNameId(int param_1);

--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -108,7 +108,7 @@ void OpenPackFile(struct pack_file_opened* pack_file, const char* file_name);
 uint32_t GetFileLengthInPack(struct pack_file_opened* pack_file, uint32_t file_index);
 uint32_t LoadFileInPack(struct pack_file_opened* pack_file, void* output_buffer,
                         uint32_t file_index);
-void GetDungeonResultMsg(union damage_source damage_source_or_result, void* buffer, int buffer_size,
+void GetDungeonResultMsg(union damage_source damage_source_or_result, char* buffer, int buffer_size,
                          undefined* param_4);
 union damage_source GetDamageSource(enum move_id, enum item_id);
 enum item_category GetItemCategoryVeneer(enum item_id item_id);
@@ -119,7 +119,7 @@ bool IsEdible(enum item_id item_id);
 bool IsHM(enum item_id item_id);
 bool IsGummi(enum item_id item_id);
 bool IsAuraBow(enum item_id item_id);
-bool IsChest(enum item_id item_id);
+bool IsTreasureBox(enum item_id item_id);
 void InitItem(struct item* item, enum item_id item_id, uint16_t quantity, bool sticky);
 void InitStandardItem(struct item* item, enum item_id item_id, bool sticky);
 int GetDisplayedBuyPrice(struct item* item);

--- a/headers/functions/functions.h
+++ b/headers/functions/functions.h
@@ -10,6 +10,7 @@
 #include "overlay14.h"
 #include "overlay19.h"
 #include "overlay29.h"
+#include "overlay30.h"
 #include "overlay31.h"
 #include "overlay34.h"
 

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -29,6 +29,7 @@ void SetAnimDataFields2(struct animation* anim, uint32_t flags, uint32_t param_3
 void LoadObjectAnimData(struct animation* anim, int16_t object_id, uint32_t flags);
 void InitAnimDataFromOtherAnimDataVeneer(struct animation* dst, struct animation* src);
 void AnimRelatedFunction(struct animation* anim, undefined4 param_2, undefined4 param_3);
+undefined GetExclusiveItemRequirements(undefined param_1, undefined param_2);
 void StatusUpdate(void);
 
 #endif

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -29,7 +29,7 @@ void SetAnimDataFields2(struct animation* anim, uint32_t flags, uint32_t param_3
 void LoadObjectAnimData(struct animation* anim, int16_t object_id, uint32_t flags);
 void InitAnimDataFromOtherAnimDataVeneer(struct animation* dst, struct animation* src);
 void AnimRelatedFunction(struct animation* anim, undefined4 param_2, undefined4 param_3);
-undefined GetExclusiveItemRequirements(undefined param_1, undefined param_2);
+void GetExclusiveItemRequirements(undefined param_1, undefined param_2);
 void StatusUpdate(void);
 
 #endif

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -23,7 +23,7 @@ struct trap* GetTrapInfo(struct entity* trap_entity);
 struct item* GetItemInfo(struct entity* item_entity);
 struct tile* GetTileAtEntity(struct entity* entity);
 void UpdateEntityPixelPos(struct entity* entity, struct pixel_position* pixel_pos);
-struct entity* InitEnemyEntity(enum monster_id monster_id);
+struct entity* CreateEnemyEntity(enum monster_id monster_id);
 struct entity* SpawnTrap(enum trap_id trap_id, struct position* position, uint8_t team,
                          uint8_t flags);
 struct entity* SpawnItemEntity(struct position* position);

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -22,6 +22,8 @@ bool CheckTouchscreenArea(int x1, int y1, int x2, int y2);
 struct trap* GetTrapInfo(struct entity* trap_entity);
 struct item* GetItemInfo(struct entity* item_entity);
 struct tile* GetTileAtEntity(struct entity* entity);
+void UpdateEnityPixelPos(struct entity* entity, struct pixel_position* pixel_pos);
+struct entity* InitEnemyEntity(enum monster_id monster_id);
 struct entity* SpawnTrap(enum trap_id trap_id, struct position* position, uint8_t team,
                          uint8_t flags);
 struct entity* SpawnItemEntity(struct position* position);
@@ -150,6 +152,7 @@ void DeleteAllMonsterSpriteFiles(void);
 void EuFaintCheck(bool non_team_member_fainted, bool set_unk_byte);
 void HandleFaint(struct entity* fainted_entity, union damage_source damage_source,
                  struct entity* killer);
+void MoveMonsterToPos(struct entity* entity, int x_pos, int y_pos, undefined param_4);
 void UpdateAiTargetPos(struct entity* monster);
 void SetMonsterTypeAndAbility(struct entity* target);
 void TryActivateSlowStart(void);
@@ -181,13 +184,16 @@ bool HasLowHealth(struct entity* entity);
 bool AreEntitiesAdjacent(struct entity* first, struct entity* second);
 bool IsSpecialStoryAlly(struct monster* monster);
 bool IsExperienceLocked(struct monster* monster);
+void InitOtherMonsterData(struct entity* entity, int fixed_room_stats_index, enum direction_id dir);
 void SpawnTeam(undefined param_1);
 void SpawnInitialMonsters(void);
 struct entity* SpawnMonster(struct spawned_monster_data* monster_data, bool cannot_be_asleep);
 void InitTeamMember(enum monster_id, int16_t x_position, int16_t y_position,
                     struct team_member* team_member_data, undefined param_5, undefined param_6,
                     undefined param_7, undefined param_8, undefined param_9);
-void InitMonster(struct monster* monster, bool flag);
+void InitMonster(undefined param_1, struct entity* entity, struct spawned_monster_data* spawn_data,
+                 undefined* param_4);
+void SubInitMonster(struct monster* monster, bool flag);
 void MarkShopkeeperSpawn(int x, int y, enum monster_id monster_id, enum monster_behavior behavior);
 void SpawnShopkeepers(void);
 void GetOutlawSpawnData(struct spawned_target_data* outlaw);
@@ -211,6 +217,9 @@ bool IsMonsterMuzzled(struct entity* monster);
 bool MonsterHasMiracleEyeStatus(struct entity* monster);
 bool MonsterHasNegativeStatus(struct entity* monster, bool check_held_item);
 bool IsMonsterSleeping(struct entity* monster);
+bool CanMonsterMoveInDirection(struct entity* monster, enum direction_id direction);
+enum mobility_type GetFinalMobilityType(struct entity* monster, enum mobility_type base_mobility,
+                                        enum direction_id direction);
 bool IsMonsterCornered(struct entity* monster);
 bool CanAttackInDirection(struct entity* monster, enum direction_id direction);
 bool CanAiMonsterMoveInDirection(struct entity* monster, enum direction_id direction,
@@ -555,6 +564,8 @@ struct tile* GetTileSafe(int x, int y);
 bool IsFullFloorFixedRoom(void);
 uint8_t GetStairsRoom(void);
 void UpdateTrapsVisibility(void);
+void DrawTileGrid(struct position* pos, undefined param_2, undefined param_3, undefined param_4);
+void HideTileGrid(void);
 void DiscoverMinimap(struct position* pos);
 bool IsWaterTileset(void);
 enum monster_id GetRandomSpawnMonsterID(void);
@@ -644,6 +655,7 @@ void MarkEnemySpawns(struct floor_properties* floor_props, bool empty_monster_ho
 void SetSecondaryTerrainOnWall(struct tile* tile);
 void GenerateSecondaryTerrainFormations(uint8_t test_flag, struct floor_properties* floor_props);
 bool StairsAlwaysReachable(int x_stairs, int y_stairs, bool mark_unreachable);
+union fixed_room_action GetNextFixedRoomAction(void);
 void ConvertWallsToChasms(void);
 void ResetInnerBoundaryTileRows(void);
 void ResetImportantSpawnPositions(struct dungeon_generation_info* gen_info);
@@ -653,6 +665,8 @@ enum hidden_stairs_type GetHiddenStairsType(struct dungeon_generation_info* gen_
                                             struct floor_properties* floor_props);
 int GetFinalKecleonShopSpawnChance(int base_kecleon_shop_chance);
 void ResetHiddenStairsSpawn(void);
+void PlaceFixedRoomTile(struct tile* tile, union fixed_room_action action, int x, int y);
+enum direction_id FixedRoomActionParamToDirection(uint8_t fixed_room_action_param);
 void ApplyKeyEffect(struct entity* user, struct entity* target);
 void LoadFixedRoomData(void);
 int LoadFixedRoom(int param_1, int param_2, int param_3, undefined4 param_4);

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -22,7 +22,7 @@ bool CheckTouchscreenArea(int x1, int y1, int x2, int y2);
 struct trap* GetTrapInfo(struct entity* trap_entity);
 struct item* GetItemInfo(struct entity* item_entity);
 struct tile* GetTileAtEntity(struct entity* entity);
-void UpdateEnityPixelPos(struct entity* entity, struct pixel_position* pixel_pos);
+void UpdateEntityPixelPos(struct entity* entity, struct pixel_position* pixel_pos);
 struct entity* InitEnemyEntity(enum monster_id monster_id);
 struct entity* SpawnTrap(enum trap_id trap_id, struct position* position, uint8_t team,
                          uint8_t flags);

--- a/headers/functions/overlay30.h
+++ b/headers/functions/overlay30.h
@@ -1,0 +1,6 @@
+#ifndef HEADERS_FUNCTIONS_OVERLAY30_H_
+#define HEADERS_FUNCTIONS_OVERLAY30_H_
+
+void WriteQuicksaveData(void* buffer, int buffer_size);
+
+#endif

--- a/headers/types/common/enums.h
+++ b/headers/types/common/enums.h
@@ -3659,4 +3659,27 @@ enum monster_gender {
     GENDER_GENDERLESS = 3,
 };
 
+enum mission_rank {
+    MISSION_RANK_E = 1,
+    MISSION_RANK_D = 2,
+    MISSION_RANK_C = 3,
+    MISSION_RANK_B = 4,
+    MISSION_RANK_A = 5,
+    MISSION_RANK_S = 6,
+    MISSION_RANK_1_STAR = 7,
+    MISSION_RANK_2_STAR = 8,
+    MISSION_RANK_3_STAR = 9,
+    MISSION_RANK_4_STAR = 10,
+    MISSION_RANK_5_STAR = 11,
+    MISSION_RANK_6_STAR = 12,
+    MISSION_RANK_7_STAR = 13,
+    MISSION_RANK_8_STAR = 14,
+    MISSION_RANK_9_STAR = 15,
+};
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(mission_rank);
+#pragma pack(pop)
+
 #endif

--- a/headers/types/dungeon_mode/dungeon.h
+++ b/headers/types/dungeon_mode/dungeon.h
@@ -506,7 +506,9 @@ struct dungeon {
     undefined field_0x745;
     undefined field_0x746;
     undefined field_0x747;
-    struct dungeon_id_8 id;             // 0x748
+    // 0x748: Current dungeon ID. Is actually a dungeon_floor_pair struct that also contains
+    // the floor number.
+    struct dungeon_id_8 id;
     uint8_t floor;                      // 0x749: Current floor number
     struct dungeon_group_id_8 group_id; // 0x74A: Same for different segments of a dungeon
     undefined field_0x74b;

--- a/headers/types/dungeon_mode/dungeon_mode.h
+++ b/headers/types/dungeon_mode/dungeon_mode.h
@@ -777,8 +777,7 @@ struct entity {
     undefined field_0xa5;
     undefined field_0xa6;
     undefined field_0xa7;
-    undefined field_0xa8;
-    undefined field_0xa9;
+    uint16_t sprite_index; // 0xA8
     undefined field_0xaa;
     undefined field_0xab;
     undefined field_0xac;

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -1232,7 +1232,7 @@ ENUM_8_BIT(fixed_room_id);
 // Action IDs used to spawn tiles when generating fixed rooms
 enum fixed_room_action_non_entity {
     FIXED_ACTION_FLOOR_ROOM = 0,
-    FIXED_ACTION_WALL_HALLWAY_AM = 1, // Halway wall, breakable with Absolute Mover IQ skill
+    FIXED_ACTION_WALL_HALLWAY_AM = 1, // Hallway wall, breakable with Absolute Mover IQ skill
     FIXED_ACTION_WALL_HALLWAY_IMPASSABLE = 2,
     FIXED_ACTION_WALL_HALLWAY = 3,
     FIXED_ACTION_LEADER_SPAWN = 4,

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -851,7 +851,8 @@ ENUM_8_BIT(mission_status);
 
 // The cause of a monster taking damage, not including the move case.
 // These codes should all be greater than any move ID.
-// Some of the values are used as faint reasons rather than damage sources.
+// Some of the values are used as faint reasons or on the "The Last Outing" screen
+// rather than as damage sources.
 enum damage_source_non_move {
     DAMAGE_SOURCE_TRANSFORM_FRIEND = 563, // "was transformed into a friend"
     DAMAGE_SOURCE_NOT_BEFRIENDED = 564,   // "left without being befriended"
@@ -917,6 +918,19 @@ enum damage_source_non_move {
     DAMAGE_SOURCE_BAD_DREAMS = 622,
     DAMAGE_SOURCE_EXPLOSION = 623,
     DAMAGE_SOURCE_OREN_BERRY = 624,
+    DAMAGE_SOURCE_DUMMY_625 = 625,
+    DAMAGE_SOURCE_DUMMY_626 = 626,
+    DAMAGE_SOURCE_DUMMY_627 = 627,
+    DAMAGE_SOURCE_DUMMY_628 = 628,
+    DAMAGE_SOURCE_DUMMY_629 = 629,
+    DAMAGE_SOURCE_DUMMY_630 = 630,
+    DAMAGE_SOURCE_DUMMY_631 = 631,
+    DAMAGE_SOURCE_DUMMY_632 = 632,
+    DAMAGE_SOURCE_ESCAPE = 633, // "Escaped in the middle of exploration"
+    DAMAGE_SOURCE_DUNGEON_CLEAR = 634, // "cleared the dungeon"
+    DAMAGE_SOURCE_RESCUE_SUCCESS = 635, // "succeeded in the rescue mission"
+    DAMAGE_SOURCE_MISSION_COMPLETE = 636, // "completed a mission! Impressive!"
+    DAMAGE_SOURCE_BEFRIEND_MEW = 637, // "befriended [CS:N]Mew[CR]!"
 };
 
 // Possible reasons why a monster can take damage or faint
@@ -1214,6 +1228,53 @@ enum fixed_room_id {
 #pragma pack(push, 1)
 ENUM_8_BIT(fixed_room_id);
 #pragma pack(pop)
+
+// Action IDs used to spawn tiles when generating fixed rooms
+enum fixed_room_action_non_entity {
+    FIXED_ACTION_FLOOR_ROOM = 0,
+    FIXED_ACTION_WALL_HALLWAY_AM = 1, // Halway wall, breakable with Absolute Mover IQ skill
+    FIXED_ACTION_WALL_HALLWAY_IMPASSABLE = 2,
+    FIXED_ACTION_WALL_HALLWAY = 3,
+    FIXED_ACTION_LEADER_SPAWN = 4,
+    FIXED_ACTION_SECONDARY_ROOM = 5, // Secondary terrain tile, part of a room
+    FIXED_ACTION_CHASM_HALLWAY = 6,
+    // If spawned, all tiles outside the fixed room are are turned into impassable chasm tiles
+    FIXED_ACTION_CHASM_ALL_HALLWAY = 7,
+    FIXED_ACTION_WARP_ZONE_ROOM = 8, // Spawns a warp zone
+    FIXED_ACTION_FLOOR_HALLWAY = 9,
+    FIXED_ACTION_CHASM_HALLWAY_IMPASSABLE = 10,
+    FIXED_ACTION_FLOOR_HALLWAY_FLAG_10 = 11, // Enables tile::terrain_flags_unk10
+    // Wall if fixed floor ID < FIXED_SEALED_CHAMBER, floor otherwise. Spawns a locked key door.
+    FIXED_ACTION_FLOOR_WALL_ROOM_KEY_DOOR_LOCKED = 12,
+    // Wall if fixed floor ID < FIXED_SEALED_CHAMBER, floor otherwise. Spawns a locked escort
+    // key door.
+    FIXED_ACTION_FLOOR_WALL_ROOM_KEY_DOOR_ESCORT = 13,
+    FIXED_ACTION_WALL_HALLWAY_IMPASSABLE_14 = 14,
+    FIXED_ACTION_WALL_HALLWAY_15 = 15,
+    FIXED_ACTION_TEAM_MEMBER_2_SPAWN = 96,
+    FIXED_ACTION_TEAM_MEMBER_3_SPAWN = 97,
+    FIXED_ACTION_TEAM_MEMBER_4_SPAWN = 98,
+    // Treated separately by the code, but doesn't seem to spawn anything special
+    FIXED_ACTION_FLOOR_ROOM_99 = 99,
+    FIXED_ACTION_WARP_ZONE_ROOM_107 = 107, // Same as FIXED_ACTION_WARP_ZONE_ROOM
+    // Treated separately by the code, but doesn't seem to spawn anything special
+    FIXED_ACTION_FLOOR_ROOM_108 = 108,
+    // Treated separately by the code, but doesn't seem to spawn anything special
+    FIXED_ACTION_FLOOR_ROOM_109 = 109,
+};
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(fixed_room_action_non_entity);
+#pragma pack(pop)
+
+// Used to determine an action that will be performed when spawining a single tile during fixed
+// room generation. Can spawn an entity or a tile.
+union fixed_room_action {
+    struct fixed_room_action_non_entity_8 tile_action;
+    // If specified, this value - 16 represents the ID of the fixed entity to spawn.
+    uint8_t entity_action;
+};
 
 // Floor layout size during floor generation
 enum floor_size {

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -926,11 +926,11 @@ enum damage_source_non_move {
     DAMAGE_SOURCE_DUMMY_630 = 630,
     DAMAGE_SOURCE_DUMMY_631 = 631,
     DAMAGE_SOURCE_DUMMY_632 = 632,
-    DAMAGE_SOURCE_ESCAPE = 633, // "Escaped in the middle of exploration"
-    DAMAGE_SOURCE_DUNGEON_CLEAR = 634, // "cleared the dungeon"
-    DAMAGE_SOURCE_RESCUE_SUCCESS = 635, // "succeeded in the rescue mission"
+    DAMAGE_SOURCE_ESCAPE = 633,           // "Escaped in the middle of exploration"
+    DAMAGE_SOURCE_DUNGEON_CLEAR = 634,    // "cleared the dungeon"
+    DAMAGE_SOURCE_RESCUE_SUCCESS = 635,   // "succeeded in the rescue mission"
     DAMAGE_SOURCE_MISSION_COMPLETE = 636, // "completed a mission! Impressive!"
-    DAMAGE_SOURCE_BEFRIEND_MEW = 637, // "befriended [CS:N]Mew[CR]!"
+    DAMAGE_SOURCE_BEFRIEND_MEW = 637,     // "befriended [CS:N]Mew[CR]!"
 };
 
 // Possible reasons why a monster can take damage or faint

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -1140,6 +1140,17 @@ arm9:
         r1: [output] target buffer
         r2: file index
         return: number of read bytes (identical to the length of the pack from the Table of Content)
+    - name: GetDungeonResultMsg
+      address:
+        EU: 0x200C584
+        NA: 0x200C4FC
+      description: |-
+        Gets the message that is shown on the dungeon results ("The Last Outing") screen, right after the leader's name.
+        
+        r0: Damage source value to use when displaying the cause of fainting or the result of the expedition
+        r1: [output] Buffer where the resulting message will be stored
+        r2: Buffer size
+        r3: (?) Seems to point to a buffer
     - name: GetDamageSource
       address:
         EU: 0x200CADC
@@ -1235,6 +1246,17 @@ arm9:
         
         r0: item ID
         return: bool
+    - name: IsChest
+      address:
+        EU: 0x200CD0C
+        NA: 0x200CC84
+      description: |-
+        Checks if the given item ID is a chest
+        
+        In particular, it checks if the category of the item is CATEGORY_TREASURE_BOXES_1, CATEGORY_TREASURE_BOXES_2 or CATEGORY_TREASURE_BOXES_3.
+        
+        r0: item ID
+        return: True if the item is a chest, false otherwise
     - name: InitItem
       address:
         EU: 0x200CF24
@@ -1719,7 +1741,7 @@ arm9:
         NA: 0x200EE4C
         JP: 0x200EE7C
       description: |-
-        Note: unverified, ported from Irdkwia's notes
+        Returns the number of items of the given kind in the bag
         
         r0: item ID
         return: count
@@ -2008,6 +2030,15 @@ arm9:
         Implements SPECIAL_PROC_0x39 (see ScriptSpecialProcessCall).
         
         return: bool
+    - name: CountNbItemsOfTypeInStorage
+      address:
+        EU: 0x200FF50
+        NA: 0x200FEA8
+      description: |-
+        Returns the number of items of the given kind in the storage
+        
+        r0: item ID
+        return: count
     - name: CountItemTypeInStorage
       address:
         EU: 0x200FF8C
@@ -3428,6 +3459,21 @@ arm9:
         NA: 0x2024428
         JP: 0x2024478
       description: "Note: unverified, ported from Irdkwia's notes"
+    - name: GetDungeonResultString
+      address:
+        EU: 0x20252A4
+        NA: 0x2024FD8
+      description: |-
+        Returns a string containing some information to be used when displaying the dungeon results screen.
+        
+        The exact string returned depends on the value of r0:
+        0: Name of the move that fainted the leader. Empty string if the leader didn't faint.
+        1-3: Seems to always result in an empty string.
+        4: Name of the pokémon that fainted the leader, or name of the leader if the leader didn't faint.
+        5: Name of the fainted leader. Empty string if the leader didn't faint.
+        
+        r0: String to return
+        return: Pointer to resulting string
     - name: SetQuestionMarks
       address:
         EU: 0x20253B0
@@ -4687,6 +4733,44 @@ arm9:
         
         r0: [output] Struct containing the dungeon group and floor group
         r1: Struct containing the dungeon ID and floor number
+    - name: GetMissionRank
+      address:
+        EU: 0x204FB4C
+        NA: 0x204F814
+      description: |-
+        Gets the mission rank for the given dungeon and floor.
+        
+        If the dungeon ID is >= DUNGEON_NORMAL_FLY_MAZE or the group of the dungeon is > DGROUP_DUMMY_0x63, returns MISSION_RANK_E.
+        
+        r0: Dungeon and floor
+        Return: Mission rank
+    - name: GetOutlawLevel
+      address:
+        EU: 0x204FBC4
+        NA: 0x204F88C
+      description: |-
+        Gets the level that should be used for outlaws for the given dungeon and floor
+        
+        r0: Dungeon and floor
+        Return: Outlaw level
+    - name: GetOutlawLeaderLevel
+      address:
+        EU: 0x204FBE0
+        NA: 0x204F8A8
+      description: |-
+        Gets the level that should be used for team leader outlaws for the given dungeon and floor. Identical to GetOutlawLevel.
+        
+        r0: Dungeon and floor
+        Return: Outlaw leader level
+    - name: GetOutlawMinionLevel
+      address:
+        EU: 0x204FBFC
+        NA: 0x204F8C4
+      description: |-
+        Gets the level that should be used for minion outlaws for the given dungeon and floor.
+        
+        r0: Dungeon and floor
+        Return: Outlaw minion level
     - name: AddGuestMonster
       address:
         EU: 0x204FC18

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -1246,17 +1246,17 @@ arm9:
         
         r0: item ID
         return: bool
-    - name: IsChest
+    - name: IsTreasureBox
       address:
         EU: 0x200CD0C
         NA: 0x200CC84
       description: |-
-        Checks if the given item ID is a chest
+        Checks if the given item ID is a treasure box
         
         In particular, it checks if the category of the item is CATEGORY_TREASURE_BOXES_1, CATEGORY_TREASURE_BOXES_2 or CATEGORY_TREASURE_BOXES_3.
         
         r0: item ID
-        return: True if the item is a chest, false otherwise
+        return: True if the item is a treasure box, false otherwise
     - name: InitItem
       address:
         EU: 0x200CF24

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -3875,7 +3875,7 @@ arm9:
         Called whenever a menu option is selected. Returns whether the option is active or not.
         
         r0: ?
-        Return: True if the menu option is enabled, false otherwise.
+        return: True if the menu option is enabled, false otherwise.
     - name: ShowKeyboard
       address:
         EU: 0x2036AE4
@@ -4658,7 +4658,7 @@ arm9:
         Seems to be used to check if you have any missions that have unmet restrictions when trying to access a dungeon.
         
         r0: ?
-        Return: (?) Seems to be composed of multiple bitflags.
+        return: (?) Seems to be composed of multiple bitflags.
     - name: GetNbFloors
       address:
         EU: 0x204F8B4
@@ -4743,7 +4743,7 @@ arm9:
         If the dungeon ID is >= DUNGEON_NORMAL_FLY_MAZE or the group of the dungeon is > DGROUP_DUMMY_0x63, returns MISSION_RANK_E.
         
         r0: Dungeon and floor
-        Return: Mission rank
+        return: Mission rank
     - name: GetOutlawLevel
       address:
         EU: 0x204FBC4
@@ -4752,7 +4752,7 @@ arm9:
         Gets the level that should be used for outlaws for the given dungeon and floor
         
         r0: Dungeon and floor
-        Return: Outlaw level
+        return: Outlaw level
     - name: GetOutlawLeaderLevel
       address:
         EU: 0x204FBE0
@@ -4761,7 +4761,7 @@ arm9:
         Gets the level that should be used for team leader outlaws for the given dungeon and floor. Identical to GetOutlawLevel.
         
         r0: Dungeon and floor
-        Return: Outlaw leader level
+        return: Outlaw leader level
     - name: GetOutlawMinionLevel
       address:
         EU: 0x204FBFC
@@ -4770,7 +4770,7 @@ arm9:
         Gets the level that should be used for minion outlaws for the given dungeon and floor.
         
         r0: Dungeon and floor
-        Return: Outlaw minion level
+        return: Outlaw minion level
     - name: AddGuestMonster
       address:
         EU: 0x204FC18
@@ -7177,7 +7177,7 @@ arm9:
       description: |-
         Enables processor interrupts by clearing the i flag in the program status register (cpsr).
         
-        Return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were already enabled)
+        return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were already enabled)
     - name: EnableIrqFlag
       address:
         EU: 0x207BB7C
@@ -7185,7 +7185,7 @@ arm9:
       description: |-
         Disables processor interrupts by setting the i flag in the program status register (cpsr).
         
-        Return: Old value of cpsr & 0x80 (0x80 if interrupts were already disabled, 0x0 if they were enabled)
+        return: Old value of cpsr & 0x80 (0x80 if interrupts were already disabled, 0x0 if they were enabled)
     - name: SetIrqFlag
       address:
         EU: 0x207BB90
@@ -7194,7 +7194,7 @@ arm9:
         Sets the value of the processor's interrupt flag according to the specified parameter.
         
         r0: Value to set the flag to (0x80 to set it, which disables interrupts; 0x0 to unset it, which enables interrupts)
-        Return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were enabled)
+        return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were enabled)
     - name: EnableIrqFiqFlags
       address:
         EU: 0x207BBA8
@@ -7202,7 +7202,7 @@ arm9:
       description: |-
         Disables processor all interrupts (both standard and fast) by setting the i and f flags in the program status register (cpsr).
         
-        Return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
+        return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
     - name: SetIrqFiqFlags
       address:
         EU: 0x207BBBC
@@ -7211,7 +7211,7 @@ arm9:
         Sets the value of the processor's interrupt flags (i and f) according to the specified parameter.
         
         r0: Value to set the flags to (0xC0 to set both flags, 0x80 to set the i flag and clear the f flag, 0x40 to set the f flag and clear the i flag and 0x0 to clear both flags)
-        Return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
+        return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
     - name: GetIrqFlag
       address:
         EU: 0x207BBD4
@@ -7219,7 +7219,7 @@ arm9:
       description: |-
         Gets the current value of the processor's interrupt request (i) flag
         
-        Return: cpsr & 0x80 (0x80 if interrupts are disabled, 0x0 if they are enabled)
+        return: cpsr & 0x80 (0x80 if interrupts are disabled, 0x0 if they are enabled)
     - name: WaitForever2
       address:
         EU: 0x207BFB8

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -336,6 +336,15 @@ overlay11:
         r1: format
         ...: variadic
         return: number of characters printed, excluding the null-terminator
+    - name: GetExclusiveItemRequirements
+      address:
+        EU: 0x230B8D4
+        NA: 0x230AF38
+      description: |-
+        Used to calculate the items required to get a certain exclusive item in the swap shop.
+        
+        r0: ?
+        r1: ?
     - name: StatusUpdate
       address:
         EU: 0x2314478

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -306,7 +306,7 @@ overlay29:
         
         r0: pointer to entity
         returns: pointer to tile
-    - name: UpdateEnityPixelPos
+    - name: UpdateEntityPixelPos
       address:
         EU: 0x22E2380
         NA: 0x22E1A40
@@ -325,7 +325,7 @@ overlay29:
         It could also be used to spawn fixed room allies, since those share their slots on the entity list.
         
         r0: Monster ID
-        Return: Pointer to the newly initialized entity, or null if the entity couldn't be initialized
+        return: Pointer to the newly initialized entity, or null if the entity couldn't be initialized
     - name: SpawnTrap
       address:
         EU: 0x22E2BA0
@@ -2299,6 +2299,7 @@ overlay29:
         
         r0: Monster entity pointer
         r1: Direction to check
+        return: bool
     - name: GetFinalMobilityType
       address:
         EU: 0x230195C
@@ -2311,6 +2312,7 @@ overlay29:
         r0: Monster entity pointer
         r1: Base mobility type
         r2: Direction of mobility
+        return: Final mobility type
     - name: IsMonsterCornered
       address:
         EU: 0x2301B44
@@ -6138,7 +6140,7 @@ overlay29:
       description: |-
         Returns the next action that needs to be performed when spawning a fixed room tile.
         
-        Return: Next action ID
+        return: Next action ID
     - name: ConvertWallsToChasms
       address:
         EU: 0x234312C
@@ -6235,7 +6237,7 @@ overlay29:
         The conversion is performed by subtracting 1 to the value. If the parameter had a value of 0, DIR_NONE is returned.
         
         r0: Parameter value
-        Return: Direction
+        return: Direction
     - name: ApplyKeyEffect
       address:
         EU: 0x23448BC

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -306,6 +306,26 @@ overlay29:
         
         r0: pointer to entity
         returns: pointer to tile
+    - name: UpdateEnityPixelPos
+      address:
+        EU: 0x22E2380
+        NA: 0x22E1A40
+      description: |-
+        Updates an entity's pixel_pos field using the specified pixel_position struct, or its own pos field if it's null.
+        
+        r0: Entity pointer
+        r1: Pixel position to use, or null to use the entity's own position
+    - name: InitEnemyEntity
+      address:
+        EU: 0x22E2A00
+        NA: 0x22E20C0
+      description: |-
+        Initializes the entity struct of a newly spawned enemy monster. Fails if there's 16 enemies on the floor already.
+        
+        It could also be used to spawn fixed room allies, since those share their slots on the entity list.
+        
+        r0: Monster ID
+        Return: Pointer to the newly initialized entity, or null if the entity couldn't be initialized
     - name: SpawnTrap
       address:
         EU: 0x22E2BA0
@@ -1559,6 +1579,17 @@ overlay29:
         r0: Fainted entity
         r1: Damage source (move ID or greater than the max move id for other causes)
         r2: Entity responsible of the fainting
+    - name: MoveMonsterToPos
+      address:
+        EU: 0x22F8FFC
+        NA: 0x22F85F0
+      description: |-
+        Moves a monster to the target position. Used both for regular movement and special movement (like teleportation).
+        
+        r0: Entity pointer
+        r1: X target position
+        r2: Y target position
+        r3: ?
     - name: UpdateAiTargetPos
       address:
         EU: 0x22F9B50
@@ -1917,6 +1948,18 @@ overlay29:
         
         r0: monster pointer
         return: bool
+    - name: InitOtherMonsterData
+      address:
+        EU: 0x22FC854
+        NA: 0x22FBE58
+      description: |-
+        Initializes stats, IQ skills and moves for a given monster
+        
+        Might only be used when spawning fixed room monsters.
+        
+        r0: Entity pointer
+        r1: Fixed room monster stats index
+        r2: Spawn direction? (when calling this function while spawning a fixed room monster, this is the parameter value associated to the spawn action, after converting it to a direction.)
     - name: SpawnTeam
       address:
         EU: 0x22FCF08
@@ -1967,11 +2010,22 @@ overlay29:
         stack[4]: ?
     - name: InitMonster
       address:
+        EU: 0x22FE3D0
+        NA: 0x22FD9D4
+      description: |-
+        Initializes the monster struct within the provided entity struct.
+        
+        r0: ?
+        r1: Pointer to the entity whose monster struct should be initialized
+        r2: pointer to the entity's spawned_monster_data struct
+        r3: (?) Pointer to something
+    - name: SubInitMonster
+      address:
         EU: 0x22FE7BC
         NA: 0x22FDDC0
         JP: 0x22FF1B0
       description: |-
-        Initializes a monster struct.
+        Called by InitMonster. Initializes some fields on the monster struct.
         
         r0: pointer to monster to initialize
         r1: some flag
@@ -2234,6 +2288,29 @@ overlay29:
         
         r0: entity pointer
         return: bool
+    - name: CanMonsterMoveInDirection
+      address:
+        EU: 0x23018A4
+        NA: 0x230105C
+      description: |-
+        Checks if the given monster can move in the specified direction
+        
+        Returns false if any monster is standing on the target tile
+        
+        r0: Monster entity pointer
+        r1: Direction to check
+    - name: GetFinalMobilityType
+      address:
+        EU: 0x230195C
+        NA: 0x2300F30
+      description: |-
+        Returns the mobility type of a monster, after accounting for things that could affect it (like items or IQ skills)
+        
+        If the specified direction is DIR_NONE, direction checks are skipped. If it's not, MOBILITY_INTANGIBLE is only returned if the direction is not diagonal.
+        
+        r0: Monster entity pointer
+        r1: Base mobility type
+        r2: Direction of mobility
     - name: IsMonsterCornered
       address:
         EU: 0x2301B44
@@ -5142,6 +5219,25 @@ overlay29:
         Exact purpose unknown. Gets called whenever a trap tile is shown or hidden.
         
         No params.
+    - name: DrawTileGrid
+      address:
+        EU: 0x2337FF8
+        NA: 0x2337428
+      description: |-
+        Draws a grid on the nearby walkable tiles. Triggered by pressing Y.
+        
+        r0: Coordinates of the entity around which the grid will be drawn
+        r1: ?
+        r2: ?
+        r3: ?
+    - name: HideTileGrid
+      address:
+        EU: 0x233836C
+        NA: 0x233779C
+      description: |-
+        Hides the grid on the nearby walkable tiles. Triggered by releasing Y.
+        
+        No params.
     - name: DiscoverMinimap
       address:
         EU: 0x233860C
@@ -6035,6 +6131,14 @@ overlay29:
         r1: y coordinate of the stairs
         r2: flag to always return true, but set a special bit on all walkable tiles that aren't reachable from the stairs
         return: bool
+    - name: GetNextFixedRoomAction
+      address:
+        EU: 0x23430B4
+        NA: 0x23424D0
+      description: |-
+        Returns the next action that needs to be performed when spawning a fixed room tile.
+        
+        Return: Next action ID
     - name: ConvertWallsToChasms
       address:
         EU: 0x234312C
@@ -6110,8 +6214,31 @@ overlay29:
         Resets hidden stairs spawn information for the floor. This includes the position on the floor generation status as well as the flag indicating whether the spawn was blocked.
         
         No params.
+    - name: PlaceFixedRoomTile
+      address:
+        EU: 0x2343B14
+        NA: 0x2342F30
+      description: |-
+        Used to spawn a single tile when generating a fixed room. The tile might contain an item or a monster.
+        
+        r0: Pointer to the tile to spawn
+        r1: Fixed room action to perform. Controls what exactly will be spawned. The action is actually 12 bits long, the highest 4 bits are used as a parameter that represents a direction (for example, when spawning a monster).
+        r2: Tile X position
+        r3: Tile Y position
+    - name: FixedRoomActionParamToDirection
+      address:
+        EU: 0x2344550
+        NA: 0x234396C
+      description: |-
+        Converts the parameter stored in a fixed room action value to a direction ID.
+        
+        The conversion is performed by subtracting 1 to the value. If the parameter had a value of 0, DIR_NONE is returned.
+        
+        r0: Parameter value
+        Return: Direction
     - name: ApplyKeyEffect
       address:
+        EU: 0x23448BC
         NA: 0x2343CD8
       description: |-
         Attempts to open a locked door in front of the target if a locked door has not already

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -315,12 +315,12 @@ overlay29:
         
         r0: Entity pointer
         r1: Pixel position to use, or null to use the entity's own position
-    - name: InitEnemyEntity
+    - name: CreateEnemyEntity
       address:
         EU: 0x22E2A00
         NA: 0x22E20C0
       description: |-
-        Initializes the entity struct of a newly spawned enemy monster. Fails if there's 16 enemies on the floor already.
+        Creates and initializes the entity struct of a newly spawned enemy monster. Fails if there's 16 enemies on the floor already.
         
         It could also be used to spawn fixed room allies, since those share their slots on the entity list.
         

--- a/symbols/overlay30.yml
+++ b/symbols/overlay30.yml
@@ -12,7 +12,18 @@ overlay30:
     NA: 0x38A0
     JP: 0x3880
   description: Controls quicksaving in dungeons.
-  functions: []
+  functions:
+    - name: WriteQuicksaveData
+      address:
+        EU: 0x2383868
+        NA: 0x2382C6C
+      description: |-
+        Function responsible for writing dungeon data when quicksaving.
+        
+        Among other things, it contains a loop that goes through all the monsters in the current dungeon, copying their data to the buffer. The data is not copied as-is though, the game uses a reduced version of the monster struct containing only the minimum required data to resume the game later.
+        
+        r0: Pointer to buffer where data should be written
+        r1: Buffer size. Seems to be 0x5800 (22 KB) when the function is called.
   data:
     - name: OVERLAY30_JP_STRING_1
       address:


### PR DESCRIPTION
Adds functions mostly related to:

- Exclusive items
- Quicksaving
- The grid that shows up in dungeon mode when you hold Y
- Moving pokémon to a different position
- Dungeon tiles
- Dungeon results screen ("The Last Outing")
- Fixed rooms
	- Includes some functions about spawning and initializing entities, since I documented those when I started researching fixed rooms

`InitMonster` has been renamed to `SubInitMonster`, since there's another function above it that is the main function responsible for initializing a new monster.