### PR TITLE
Memory mapping + miscellaneous sound functions

### DIFF
--- a/headers/data/overlay11.h
+++ b/headers/data/overlay11.h
@@ -16,5 +16,6 @@ extern struct monster_id_16 RECRUITMENT_TABLE_SPECIES[22];
 extern struct level_tilemap_list_entry LEVEL_TILEMAP_LIST[81];
 extern struct overlay_load_entry OVERLAY11_OVERLAY_LOAD_TABLE[21];
 extern struct main_ground_data GROUND_STATE_PTRS;
+extern uint32_t WORLD_MAP_MODE;
 
 #endif

--- a/headers/data/ram.h
+++ b/headers/data/ram.h
@@ -38,7 +38,6 @@ extern struct level_up_entry LEVEL_UP_DATA_DECOMPRESS_BUFFER[100];
 extern struct team_member_table TEAM_MEMBER_TABLE;
 extern struct vram_banks_set ENABLED_VRAM_BANKS;
 extern uint32_t FRAMES_SINCE_LAUNCH_TIMES_THREE;
-extern uint32_t WORLD_MAP_MODE;
 extern struct sentry_duty SENTRY_DUTY_STRUCT;
 extern bool TURNING_ON_THE_SPOT_FLAG;
 extern struct loaded_attack_sprite_data* LOADED_ATTACK_SPRITE_DATA;

--- a/headers/data/ram.h
+++ b/headers/data/ram.h
@@ -1,9 +1,16 @@
 #ifndef HEADERS_DATA_RAM_H_
 #define HEADERS_DATA_RAM_H_
 
+extern uint8_t DEFAULT_MEMORY_ARENA_MEMORY[1991680];
+extern struct mem_arena GROUND_MEMORY_ARENA_2;
+extern struct mem_block GROUND_MEMORY_ARENA_2_BLOCKS[32];
+extern uint8_t GROUND_MEMORY_ARENA_2_MEMORY[720100];
 extern struct rgba* DUNGEON_COLORMAP_PTR;
 extern struct dungeon DUNGEON_STRUCT;
 extern struct move_data_table MOVE_DATA_TABLE;
+extern struct mem_arena SOUND_MEMORY_ARENA;
+extern struct mem_block SOUND_MEMORY_ARENA_BLOCKS[20];
+extern uint8_t SOUND_MEMORY_ARENA_MEMORY[245252];
 extern uint32_t FRAMES_SINCE_LAUNCH;
 extern struct item BAG_ITEMS[50];
 extern struct item* BAG_ITEMS_PTR;
@@ -24,6 +31,7 @@ extern struct animation_control* CURSOR_ANIMATION_CONTROL;
 extern struct animation_control* CURSOR_16_ANIMATION_CONTROL;
 extern uint16_t ALERT_SPRITE_ID;
 extern struct animation_control* ALERT_ANIMATION_CONTROL;
+extern struct mem_arena* SOUND_MEMORY_ARENA_PTR;
 extern struct move LAST_NEW_MOVE;
 extern struct script_var_value_table SCRIPT_VARS_VALUES;
 extern uint8_t BAG_LEVEL;
@@ -38,6 +46,11 @@ extern struct level_up_entry LEVEL_UP_DATA_DECOMPRESS_BUFFER[100];
 extern struct team_member_table TEAM_MEMBER_TABLE;
 extern struct vram_banks_set ENABLED_VRAM_BANKS;
 extern uint32_t FRAMES_SINCE_LAUNCH_TIMES_THREE;
+extern struct mem_arena* GROUND_MEMORY_ARENA_1_PTR;
+extern struct mem_arena* GROUND_MEMORY_ARENA_2_PTR;
+extern struct mem_arena GROUND_MEMORY_ARENA_1;
+extern struct mem_block GROUND_MEMORY_ARENA_1_BLOCKS[52];
+extern uint8_t GROUND_MEMORY_ARENA_1_MEMORY[408324];
 extern struct sentry_duty SENTRY_DUTY_STRUCT;
 extern bool TURNING_ON_THE_SPOT_FLAG;
 extern struct loaded_attack_sprite_data* LOADED_ATTACK_SPRITE_DATA;

