### PR TITLE
Info regarding portrait box, live actor direction and music in dungeon

### DIFF
--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -33,6 +33,8 @@ void AllocAndInitPartnerFollowDataAndLiveActorList(void);
 void InitPartnerFollowDataAndLiveActorList(void);
 void DeleteLiveActor(int16_t actor_id);
 void InitPartnerFollowData(void);
+void GetDirectionLiveActor(struct live_actor* actor, struct direction_id_8* target);
+void SetDirectionLiveActor(struct live_actor* actor, struct direction_id_8 direction);
 void GetExclusiveItemRequirements(undefined param_1, undefined param_2);
 void StatusUpdate(void);
 

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -748,15 +748,17 @@ void LogMessageByIdWithPopup(struct entity* user, int message_id);
 void LogMessageWithPopup(struct entity* user, const char* message);
 void LogMessage(struct entity* user, const char* message, bool show_popup);
 void LogMessageById(struct entity* user, int message_id, bool show_popup);
+void InitPortraitDungeon(struct portrait_box* portrait, enum monster_id monster_id,
+                         enum portrait_emotion emotion);
 void OpenMessageLog(undefined4 param_1, undefined4 param_2);
 bool RunDungeonMode(undefined4* param_1, undefined4 param_2);
 void DisplayDungeonTip(struct message_tip* message_tip, bool log);
 void SetBothScreensWindowColorToDefault(void);
 int GetPersonalityIndex(struct monster* monster);
-void DisplayMessage(undefined4 param_1, int message_id, bool wait_for_input);
-void DisplayMessage2(undefined4 param_1, int message_id, bool wait_for_input);
+void DisplayMessage(struct portrait_box* portrait, int message_id, bool wait_for_input);
+void DisplayMessage2(struct portrait_box* portrait, int message_id, bool wait_for_input);
 bool YesNoMenu(undefined param_1, int message_id, int default_option, undefined param_4);
