### PR TITLE
Fix struct rgba field ordering

### DIFF
--- a/headers/types/common/util.h
+++ b/headers/types/common/util.h
@@ -6,8 +6,8 @@
 // RGBA8 structure. Sometimes alpha is ignored and only used for padding
 struct rgba {
     uint8_t r;
-    uint8_t b;
     uint8_t g;
+    uint8_t b;
     uint8_t a; // Sometimes used only for padding
 };
 ASSERT_SIZE(struct rgba, 4);


### PR DESCRIPTION
The green and blue bytes were presumably swapped accidentally.