### PR TITLE
Some 3d engine documentation

### DIFF
--- a/headers/data/arm9.h
+++ b/headers/data/arm9.h
@@ -114,6 +114,7 @@ extern struct item* BAG_ITEMS_PTR_MIRROR;
 extern void* ITEM_DATA_TABLE_PTRS[3];
 extern struct move_data_table* MOVE_DATA_TABLE_PTR;
 extern struct wan_table* WAN_TABLE;
+extern struct render_3d_global RENDER_3D;
 extern int16_t TBL_TALK_GROUP_STRING_ID_START[6];
 extern int16_t KEYBOARD_STRING_IDS[30];
 extern bool NOTIFY_NOTE;

--- a/headers/data/arm9/itcm.h
+++ b/headers/data/arm9/itcm.h
@@ -4,5 +4,6 @@
 extern struct mem_alloc_table MEMORY_ALLOCATION_TABLE;
 extern struct mem_arena DEFAULT_MEMORY_ARENA;
 extern struct mem_block DEFAULT_MEMORY_ARENA_BLOCKS[256];
-extern struct render_3d_element_concrete* RENDER_3D_FUNCTIONS[4];
+extern render_3d_element_concrete_fn_t RENDER_3D_FUNCTIONS[4];
+
 #endif

--- a/headers/data/arm9/itcm.h
+++ b/headers/data/arm9/itcm.h
@@ -4,5 +4,5 @@
 extern struct mem_alloc_table MEMORY_ALLOCATION_TABLE;
 extern struct mem_arena DEFAULT_MEMORY_ARENA;
 extern struct mem_block DEFAULT_MEMORY_ARENA_BLOCKS[256];
-
+extern struct render_3d_element_concrete* RENDER_3D_FUNCTIONS[4];
 #endif

--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -317,7 +317,17 @@ void StopSe(int param_1, int param_2);
 void InitAnimationControl(struct animation_control* animation_control);
 void InitAnimationControlWithSet(struct animation_control* animation_control);
 void SetSpriteIdForAnimationControl(struct animation_control* anim_ctrl, uint16_t sprite_id);
+void SetAnimationForAnimationControlInternal(struct animation_control* anim_ctrl,
+                                             struct wan_header* wan_header, int animation_group_id,
+                                             int animation_id, int unk1, int low_palette_pos,
+                                             int unk2, int unk3, int palette_bank);
+void SetAnimationForAnimationControl(struct animation_control* anim_ctrl, int animation_key,
+                                     enum direction_id direction, int unk1, int low_palette_pos,
+                                     int unk2, int unk3);
 struct wan_header* GetWanForAnimationControl(struct animation_control* anim_ctrl);
+void SetAndPlayAnimationForAnimationControl(struct animation_control* anim_ctrl, int animation_key,
+                                            enum direction_id direction, int unk1,
+                                            int low_palette_pos, int unk2, int unk3);
 void SwitchAnimationControlToNextFrame(struct animation_control* anim_ctrl);
 void LoadAnimationFrameAndIncrementInAnimationControl(struct animation_control* anim_ctrl,
                                                       struct wan_animation_frame* anim_frame);
@@ -347,6 +357,14 @@ void UnloadWte(struct wte_handle* handle);
 undefined* LoadWtuFromBin(int bin_file_id, int file_id, int load_type);
 void ProcessWte(undefined* header, undefined4 unk_pal, undefined4 unk_tex,
                 undefined4 unk_tex_param);
+void GeomSetTexImageParam(int texture_format, int texture_coordinates_transformation_modes,
+                          int texture_s_size, int texture_t_size, bool repeat_s, bool flip_s,
+                          bool color_0, bool vram_offset);
+void GeomSetVertexCoord16(int x, int y, int z);
+void InitRender3dData(void);
+void GeomSwapBuffers(void);
+void InitRender3dElement(struct render_3d_element* element);
+void Generate3dCanvasBorder(struct render_3d_element* element);
 int HandleSir0Translation(uint8_t** dst, uint8_t* src);
 void ConvertPointersSir0(undefined* sir0_ptr);
 int HandleSir0TranslationVeneer(uint8_t** dst, uint8_t* src);