-void DisplayMessageInternal(int message_id, bool wait_for_input, undefined4 param_3,
+void DisplayMessageInternal(int message_id, bool wait_for_input, struct portrait_box* portrait,
                             undefined4 param_4, undefined4 param_5, undefined4 param_6);
 void OpenMenu(undefined param_1, undefined param_2, bool open_bag);
 int OthersMenuLoop(void);

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -125,20 +125,13 @@ struct dialog_box {
 };
 ASSERT_SIZE(struct dialog_box, 224);
 
-// Structure for dialog boxes with portraits?
+// Represent a portrait that appear inside a dialogue box
 struct portrait_box {
-    undefined field_0x0;
-    undefined field_0x1;
-    undefined field_0x2;
+    struct monster_id_16 monster_id;
+    struct portrait_emotion_8 portrait_emotion;
     undefined field_0x3;
-    undefined field_0x4;
-    undefined field_0x5;
-    undefined field_0x6;
-    undefined field_0x7;
-    undefined field_0x8;
-    undefined field_0x9;
-    undefined field_0xa;
-    undefined field_0xb;
+    undefined4 field_0x4;
+    undefined4 field_0x8;
     undefined field_0xc;
     undefined field_0xd;
     undefined field_0xe;

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -125,7 +125,7 @@ struct dialog_box {
 };
 ASSERT_SIZE(struct dialog_box, 224);
 
-// Represent a portrait that appear inside a dialogue box
+// Represents a portrait that appears inside a dialogue box
 struct portrait_box {
     struct monster_id_16 monster_id;
     struct portrait_emotion_8 portrait_emotion;

--- a/headers/types/common/enums.h
+++ b/headers/types/common/enums.h
@@ -708,6 +708,35 @@ enum monster_id {
 ENUM_16_BIT(monster_id);
 #pragma pack(pop)
 
+// Emotion for portraits
+enum portrait_emotion {
+    PORTRAIT_NORMAL = 0,
+    PORTRAIT_HAPPY = 1,
+    PORTRAIT_PAIN = 2,
+    PORTRAIT_ANGRY = 3,
+    PORTRAIT_WORRIED = 4,
+    PORTRAIT_SAD = 5,
+    PORTRAIT_CRYING = 6,
+    PORTRAIT_SHOUTING = 7,
+    PORTRAIT_TEARY_EYED = 8,
+    PORTRAIT_DETERMINED = 9,
+    PORTRAIT_JOYOUS = 10,
+    PORTRAIT_INSPIRED = 11,
+    PORTRAIT_SURPRISED = 12,
+    PORTRAIT_DIZZY = 13,
+    PORTRAIT_SPECIAL0 = 14,
+    PORTRAIT_SPECIAL1 = 15,
+    PORTRAIT_SIGH = 16,
+    PORTRAIT_STUNNED = 17,
+    PORTRAIT_SPECIAL2 = 18,
+    PORTRAIT_SPECIAL3 = 19
+};
+
+// This is usually stored as an 8-bit integer
+#pragma pack(push, 1)
+ENUM_8_BIT(portrait_emotion);
+#pragma pack(pop)
+
 // Item ID
 enum item_id {
     ITEM_NOTHING = 0,

--- a/headers/types/common/enums.h
+++ b/headers/types/common/enums.h
@@ -729,7 +729,7 @@ enum portrait_emotion {
     PORTRAIT_SIGH = 16,
     PORTRAIT_STUNNED = 17,
     PORTRAIT_SPECIAL2 = 18,
-    PORTRAIT_SPECIAL3 = 19
+    PORTRAIT_SPECIAL3 = 19,
 };
 
 // This is usually stored as an 8-bit integer

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -356,6 +356,24 @@ overlay11:
         Initialize the partner follow data structure, without allocating it (in GROUND_STATE_PTRS)
         
         No params.
+    - name: GetDirectionLiveActor
+      address:
+        EU: 0x22FDB48
+      description: |-
+        Put the direction of the actor in the destination
+        
+        r0: live actor
+        r1: destination address (1 byte)
+    - name: SetDirectionLiveActor
+      address:
+        EU: 0x22FDB58
+      description: |-
+        Store the direction in the actor structure
+        -1 input is ignored
+        Unsure if this change the animation
+        
+        r0: live actor
+        r1: direction
     - name: SprintfStatic
       address:
         EU: 0x2309868

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -6989,7 +6989,7 @@ overlay29:
       address:
         EU: 0x234C6C0
       description: |-
-        Initialise the portrait box structure for the given monster and expression
+        Initialize the portrait box structure for the given monster and expression
         
         r0: pointer the portrait box data structure to initialize
         r1: monster id
@@ -7085,7 +7085,7 @@ overlay29:
         
         r0: ID of the string to display
         r1: True to wait for player input before closing the dialogue box, false to close it automatically once all the characters get printed.
-        r2: ? (r0 in DisplayMessage)
+        r2: pointer to the structure representing the desired state of the portrait
         r3: ?
         stack[0]: ?
         stack[1]: ?

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -976,7 +976,7 @@ overlay29:
         NA: 0x22EAE14
         JP: 0x22EC47C
       description: |-
-        Note: unverified, ported from Irdkwia's notes
+        Replace the currently playing music with the provided music
         
         r0: music ID
     - name: TrySwitchPlace
@@ -6985,6 +6985,15 @@ overlay29:
         r0: user entity pointer
         r1: message ID
         r2: bool, whether or not to present a message popup
+    - name: InitPortraitDungeon
+      address:
+        EU: 0x234C6C0
+      description: |-
+        Initialise the portrait box structure for the given monster and expression
+        
+        r0: pointer the portrait box data structure to initialize
+        r1: monster id
+        r2: emotion id
     - name: OpenMessageLog
       address:
         EU: 0x234C75C
@@ -7044,7 +7053,7 @@ overlay29:
       description: |-
         Displays a message in a dialogue box that optionally waits for player input before closing.
         
-        r0: ?
+        r0: pointer to the structure representing the desired state of the portrait
         r1: ID of the string to display
         r2: True to wait for player input before closing the dialogue box, false to close it automatically once all the characters get printed.
     - name: DisplayMessage2


### PR DESCRIPTION
I’m still a bit unsure in which order I want to add stuff in pmdsky-debug. I think I’ll for now focus in the palette in overlay11 stuff. But I did that in the meantime.

Also, I think portrait_box is the "kaomodo" struct in this PR: https://github.com/UsernameFodder/pmdsky-debug/pull/21/files