### PR TITLE
Properly document MainGame

### DIFF
--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -743,6 +743,7 @@ void ScriptSpecialProcess0x3D(void);
 void ScriptSpecialProcess0x3E(void);
 void ScriptSpecialProcess0x17(void);
 void ItemAtTableIdx(int idx, struct bulk_item* item);
+void MainLoop(void);
 int DungeonSwapIdToIdx(enum dungeon_id dungeon_id);
 enum dungeon_id DungeonSwapIdxToId(int idx);
 enum dungeon_mode GetDungeonModeSpecial(enum dungeon_id dungeon_id);

--- a/headers/functions/overlay10.h
+++ b/headers/functions/overlay10.h
@@ -11,6 +11,6 @@ int16_t GetItemAnimation1(enum item_id item_id);
 int16_t GetItemAnimation2(enum item_id item_id);
 int GetMoveAnimationSpeed(enum move_id move_id);
 bool IsBackgroundTileset(int tileset_id);
-int CheckEndDungeon(int end_cond);
+int MainGame(int end_cond);
 
 #endif

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -7337,6 +7337,14 @@ arm9:
         
         r0: table index
         r1: [output] pointer to an owned_item
+    - name: MainLoop
+      address:
+        EU: 0x2066098
+        NA: 0x2065D1C
+      description: |-
+        This function gets called shortly after the game is started. Contains a single infinite loop and has no return statement.
+        
+        No params.
     - name: DungeonSwapIdToIdx
       address:
         EU: 0x206AAAC

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -137,7 +137,7 @@ overlay10:
       description: |-
         Contains several functions that handle switching between ground and dungeon mode. It also handles other situations, like what happens right after exiting a dungeon.
         
-        The name comes from a debug print with the string "MainGame enter dungeon mode %d %d". Despite its name, it's not a main function. It doesn't get called until the player selects the option to resume a saved game, and it might return under certain circumstances.
+        The function doesn't get called until the player selects the option to resume a saved game and doesn't return until the player returns to the main menu.
         
         r0: End condition code? Seems to control what tasks get run and what transition happens when the dungeon ends
         return: return code?

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -129,15 +129,15 @@ overlay10:
         
         r0: Tileset ID
         return: True if the tileset ID corresponds to a background, false if it corresponds to a regular tileset
-    - name: CheckEndDungeon
+    - name: MainGame
       address:
         EU: 0x22C31E4
         NA: 0x22C288C
         JP: 0x22C3F74
       description: |-
-        Do the stuff when you lose in a dungeon.
+        Contains several functions that handle switching between ground and dungeon mode. It also handles other situations, like what happens right after exiting a dungeon.
         
-        Note: unverified, ported from Irdkwia's notes
+        The name comes from a debug print with the string "MainGame enter dungeon mode %d %d". Despite its name, it's not a main function. It doesn't get called until the player selects the option to resume a saved game, and it might return under certain circumstances.
         
         r0: End condition code? Seems to control what tasks get run and what transition happens when the dungeon ends
         return: return code?

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -7573,7 +7573,7 @@ overlay29:
       description: |-
         This appears to be the top-level function for running dungeon mode.
         
-        It gets called by some code in overlay 10 right after doing the dungeon fade transition, and once it exits, the dungeon results are processed.
+        It gets called by MainGame right after doing the dungeon fade transition, and once it exits, the dungeon results are processed.
         
         This function is presumably in charge of allocating the dungeon struct, setting it up, launching the dungeon engine, etc.
     - name: DisplayDungeonTip


### PR DESCRIPTION
Renames `CheckEndDungeon` to `MainGame` and documents it in more detail.