### PR TITLE
Rename some special process IDs

### DIFF
--- a/headers/types/ground_mode/enums.h
+++ b/headers/types/ground_mode/enums.h
@@ -930,8 +930,8 @@ enum special_process_id {
     // 57 and 58 are unused but sure do something! Don't know what though.
     // 57 might be "IsStorageFull"?
     SPECIAL_PROC_0x39 = 57,
-    SPECIAL_PROC_0x3A = 58,
-    SPECIAL_PROC_0x3B = 59, // 59 is something related to the lottery.
+    SPECIAL_PROC_INCREMENT_DUNGEONS_CLEARED = 58,
+    SPECIAL_PROC_INCREMENT_BIG_TREASURE_WINS = 59,
     SPECIAL_PROC_SEND_SKY_GIFT_TO_GUILDMASTER = 60,
     // 61 and 62 are unusued but do something.
     SPECIAL_PROC_0x3D = 61,

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -5224,7 +5224,7 @@ arm9:
       description: |-
         Increments by 1 the number of dungeons cleared.
         
-        Implements SPECIAL_PROC_0x3A (see ScriptSpecialProcessCall).
+        Implements SPECIAL_PROC_INCREMENT_DUNGEONS_CLEARED (see ScriptSpecialProcessCall).
         
         No params.
     - name: GetNbDungeonsCleared
@@ -5372,7 +5372,7 @@ arm9:
       description: |-
         Increments by 1 the number of big treasure wins.
         
-        Implements SPECIAL_PROC_0x3B (see ScriptSpecialProcessCall).
+        Implements SPECIAL_PROC_INCREMENT_BIG_TREASURE_WINS (see ScriptSpecialProcessCall).
         
         No params.
     - name: SetNbBigTreasureWins


### PR DESCRIPTION
Based on the implementing function names, it seems like we already know what these special processes are, so rename the enum values.