--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -301,6 +301,7 @@ void SendAudioCommandWrapperVeneer(enum music_id music_id, undefined param_2, in
 void SendAudioCommandWrapper(enum music_id music_id, undefined param_2, int volume);
 struct audio_command* AllocAudioCommand(int status);
 void SendAudioCommand(struct audio_command command);
+void InitSoundSystem(void);
 void ManipBgmPlayback(void);
 void SoundDriverReset(void);
 uint32_t LoadDseFile(struct iovec* iov, const char* filename);
@@ -753,7 +754,10 @@ enum dungeon_id DungeonSwapIdxToId(int idx);
 enum dungeon_mode GetDungeonModeSpecial(enum dungeon_id dungeon_id);
 int ResumeBgm(undefined4 param_1, undefined4 param_2, undefined4 param_3);
 int FlushChannels(undefined* param_1, int param_2, int param_3);
+void ParseDseEvents(undefined4 param_1, int param_2, undefined4 param_3, undefined4 param_4);
+void UpdateSequencerTracks(int param_1, undefined4 param_2, undefined4 param_3, undefined4 param_4);
 void UpdateChannels(void);
+void UpdateTrackVolumeEnvelopes(undefined* param_1);
 void EnableVramBanksInSetDontSave(struct vram_banks_set vram_banks);
 void EnableVramBanksInSet(struct vram_banks_set* vram_banks);
 int ClearIrqFlag(void);

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -44,7 +44,7 @@ struct mem_block {
     uint32_t allocator_flags_unused : 28;
 
     // 0x8: Flags passed by the user to the memory allocator API functions when this block was
-    // allocated. The least significant byte are reserved for specifying the memory arena to use,
+    // allocated. The least significant byte is reserved for specifying the memory arena to use,
     // and have functionality determined by the arena locator function currently in use by the
     // game. The upper bytes are the same as the internal memory allocator flags
     // (just left-shifted by 8).
@@ -86,6 +86,10 @@ struct mem_alloc_table {
     struct mem_arena default_arena; // 0x4: The default memory arena for allocations
     // Not actually sure how long this array is, but has at least 4 elements, and can't have
     // more than 8 because it would overlap with default_arena.data
+    // The 4 known arenas are:
+    // - The default arena (used for most things, including dungeon mode)
+    // - Two ground mode arenas (used in some cases, but not all)
+    // - The sound data arena (used by the DSE sound engine)
     struct mem_arena* arenas[8]; // 0x20: Array of global memory arenas
 };
 ASSERT_SIZE(struct mem_alloc_table, 64);

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -59,7 +59,7 @@ arm9:
         
         This includes MEMORY_ALLOCATION_ARENA_GETTERS and some other stuff.
         
-        Dungeon mode uses the default arena getters. Ground mode uses its own arena getters, which are defined in overlay 11 and set (by calling this function) at the start of GroundMainLoop.
+        Dungeon mode uses the default arena getters. Ground mode uses its own arena getters that return custom arenas for some flag values, which are defined in overlay 11 and set (by calling this function) at the start of GroundMainLoop. Note that the sound memory arena is provided explicitly to MemLocateSet in the sound code, so doesn't go through this path.
         
         r0: GetAllocArena function pointer (GetAllocArenaDefault is used if null)
         r1: GetFreeArena function pointer (GetFreeArenaDefault is used if null)
@@ -3049,6 +3049,26 @@ arm9:
         This function calls a stubbed-out one with the string "audio command list"
         
         r0: Command to send
+    - name: InitSoundSystem
+      address:
+        NA: 0x2018C28
+      description: |-
+        Initialize the DSE sound engine?
+        
+        This function is called somewhere in the hierarchy under TaskProcBoot and appears to allocate a bunch of memory (including a dedicated memory arena, see SOUND_MEMORY_ARENA) for sound data, and reads a bunch of core sound files.
+        
+        File paths referenced:
+        - SOUND/SYSTEM/se_sys.swd
+        - SOUND/SYSTEM/se_sys.sed
+        - SOUND/SE/motion.swd
+        - SOUND/SE/motion.sed
+        - SOUND/BGM/bgm.swd (this is the main sample bank, see https://projectpokemon.org/home/docs/mystery-dungeon-nds/pok%C3%A9mon-mystery-dungeon-explorers-r78/)
+        
+        Debug strings:
+        - entry system se swd %04x\n
+        - entry system se sed %04x\n
+        - entry motion se swd %04x\n
+        - entry motion se sed %04x\n
     - name: ManipBgmPlayback
       address:
         EU: 0x2018F40
@@ -7446,15 +7466,27 @@ arm9:
         NA: 0x2070674
         JP: 0x207095C
       description: "Note: unverified, ported from Irdkwia's notes"
+    - name: ParseDseEvents
+      address:
+        NA: 0x2071224
+      description: "From https://projectpokemon.org/docs/mystery-dungeon-nds/procyon-studios-digital-sound-elements-r12/"
+    - name: UpdateSequencerTracks
+      address:
+        NA: 0x20713E8
+      description: "From https://projectpokemon.org/docs/mystery-dungeon-nds/procyon-studios-digital-sound-elements-r12/"
     - name: UpdateChannels
       address:
         EU: 0x2074824
         NA: 0x207448C
         JP: 0x2074774
       description: |-
-        Note: unverified, ported from Irdkwia's notes
+        From https://projectpokemon.org/docs/mystery-dungeon-nds/procyon-studios-digital-sound-elements-r12/ and Irdkwia's notes.
         
         No params.
+    - name: UpdateTrackVolumeEnvelopes
+      address:
+        NA: 0x2074E0C
+      description: "From https://projectpokemon.org/docs/mystery-dungeon-nds/procyon-studios-digital-sound-elements-r12/"
     - name: EnableVramBanksInSetDontSave
       address:
         EU: 0x2076744
@@ -9998,7 +10030,10 @@ arm9:
       length:
         EU: 0x1FC
         NA: 0x1FC
-      description: "Irdkwia's notes: named DSEEventFunctionPtrTable with length 0x3C0 (note the disagreement), 240*0x4."
+      description: |-
+        Table of all DSE events, see https://projectpokemon.org/docs/mystery-dungeon-nds/procyon-studios-digital-sound-elements-r12/
+        
+        Irdkwia's notes: named DSEEventFunctionPtrTable with length 0x3C0 (note the disagreement), 240*0x4.
     - name: MUSIC_DURATION_LOOKUP_TABLE_1
       address:
         EU: 0x20B1894

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -146,6 +146,11 @@ overlay11:
       description: |-
         The GetAllocArena function used for ground mode. See SetMemAllocatorParams for more information.
         
+        For (flags & 0xFF):
+          8, 15, 16: GROUND_MEMORY_ARENA_1
+          14: GROUND_MEMORY_ARENA_2
+          other: null (default arena)
+        
         r0: initial memory arena pointer, or null
         r1: flags (see MemAlloc)
         return: memory arena pointer, or null

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -620,3 +620,11 @@ overlay11:
         Host pointers to multiple structure used for performing an overworld scene
         
         type: struct main_ground_data
+    - name: WORLD_MAP_MODE
+      address:
+        EU: 0x2325924
+        NA: 0x2324DE4
+      length:
+        EU: 0x4
+        NA: 0x4
+      description: The current world map

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -18,6 +18,45 @@ ram:
     More specifically, this file is a dumping ground for addresses that are useful to know about, but don't fall in the address ranges of any of the other files. Dynamically loaded constructs that do fall within the address range of a relevant binary should be listed in the corresponding YAML file of that binary, since it still has direct utility when reverse-engineering that particular binary.
   functions: []
   data:
+    - name: DEFAULT_MEMORY_ARENA_MEMORY
+      address:
+        NA: 0x20B4BC0
+      length:
+        NA: 0x1E6400
+      description: |-
+        The memory region for the default memory arena.
+        
+        The length is defined by DEFAULT_MEMORY_ARENA_SIZE.
+        
+        One mode that uses this region for heap allocations is dungeon mode.
+    - name: GROUND_MEMORY_ARENA_2
+      address:
+        NA: 0x2145A08
+      length:
+        NA: 0x1C
+      description: |-
+        This is a memory subarena under DEFAULT_MEMORY_ARENA used for some things in ground mode.
+        
+        It's used for user_flags 14.
+        
+        Including the allocator metadata, this arena occupies 0xB0000 bytes of space.
+        
+        type: struct mem_arena
+    - name: GROUND_MEMORY_ARENA_2_BLOCKS
+      address:
+        NA: 0x2145A24
+      length:
+        NA: 0x300
+      description: |-
+        The block array for GROUND_MEMORY_ARENA_2.
+        
+        type: struct mem_block[32]
+    - name: GROUND_MEMORY_ARENA_2_MEMORY
+      address:
+        NA: 0x2145D24
+      length:
+        NA: 0xAFCE4
+      description: The memory region for GROUND_MEMORY_ARENA_2.
     - name: DUNGEON_COLORMAP_PTR
       address:
         EU: 0x21BA634
@@ -55,6 +94,37 @@ ram:
         Pointed to by MOVE_DATA_TABLE_PTR in the ARM 9 binary.
         
         type: struct move_data_table
+    - name: SOUND_MEMORY_ARENA
+      address:
+        NA: 0x224EFA0
+      length:
+        NA: 0x1C
+      description: |-
+        This is a memory subarena under DEFAULT_MEMORY_ARENA that seems to be used exclusively for sound data.
+        
+        Including allocator metadata, this subarena occupies 0x3C000 bytes of space within the default arena.
+        
+        It's referenced by various sound functions like LoadDseFile, PlaySeLoad, and PlayBgm when allocating memory.
+        
+        type: struct mem_arena
+    - name: SOUND_MEMORY_ARENA_BLOCKS
+      address:
+        NA: 0x224EFBC
+      length:
+        NA: 0x1E0
+      description: |-
+        The block array for SOUND_MEMORY_ARENA.
+        
+        type: struct mem_block[20]
+    - name: SOUND_MEMORY_ARENA_MEMORY
+      address:
+        NA: 0x224F19C
+      length:
+        NA: 0x3BE04
+      description: |-
+        The memory region for SOUND_MEMORY_ARENA.
+        
+        This region appears to be used for sound-related heap allocations, like when loading sound files into memory.
     - name: FRAMES_SINCE_LAUNCH
       address:
         EU:
@@ -230,6 +300,12 @@ ram:
       length:
         EU: 0x7C
       description: "animation_control of \"FONT/alter.wan\""
+    - name: SOUND_MEMORY_ARENA_PTR
+      address:
+        NA: 0x22A4E54
+      length:
+        NA: 0x4
+      description: Pointer to SOUND_MEMORY_ARENA.
     - name: DIALOG_BOX_LIST
       address:
         NA: 0x22A88DC
@@ -380,6 +456,46 @@ ram:
         EU: 0x4
         NA: 0x4
       description: "Starts at 0 when the game is first launched, and ticks up by 3 per frame while the game is running."
+    - name: GROUND_MEMORY_ARENA_1_PTR
+      address:
+        NA: 0x2324CB4
+      length:
+        NA: 0x4
+      description: Pointer to GROUND_MEMORY_ARENA_1.
+    - name: GROUND_MEMORY_ARENA_2_PTR
+      address:
+        NA: 0x2324CB8
+      length:
+        NA: 0x4
+      description: Pointer to GROUND_MEMORY_ARENA_2.
+    - name: GROUND_MEMORY_ARENA_1
+      address:
+        NA: 0x2324FC0
+      length:
+        NA: 0x1C
+      description: |-
+        This is a top-level memory arena used for some things in ground mode.
+        
+        It's used for user_flags 8, 15, and 16.
+        
+        Including the allocator metadata, this arena occupies 0x64000 bytes of space.
+        
+        type: struct mem_arena
+    - name: GROUND_MEMORY_ARENA_1_BLOCKS
+      address:
+        NA: 0x2324FDC
+      length:
+        NA: 0x4E0
+      description: |-
+        The block array for GROUND_MEMORY_ARENA_1.
+        
+        type: struct mem_block[52]
+    - name: GROUND_MEMORY_ARENA_1_MEMORY
+      address:
+        NA: 0x23254BC
+      length:
+        NA: 0x63B04
+      description: The memory region for GROUND_MEMORY_ARENA_1.
     - name: SENTRY_DUTY_STRUCT
       address:
         NA: 0x237A5D0

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -380,14 +380,6 @@ ram:
         EU: 0x4
         NA: 0x4
       description: "Starts at 0 when the game is first launched, and ticks up by 3 per frame while the game is running."
-    - name: WORLD_MAP_MODE
-      address:
-        EU: 0x2325924
-        NA: 0x2324DE4
-      length:
-        EU: 0x4
-        NA: 0x4
-      description: The current world map
     - name: SENTRY_DUTY_STRUCT
       address:
         NA: 0x237A5D0


### PR DESCRIPTION
- Document the locations of all 4 known memory arenas
- Add a couple more sound-engine-related functions (mostly taken from the Project Pokémon docs).
- Move `WORLD_MAP_MODE` into overlay11.