### PR TITLE
resymgen: Support multiple naming conventions in checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resymgen"
 description = "Generates symbol tables for reverse engineering applications from a YAML specification"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["UsernameFodder <usernamefodder@gmail.com>"]
 edition = "2018"
 rust-version = "1.58"

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,8 @@ fn run_resymgen() -> Result<(), Box<dyn Error>> {
                         .takes_value(true)
                         .short("f")
                         .long("function-names")
+                        .multiple(true)
+                        .number_of_values(1)
                         .set(ArgSettings::CaseInsensitive)
                         .possible_values(&SUPPORTED_NAMING_CONVENTIONS),
                     Arg::with_name("data names")
@@ -164,6 +166,8 @@ fn run_resymgen() -> Result<(), Box<dyn Error>> {
                         .takes_value(true)
                         .short("d")
                         .long("data-names")
+                        .multiple(true)
+                        .number_of_values(1)
                         .set(ArgSettings::CaseInsensitive)
                         .possible_values(&SUPPORTED_NAMING_CONVENTIONS),
                     Arg::with_name("input")
@@ -347,11 +351,15 @@ fn run_resymgen() -> Result<(), Box<dyn Error>> {
             if matches.is_present("no overlap") {
                 checks.push(resymgen::Check::NoOverlap);
             }
-            if let Some(conv) = matches.value_of("function names") {
-                checks.push(resymgen::Check::FunctionNames(naming_convention(conv)));
+            if let Some(convs) = matches.values_of("function names") {
+                checks.push(resymgen::Check::FunctionNames(
+                    convs.map(naming_convention).collect(),
+                ));
             }
-            if let Some(conv) = matches.value_of("data names") {
-                checks.push(resymgen::Check::DataNames(naming_convention(conv)));
+            if let Some(convs) = matches.values_of("data names") {
+                checks.push(resymgen::Check::DataNames(
+                    convs.map(naming_convention).collect(),
+                ));
             }
             // This one handles multiple files internally so that check result printing
             // can be merged appropriately

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,14 +377,14 @@ fn run_resymgen() -> Result<(), Box<dyn Error>> {
             let iformat = int_format(matches.is_present("decimal"));
             let fix_formatting = matches.is_present("fix formatting");
             let unmerged_symbols = resymgen::merge_symbols(
-                &symgen_file,
+                symgen_file,
                 &input_files,
                 input_format,
                 &merge_params,
                 iformat,
             )?;
             if fix_formatting {
-                resymgen::format_file(&symgen_file, true, iformat)?;
+                resymgen::format_file(symgen_file, true, iformat)?;
             }
 
             // Print the unmerged symbols from each file, with terminal colors


### PR DESCRIPTION
Allow the `--function-names` and `--data-names` options for `resymgen check` to be specified more than once with different values, which will check that at least one of the specified naming conventions is satisfied.

Closes https://github.com/UsernameFodder/pmdsky-debug/issues/152.