--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -323,11 +323,11 @@ void SetAnimationForAnimationControlInternal(struct animation_control* anim_ctrl
                                              int unk2, int unk3, int palette_bank);
 void SetAnimationForAnimationControl(struct animation_control* anim_ctrl, int animation_key,
                                      enum direction_id direction, int unk1, int low_palette_pos,
-                                     int unk2, int unk3);
+                                     int unk2, int unk3, int unk4);
 struct wan_header* GetWanForAnimationControl(struct animation_control* anim_ctrl);
 void SetAndPlayAnimationForAnimationControl(struct animation_control* anim_ctrl, int animation_key,
                                             enum direction_id direction, int unk1,
-                                            int low_palette_pos, int unk2, int unk3);
+                                            int low_palette_pos, int unk2, int unk3, int unk4);
 void SwitchAnimationControlToNextFrame(struct animation_control* anim_ctrl);
 void LoadAnimationFrameAndIncrementInAnimationControl(struct animation_control* anim_ctrl,
                                                       struct wan_animation_frame* anim_frame);

--- a/headers/functions/arm9/itcm.h
+++ b/headers/functions/arm9/itcm.h
@@ -1,7 +1,7 @@
 #ifndef HEADERS_FUNCTIONS_ARM9_ITCM_H_
 #define HEADERS_FUNCTIONS_ARM9_ITCM_H_
 
-struct render_3d_element* AllocateNewRender3dElement(void);
+struct render_3d_element* AllocateRender3dElement(void);
 void Render3dStack(void);
 void GetKeyN2MSwitch(int key, int sw);
 enum monster_id GetKeyN2M(int key);

--- a/headers/functions/arm9/itcm.h
+++ b/headers/functions/arm9/itcm.h
@@ -1,6 +1,8 @@
 #ifndef HEADERS_FUNCTIONS_ARM9_ITCM_H_
 #define HEADERS_FUNCTIONS_ARM9_ITCM_H_
 
+struct render_3d_element* AllocateNewRender3dElement(void);
+void Render3DStack(void);
 void GetKeyN2MSwitch(int key, int sw);
 enum monster_id GetKeyN2M(int key);
 enum monster_id GetKeyN2MBaseForm(int key);

--- a/headers/functions/arm9/itcm.h
+++ b/headers/functions/arm9/itcm.h
@@ -2,7 +2,7 @@
 #define HEADERS_FUNCTIONS_ARM9_ITCM_H_
 
 struct render_3d_element* AllocateNewRender3dElement(void);
-void Render3DStack(void);
+void Render3dStack(void);
 void GetKeyN2MSwitch(int key, int sw);
 enum monster_id GetKeyN2M(int key);
 enum monster_id GetKeyN2MBaseForm(int key);

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -614,7 +614,7 @@ bool TryActivateWeather(bool param_1, bool param_2);
 int DigitCount(int n);
 void LoadTextureUi(void);
 int DisplayNumberTextureUi(int16_t x, int16_t y, int n, int ally_mode);
-int DisplayCharTextureUi(undefined* call_back_str, int16_t x, int16_t y, int char_id,
+int DisplayCharTextureUi(struct render_3d_element* call_back_str, int16_t x, int16_t y, int char_id,
                          int16_t param_5);
 void DisplayUi(void);
 struct tile* GetTile(int x, int y);

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -614,8 +614,8 @@ bool TryActivateWeather(bool param_1, bool param_2);
 int DigitCount(int n);
 void LoadTextureUi(void);
 int DisplayNumberTextureUi(int16_t x, int16_t y, int n, int ally_mode);
-int DisplayCharTextureUi(struct render_3d_element* call_back_str, int16_t x, int16_t y, int char_id,
-                         int16_t param_5);
+int DisplayCharTextureUi(struct render_3d_element* render_3d_element, int16_t x, int16_t y,
+                         int char_id, int16_t param_5);
 void DisplayUi(void);
 struct tile* GetTile(int x, int y);
 struct tile* GetTileSafe(int x, int y);

--- a/headers/types/common/graphics.h
+++ b/headers/types/common/graphics.h
@@ -108,7 +108,7 @@ ASSERT_SIZE(struct render_3d_element, 52);
 
 // Function that will use the relevant 3d render API to render a render_3d_element from the
 // RENDER_3D queue.
-typedef void (*render_3d_element_concrete)(struct render_3d_element*);
+typedef void (*render_3d_element_concrete_fn_t)(struct render_3d_element* element);
 
 // A global, unique structure that stores element relating to the 3d engine, in particular the list
 // of elements to render later in the frame.

--- a/headers/types/common/graphics.h
+++ b/headers/types/common/graphics.h
@@ -73,12 +73,12 @@ struct animation_control {
 ASSERT_SIZE(struct animation_control, 124);
 
 // Represent a single element to render using the 3D engine
-// This structure is used in two different way. The first one is for planning rendering, that will
+// This structure is used in two different ways. The first one is for planning rendering, that will
 // then call function that will call a function that will then add themm to RENDER_3D for rendering
 // later in the frame.
 struct render_3d_element {
     undefined2 render_function_id; // range from 0 to 3 (included)
-    undefined2 field1_0x2;         /* appears to be a render priority level. Impact sorting. */
+    undefined2 field1_0x2;         // appears to be a render priority level. Impact sorting.
     undefined4 field2_0x4;
     undefined4 field3_0x8;
     uint16_t x_tileset_start;
@@ -103,8 +103,8 @@ struct render_3d_element {
 };
 ASSERT_SIZE(struct render_3d_element, 52);
 
-// A global, unique structure that store element relating to the 3d engine, in particular the list
-// of element to render later in the frame.
+// A global, unique structure that stores element relating to the 3d engine, in particular the list
+// of elements to render later in the frame.
 struct render_3d_global {
     uint16_t current_index;
     uint16_t max_index; // Seems to consistently be 128, size of render_stack

--- a/headers/types/common/graphics.h
+++ b/headers/types/common/graphics.h
@@ -24,12 +24,13 @@ struct animation_control {
     struct vec2_16 anim_frame_offset;
     struct vec2_16 anim_frame_shadow_offset;
     uint32_t anim_frame_flag;
-    uint32_t anim_frame_flag_sum; // ORed from the current WAN animation frame flag
-    undefined2 field18_0x30;
+    uint32_t anim_frame_flag_sum;     // ORed from the current WAN animation frame flag
+    uint16_t animations_or_group_len; // number of animation group Chara sprites, other number of
+                                      // animation in the first animation group
     undefined2 field19_0x32;
     undefined field20_0x34;
     undefined field21_0x35;
-    undefined2 field22_0x36;
+    undefined2 field22_0x36; // seems to be an index into the wan fragments table
     undefined2 field23_0x38;
     uint16_t anim_frame_frame_id;
     undefined2 field25_0x3c;
@@ -70,5 +71,98 @@ struct animation_control {
     undefined field57_0x7b;
 };
 ASSERT_SIZE(struct animation_control, 124);
+
+// Represent a single element to render using the 3D engine
+// This structure is used in two different way. The first one is for planning rendering, that will
+// then call function that will call a function that will then add themm to RENDER_3D for rendering
+// later in the frame.
+struct render_3d_element {
+    undefined2 render_function_id; // range from 0 to 3 (included)
+    undefined2 field1_0x2;         /* appears to be a render priority level. Impact sorting. */
+    undefined4 field2_0x4;
+    undefined4 field3_0x8;
+    uint16_t x_tileset_start;
+    uint16_t y_tileset_start;
+    uint16_t x_tileset_width_offset;
+    uint16_t y_tileset_height_offset;
+    undefined2 field8_0x14;
+    undefined2 x_start_1;
+    undefined2 y_start_1;
+    undefined2 x_end_1;
+    undefined2 y_start_2;
+    undefined2 x_start_2;
+    undefined2 y_end_1;
+    undefined2 x_end_2;
+    undefined2 y_end_2;
+    undefined2 field17_0x26[4];
+    undefined2 field18_0x2e;
+    undefined field19_0x30;
+    char field20_0x31;
+    bool field21_0x32;
+    undefined field22_0x33;
+};
+ASSERT_SIZE(struct render_3d_element, 52);
+
+// A global, unique structure that store element relating to the 3d engine, in particular the list
+// of element to render later in the frame.
+struct render_3d_global {
+    uint16_t current_index;
+    uint16_t max_index; // Seems to consistently be 128, size of render_stack
+    undefined4 field2_0x4;
+    undefined4 field3_0x8;
+    undefined field4_0xc;
+    undefined field5_0xd;
+    undefined field6_0xe;
+    undefined field7_0xf;
+    undefined field8_0x10;
+    undefined field9_0x11;
+    undefined field10_0x12;
+    undefined field11_0x13;
+    undefined field12_0x14;
+    undefined field13_0x15;
+    undefined field14_0x16;
+    undefined field15_0x17;
+    undefined field16_0x18;
+    undefined field17_0x19;
+    undefined field18_0x1a;
+    undefined field19_0x1b;
+    undefined field20_0x1c;
+    undefined field21_0x1d;
+    undefined field22_0x1e;
+    undefined field23_0x1f;
+    undefined field24_0x20;
+    undefined field25_0x21;
+    undefined field26_0x22;
+    undefined field27_0x23;
+    undefined field28_0x24;
+    undefined field29_0x25;
+    undefined field30_0x26;
+    undefined field31_0x27;
+    undefined field32_0x28;
+    undefined field33_0x29;
+    undefined field34_0x2a;
+    undefined field35_0x2b;
+    undefined field36_0x2c;
+    undefined field37_0x2d;
+    undefined field38_0x2e;
+    undefined field39_0x2f;
+    undefined field40_0x30;
+    undefined field41_0x31;
+    undefined field42_0x32;
+    undefined field43_0x33;
+    undefined field44_0x34;
+    undefined field45_0x35;
+    undefined field46_0x36;
+    undefined field47_0x37;
+    undefined field48_0x38;
+    undefined field49_0x39;
+    undefined field50_0x3a;
+    undefined field51_0x3b;
+    undefined field52_0x3c;
+    undefined field53_0x3d;
+    undefined field54_0x3e;
+    undefined field55_0x3f;
+    struct render_3d_element* render_stack[128];
+};
 
 #endif

--- a/headers/types/common/graphics.h
+++ b/headers/types/common/graphics.h
@@ -74,11 +74,14 @@ ASSERT_SIZE(struct animation_control, 124);
 
 // Represent a single element to render using the 3D engine
 // This structure is used in two different ways. The first one is for planning rendering, that will
-// then call function that will call a function that will then add themm to RENDER_3D for rendering
-// later in the frame.
+// be passed as an argument to a function. Said function will then add them to RENDER_3D
+// for rendering later in the frame (second type of use, with slightly different argument, but that
+// often appear to be a copy of the struct with some value changed)
 struct render_3d_element {
-    undefined2 render_function_id; // range from 0 to 3 (included)
-    undefined2 field1_0x2;         // appears to be a render priority level. Impact sorting.
+    // range from 0 to 3 (included). Function used in the rendering phase, from the
+    // RENDER_3D_FUNCTIONS table
+    undefined2 render_function_id;
+    undefined2 field1_0x2; // appears to be a render priority level. Impact sorting.
     undefined4 field2_0x4;
     undefined4 field3_0x8;
     uint16_t x_tileset_start;
@@ -102,6 +105,10 @@ struct render_3d_element {
     undefined field22_0x33;
 };
 ASSERT_SIZE(struct render_3d_element, 52);
+
+// Function that will use the relevant 3d render API to render a render_3d_element from the
+// RENDER_3D queue.
+typedef void (*render_3d_element_concrete)(struct render_3d_element*);
 
 // A global, unique structure that stores element relating to the 3d engine, in particular the list
 // of elements to render later in the frame.
@@ -162,7 +169,8 @@ struct render_3d_global {
     undefined field53_0x3d;
     undefined field54_0x3e;
     undefined field55_0x3f;
-    struct render_3d_element* render_stack[128];
+    struct render_3d_element* render_stack; // an array that can contain up to max_index entries.
 };
+ASSERT_SIZE(struct render_3d_global, 68);
 
 #endif

--- a/headers/types/files/wan.h
+++ b/headers/types/files/wan.h
@@ -39,8 +39,8 @@ struct wan_palettes {
     uint16_t nb_color;
     uint16_t unk2;
     uint8_t unk3;
-    uint8_t unk5;
-    uint32_t unk4; // Normally always 0
+    uint8_t unk4;
+    uint32_t unk5; // Normally always 0
 };
 ASSERT_SIZE(struct wan_palettes, 16);
 

--- a/headers/types/files/wan.h
+++ b/headers/types/files/wan.h
@@ -38,7 +38,8 @@ struct wan_palettes {
     uint16_t unk1;
     uint16_t nb_color;
     uint16_t unk2;
-    uint16_t unk3;
+    uint8_t unk3;
+    uint8_t unk5;
     uint32_t unk4; // Normally always 0
 };
 ASSERT_SIZE(struct wan_palettes, 16);
@@ -50,7 +51,7 @@ struct wan_animation_group {
     struct wan_animation_frame** pnt;
     uint16_t len;
     // The frame offset relative to the first frame of the animation that will be used instead of
-    // the first frame when looping the animation.
+    // the first frame when looping the animation. (untested)
     uint16_t loop_start;
 };
 ASSERT_SIZE(struct wan_animation_group, 8);

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -3144,6 +3144,37 @@ arm9:
         
         r0: animation control
         r1: sprite id in WAN_TABLE
+    - name: SetAnimationForAnimationControlInternal
+      address:
+        EU: 0x201C218
+      description: |-
+        Set the wan animation (and other related settings) of an animation_control
+        Used by SetAnimationForAnimationControl
+        
+        r0: animation_control
+        r1: wan_header
+        r2: animation group id
+        r3: animation id
+        stack[0]: ?
+        stack[1] (0x4): palette pos low (see the field on animation_control)
+        stack[2] (0x8): ?
+        stack[3] (0xC): ?
+        stack[4] (0x10): palette_bank (directly set to the animation_control field with said name)
+    - name: SetAnimationForAnimationControl
+      address:
+        EU: 0x201C368
+      description: |-
+        Set the animation to play with this animation control, but do not start it.
+        
+        (args same as SetAndPlayAnimationForAnimationControl)
+        r0: animation_control
+        r1: animation key (either an animation or animation group depending on the type of sprite and if it does have animation group with this animation key as index)
+        r2: direction_id (unsure) (the key to the wan_animation in itself, only used when animation key represent a wan_animation_group)
+        r3: ?
+        stack[0]: low_palette_pos
+        stack[1] (0x4): ?
+        stack[2] (0x8): ?
+        stack[3] (0xC): ?
     - name: GetWanForAnimationControl
       address:
         EU: 0x201C484
@@ -3153,6 +3184,20 @@ arm9:
         
         r0: animation_control
         return: wan_header
+    - name: SetAndPlayAnimationForAnimationControl
+      address:
+        EU: 0x201C4B4
+      description: |-
+        Set the animation to play with the animation control, and start it.
+        
+        r0: animation_control
+        r1: animation key (either an animation or animation group depending on the type of sprite and if it does have animation group with this animation key as index)
+        r2: direction_id (unsure) (the key to the wan_animation in itself, only used when animation key represent a wan_animation_group)
+        r3: ?
+        stack[0]: low_palette_pos
+        stack[1] (0x4): ?
+        stack[2] (0x8): ?
+        stack[3] (0xC): ?
     - name: SwitchAnimationControlToNextFrame
       address:
         EU: 0x201C4F4
@@ -3373,6 +3418,62 @@ arm9:
         r1: unk_pal
         r2: unk_tex
         r3: unk_tex_param
+    - name: GeomSetTexImageParam
+      address:
+        EU: 0x201E530
+      description: |-
+        Send the "TEXIMAGE_PARAM" geometry engine command, that define some parameters for the texture
+        See http://problemkaputt.de/gbatek.htm#ds3dtextureattributes for more information on the parameters
+        
+        r0: texture format
+        r1: texture coordinates transformation modes
+        r2: texture S-Size
+        r3: texture T-Size
+        stack[0] (0x0): repeat in S Direction
+        stack[1] (0x4): flip in S direction
+        stack[2] (0x8): What to make of color 0 (bit 29)
+        stack[3] (0xC): Texture VRAM offset (Will be divided by 8)
+    - name: GeomSetVertexCoord16
+      address:
+        EU: 0x201E570
+      description: |-
+        Send the "VTX_16" geometry engine command, that define the coordinate of a point of a polygon, using 16 bits.
+        Inputs are clamped over their 16 lower bits
+        
+        r0: x coordinate
+        r1: y coordinate
+        r2: z coordinate
+    - name: InitRender3dData
+      address:
+        EU: 0x201E5A0
+      description: |-
+        Initialize the global "RENDER_3D" structure.
+        
+        No params.
+    - name: GeomSwapBuffers
+      address:
+        EU: 0x201E7B8
+      description: |-
+        Call the "SWAP_BUFFERS" command. This will swap the geometry buffer. The parameter of 1 is provided, that enable manual Y-sorting of translucent polygon.
+        
+        No params.
+    - name: InitRender3dElement
+      address:
+        EU: 0x201E7CC
+        NA: 0x201E730
+      description: |-
+        Initialize the render_3d_element structure (without performing any drawing or external data access)
+        
+        r0: render_3d_element
+    - name: Generate3dCanvasBorder
+      address:
+        EU: 0x201EA88
+      description: |-
+        Draw the border for dialogue box and other menus, using the 3D engine.
+        The render_3d_element contain certain value that needs to be set to a correct value for it to work.
+        The element is not immediatly sent to the geometry engine, but are queud up in RENDER_3D
+        
+        r0: render_3d_element
     - name: HandleSir0Translation
       address:
         EU: 0x201F550

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -3422,7 +3422,7 @@ arm9:
       address:
         EU: 0x201E530
       description: |-
-        Send the "TEXIMAGE_PARAM" geometry engine command, that define some parameters for the texture
+        Send the "TEXIMAGE_PARAM" geometry engine command, that defines some parameters for the texture
         See http://problemkaputt.de/gbatek.htm#ds3dtextureattributes for more information on the parameters
         
         r0: texture format
@@ -3437,7 +3437,7 @@ arm9:
       address:
         EU: 0x201E570
       description: |-
-        Send the "VTX_16" geometry engine command, that define the coordinate of a point of a polygon, using 16 bits.
+        Send the "VTX_16" geometry engine command, that defines the coordinate of a point of a polygon, using 16 bits.
         Inputs are clamped over their 16 lower bits
         
         r0: x coordinate
@@ -3454,7 +3454,7 @@ arm9:
       address:
         EU: 0x201E7B8
       description: |-
-        Call the "SWAP_BUFFERS" command. This will swap the geometry buffer. The parameter of 1 is provided, that enable manual Y-sorting of translucent polygon.
+        Call the "SWAP_BUFFERS" command. This will swap the geometry buffer. The parameter of 1 is provided, which enables manual Y-sorting of translucent polygons.
         
         No params.
     - name: InitRender3dElement
@@ -3470,8 +3470,8 @@ arm9:
         EU: 0x201EA88
       description: |-
         Draw the border for dialogue box and other menus, using the 3D engine.
-        The render_3d_element contain certain value that needs to be set to a correct value for it to work.
-        The element is not immediatly sent to the geometry engine, but are queud up in RENDER_3D
+        The render_3d_element contains certain value that needs to be set to a correct value for it to work.
+        The element is not immediately sent to the geometry engine, but is queued up in RENDER_3D
         
         r0: render_3d_element
     - name: HandleSir0Translation

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -9860,6 +9860,13 @@ arm9:
         pointer to the list of wan sprite loaded in RAM
         
         struct wan_table*
+    - name: RENDER_3D
+      address:
+        EU: 0x20B0540
+      description: |-
+        The (seemingly) unique instance render_3d_global in the game
+        
+        struct render_3d_global
     - name: LANGUAGE_INFO_DATA
       address:
         EU: 0x20B05A8

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -9866,7 +9866,7 @@ arm9:
       description: |-
         The (seemingly) unique instance render_3d_global in the game
         
-        struct render_3d_global
+        type: struct render_3d_global
     - name: LANGUAGE_INFO_DATA
       address:
         EU: 0x20B05A8

--- a/symbols/arm9/itcm.yml
+++ b/symbols/arm9/itcm.yml
@@ -29,7 +29,7 @@ itcm:
     
     In Explorers of Sky, a fixed region of the ARM9 binary appears to be loaded in the ITCM at all times, and seems to contain functions related to the dungeon AI, among other things. The ITCM has a max capacity of 0x8000, although not all of it is used.
   functions:
-    - name: AllocateNewRender3dElement
+    - name: AllocateRender3dElement
       address:
         EU: 0x20B4938
         EU-ITCM: 0x1FF8C78
@@ -238,4 +238,4 @@ itcm:
       description: |-
         Pointers to the 4 functions available from render_3d_element (in ITCM)
         
-        type: void* [4] // array of 4 pointer to functions. Take 1 parameter, a pointer to the render_3d_element
+        type: render_3d_element_concrete[4]

--- a/symbols/arm9/itcm.yml
+++ b/symbols/arm9/itcm.yml
@@ -29,6 +29,22 @@ itcm:
     
     In Explorers of Sky, a fixed region of the ARM9 binary appears to be loaded in the ITCM at all times, and seems to contain functions related to the dungeon AI, among other things. The ITCM has a max capacity of 0x8000, although not all of it is used.
   functions:
+    - name: AllocateNewRender3dElement
+      address:
+        EU: 0x20B4938
+        EU-ITCM: 0x1FF8C78
+      description: |-
+        Return a new render_3d_element from RENDER_3D, to be to draw a new element using the 3d render engine later in the frame.
+        
+        return: render_3d_element or NULL if there is no more avalaible space in the stack
+    - name: Render3DStack
+      address:
+        EU: 0x20B4A8C
+        EU-ITCM: 0x1FF8DCC
+      description: |-
+        Perform rendering of the render_stack of RENDER_3D structure. Does nothing if there are no elements, otherwise, sort them based on a value, and render them all consequetively.
+        
+        No params.
     - name: GetKeyN2MSwitch
       address:
         EU: 0x20B50F4
@@ -215,3 +231,11 @@ itcm:
         Note: This symbol isn't actually part of the ITCM, it gets created at runtime on the spot in RAM that used to contain the code that was moved to the ITCM.
         
         type: struct mem_block[256]
+    - name: RENDER_3D_FUNCTIONS
+      address:
+        EU: 0x20B3DE0
+        EU-ITCM: 0x1FF8120
+      description: |-
+        Pointers to the 4 function avalaible from render_3d_element (in ITCM)
+        
+        type: void* [4] // array of 4 pointer to functions. Take 1 parameter, a pointer to the render_3d_element

--- a/symbols/arm9/itcm.yml
+++ b/symbols/arm9/itcm.yml
@@ -36,13 +36,13 @@ itcm:
       description: |-
         Return a new render_3d_element from RENDER_3D, to be to draw a new element using the 3d render engine later in the frame.
         
-        return: render_3d_element or NULL if there is no more avalaible space in the stack
-    - name: Render3DStack
+        return: render_3d_element or NULL if there is no more available space in the stack
+    - name: Render3dStack
       address:
         EU: 0x20B4A8C
         EU-ITCM: 0x1FF8DCC
       description: |-
-        Perform rendering of the render_stack of RENDER_3D structure. Does nothing if there are no elements, otherwise, sort them based on a value, and render them all consequetively.
+        Perform rendering of the render_stack of RENDER_3D structure. Does nothing if there are no elements, otherwise, sort them based on a value, and render them all consecutively.
         
         No params.
     - name: GetKeyN2MSwitch
@@ -236,6 +236,6 @@ itcm:
         EU: 0x20B3DE0
         EU-ITCM: 0x1FF8120
       description: |-
-        Pointers to the 4 function avalaible from render_3d_element (in ITCM)
+        Pointers to the 4 functions available from render_3d_element (in ITCM)
         
         type: void* [4] // array of 4 pointer to functions. Take 1 parameter, a pointer to the render_3d_element

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -5629,7 +5629,7 @@ overlay29:
       description: |-
         Note: unverified, ported from Irdkwia's notes
         
-        r0: call_back_str
+        r0: render_3d_element
         r1: x position
         r2: y position
         r3: char_id


### PR DESCRIPTION
I had this lying around since about 2 weeks, but finally decided to do the needed finalisation.

The gist of that is the game use the 3D rendering system to render a few things. From what I’ve seen, it mostly include weather and text box border/background, but could be easily extended (and is what Irdkwia used for the moving spirit effect in the "angry" part of Tangent’s hack (that I can’t remember the name of).