### PR TITLE
Various JP symbols (ov18 - ov34)

### DIFF
--- a/symbols/literals.yml
+++ b/symbols/literals.yml
@@ -109,6 +109,7 @@ overlay29:
       address:
         EU: 0x231CDE4
         NA: 0x231C384
+        JP: 0x231D850
       description: IQ boost from ingesting Nectar.
 overlay34:
   versions:

--- a/symbols/overlay18.yml
+++ b/symbols/overlay18.yml
@@ -151,6 +151,7 @@ overlay18:
       length:
         EU: 0x48
         NA: 0x48
+        JP: 0x48
     - name: MOVES_SUBMENU_7
       address:
         EU: 0x238DFC0

--- a/symbols/overlay18.yml
+++ b/symbols/overlay18.yml
@@ -84,55 +84,70 @@ overlay18:
       address:
         EU: 0x238DE60
         NA: 0x238D320
+        JP: 0x238E88C
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: MOVES_SUBMENU_1
       address:
         EU: 0x238DE78
         NA: 0x238D338
+        JP: 0x238E8A4
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: MOVES_SUBMENU_2
       address:
         EU: 0x238DE98
         NA: 0x238D358
+        JP: 0x238E8C4
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: MOVES_MAIN_MENU
       address:
         EU: 0x238DEB8
         NA: 0x238D378
+        JP: 0x238E8E4
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: MOVES_SUBMENU_3
       address:
         EU: 0x238DED8
         NA: 0x238D398
+        JP: 0x238E904
       length:
         EU: 0x28
         NA: 0x28
+        JP: 0x28
     - name: MOVES_SUBMENU_4
       address:
         EU: 0x238DF00
         NA: 0x238D3C0
+        JP: 0x238E92C
       length:
         EU: 0x30
         NA: 0x30
+        JP: 0x30
     - name: MOVES_SUBMENU_5
       address:
         EU: 0x238DF30
         NA: 0x238D3F0
+        JP: 0x238E95C
       length:
         EU: 0x48
         NA: 0x48
+        JP: 0x48
     - name: MOVES_SUBMENU_6
       address:
         EU: 0x238DF78
         NA: 0x238D438
+        JP: 0x238E9A4
       length:
         EU: 0x48
         NA: 0x48
@@ -140,9 +155,11 @@ overlay18:
       address:
         EU: 0x238DFC0
         NA: 0x238D480
+        JP: 0x238E9EC
       length:
         EU: 0x48
         NA: 0x48
+        JP: 0x48
     - name: OVERLAY18_FUNCTION_POINTER_TABLE
       address:
         NA: 0x238D4C8

--- a/symbols/overlay19.yml
+++ b/symbols/overlay19.yml
@@ -132,16 +132,20 @@ overlay19:
       address:
         EU: 0x238ED3C
         NA: 0x238E208
+        JP: 0x238F760
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: BAR_MENU_CONFIRM_2
       address:
         EU: 0x238ED54
         NA: 0x238E220
+        JP: 0x238F778
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: OVERLAY19_UNKNOWN_STRING_IDS__NA_238E238
       address:
         NA: 0x238E238
@@ -152,23 +156,29 @@ overlay19:
       address:
         EU: 0x238ED84
         NA: 0x238E250
+        JP: 0x238F7A8
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: BAR_SUBMENU_1
       address:
         EU: 0x238EDA4
         NA: 0x238E270
+        JP: 0x238F7C8
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: BAR_SUBMENU_2
       address:
         EU: 0x238EDC4
         NA: 0x238E290
+        JP: 0x238F7E8
       length:
         EU: 0x30
         NA: 0x30
+        JP: 0x30
     - name: OVERLAY19_RESERVED_SPACE
       address:
         NA: 0x238E344

--- a/symbols/overlay20.yml
+++ b/symbols/overlay20.yml
@@ -24,37 +24,47 @@ overlay20:
       address:
         EU: 0x238DAC4
         NA: 0x238CF84
+        JP: 0x238E4E0
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: RECYCLE_MENU_CONFIRM_2
       address:
         EU: 0x238DADC
         NA: 0x238CF9C
+        JP: 0x238E4F8
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: RECYCLE_SUBMENU_1
       address:
         EU: 0x238DAF4
         NA: 0x238CFB4
+        JP: 0x238E510
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: RECYCLE_SUBMENU_2
       address:
         EU: 0x238DB0C
         NA: 0x238CFCC
+        JP: 0x238E528
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: RECYCLE_MAIN_MENU_1
       address:
         EU: 0x238DB2C
         NA: 0x238CFEC
+        JP: 0x238E548
       length:
         EU: 0x28
         NA: 0x28
+        JP: 0x28
     - name: OVERLAY20_UNKNOWN_TABLE__NA_238D014
       address:
         NA: 0x238D014
@@ -101,9 +111,11 @@ overlay20:
       address:
         EU: 0x238DBC8
         NA: 0x238D088
+        JP: 0x238E5E4
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: RECYCLE_D_BOX_LAYOUT_7
       address:
         NA: 0x238D0A8

--- a/symbols/overlay21.yml
+++ b/symbols/overlay21.yml
@@ -24,44 +24,56 @@ overlay21:
       address:
         EU: 0x238D578
         NA: 0x238CA38
+        JP: 0x238DFA8
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: SWAP_SHOP_SUBMENU_1
       address:
         EU: 0x238D590
         NA: 0x238CA50
+        JP: 0x238DFC0
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: SWAP_SHOP_SUBMENU_2
       address:
         EU: 0x238D5A8
         NA: 0x238CA68
+        JP: 0x238DFD8
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: SWAP_SHOP_MAIN_MENU_1
       address:
         EU: 0x238D5C8
         NA: 0x238CA88
+        JP: 0x238DFF8
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: SWAP_SHOP_MAIN_MENU_2
       address:
         EU: 0x238D5E8
         NA: 0x238CAA8
+        JP: 0x238E018
       length:
         EU: 0x28
         NA: 0x28
+        JP: 0x28
     - name: SWAP_SHOP_SUBMENU_3
       address:
         EU: 0x238D610
         NA: 0x238CAD0
+        JP: 0x238E040
       length:
         EU: 0x30
         NA: 0x30
+        JP: 0x30
     - name: OVERLAY21_UNKNOWN_STRING_IDS
       address:
         NA: 0x238CB00

--- a/symbols/overlay22.yml
+++ b/symbols/overlay22.yml
@@ -36,30 +36,38 @@ overlay22:
       address:
         EU: 0x238F3A8
         NA: 0x238E868
+        JP: 0x238FDC8
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: SHOP_MAIN_MENU_1
       address:
         EU: 0x238F3C0
         NA: 0x238E880
+        JP: 0x238FDE0
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: SHOP_MAIN_MENU_2
       address:
         EU: 0x238F3E0
         NA: 0x238E8A0
+        JP: 0x238FE00
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: SHOP_MAIN_MENU_3
       address:
         EU: 0x238F400
         NA: 0x238E8C0
+        JP: 0x238FE20
       length:
         EU: 0x30
         NA: 0x30
+        JP: 0x30
     - name: OVERLAY22_UNKNOWN_STRING_IDS
       address:
         NA: 0x238E8F0

--- a/symbols/overlay23.yml
+++ b/symbols/overlay23.yml
@@ -36,37 +36,47 @@ overlay23:
       address:
         EU: 0x238DE3C
         NA: 0x238D2FC
+        JP: 0x238E8B4
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: STORAGE_MAIN_MENU_1
       address:
         EU: 0x238DE54
         NA: 0x238D314
+        JP: 0x238E8CC
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: STORAGE_MAIN_MENU_2
       address:
         EU: 0x238DE74
         NA: 0x238D334
+        JP: 0x238E8EC
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: STORAGE_MAIN_MENU_3
       address:
         EU: 0x238DE94
         NA: 0x238D354
+        JP: 0x238E90C
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: STORAGE_MAIN_MENU_4
       address:
         EU: 0x238DEB4
         NA: 0x238D374
+        JP: 0x238E92C
       length:
         EU: 0x28
         NA: 0x28
+        JP: 0x28
     - name: OVERLAY23_UNKNOWN_STRING_IDS
       address:
         NA: 0x238D39C

--- a/symbols/overlay24.yml
+++ b/symbols/overlay24.yml
@@ -30,16 +30,20 @@ overlay24:
       address:
         EU: 0x238D060
         NA: 0x238C520
+        JP: 0x238DA88
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: DAYCARE_MAIN_MENU
       address:
         EU: 0x238D078
         NA: 0x238C538
+        JP: 0x238DAA0
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: OVERLAY24_UNKNOWN_STRING_IDS
       address:
         NA: 0x238C558

--- a/symbols/overlay25.yml
+++ b/symbols/overlay25.yml
@@ -30,23 +30,29 @@ overlay25:
       address:
         EU: 0x238BFF4
         NA: 0x238B4B4
+        JP: 0x238CA14
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: APPRAISAL_MAIN_MENU
       address:
         EU: 0x238C00C
         NA: 0x238B4CC
+        JP: 0x238CA2C
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: APPRAISAL_SUBMENU
       address:
         EU: 0x238C02C
         NA: 0x238B4EC
+        JP: 0x238CA4C
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: OVERLAY25_UNKNOWN_STRING_IDS
       address:
         NA: 0x238B50C

--- a/symbols/overlay27.yml
+++ b/symbols/overlay27.yml
@@ -36,30 +36,38 @@ overlay27:
       address:
         EU: 0x238D49C
         NA: 0x238C95C
+        JP: 0x238DEEC
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: DISCARD_ITEMS_SUBMENU_1
       address:
         EU: 0x238D4B4
         NA: 0x238C974
+        JP: 0x238DF04
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: DISCARD_ITEMS_SUBMENU_2
       address:
         EU: 0x238D4D4
         NA: 0x238C994
+        JP: 0x238DF24
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: DISCARD_ITEMS_MAIN_MENU
       address:
         EU: 0x238D4F4
         NA: 0x238C9B4
+        JP: 0x238DF44
       length:
         EU: 0x28
         NA: 0x28
+        JP: 0x28
     - name: OVERLAY27_UNKNOWN_STRING_IDS
       address:
         NA: 0x238C9DC

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -7902,9 +7902,11 @@ overlay29:
       address:
         EU: 0x23114D0
         NA: 0x2310A70
+        JP: 0x2311F98
       length:
         EU: 0x4
         NA: 0x4
+        JP: 0x4
       description: |-
         The base value by which belly is decreased every turn.
         
@@ -8429,17 +8431,21 @@ overlay29:
       address:
         EU: 0x2353374
         NA: 0x2352768
+        JP: 0x23539E8
       length:
         EU: 0x2
         NA: 0x2
+        JP: 0x2
       description: The additional amount by which belly is decreased every turn when inside walls (integer part)
     - name: BELLY_DRAIN_IN_WALLS_THOUSANDTHS
       address:
         EU: 0x2353376
         NA: 0x235276A
+        JP: 0x23539EA
       length:
         EU: 0x2
         NA: 0x2
+        JP: 0x2
       description: The additional amount by which belly is decreased every turn when inside walls (fractional thousandths)
     - name: DAMAGE_MULTIPLIER_0_5
       address:
@@ -8579,9 +8585,11 @@ overlay29:
       address:
         EU: 0x2354138
         NA: 0x2353538
+        JP: 0x23547B8
       length:
         EU: 0x4
         NA: 0x4
+        JP: 0x4
       description: |-
         [Runtime] Pointer to the dungeon struct in dungeon mode.
         

--- a/symbols/overlay31.yml
+++ b/symbols/overlay31.yml
@@ -194,10 +194,10 @@ overlay31:
         EU: 0x238AAF4
         NA: 0x2389ED0
         JP: 0x238B198
-        JP: 0x20
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: OVERLAY31_UNKNOWN_STRUCT__NA_2389EF0
       address:
         NA: 0x2389EF0

--- a/symbols/overlay31.yml
+++ b/symbols/overlay31.yml
@@ -127,9 +127,11 @@ overlay31:
       address:
         EU: 0x238A9F8
         NA: 0x2389DD4
+        JP: 0x238B09C
       length:
         EU: 0x40
         NA: 0x40
+        JP: 0x40
     - name: OVERLAY31_UNKNOWN_STRING_IDS
       address:
         NA: 0x2389E20
@@ -164,27 +166,35 @@ overlay31:
       address:
         EU: 0x238AA94
         NA: 0x2389E70
+        JP: 0x238B138
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: DUNGEON_SUBMENU_2
       address:
         EU: 0x238AAB4
         NA: 0x2389E90
+        JP: 0x238B158
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: DUNGEON_SUBMENU_3
       address:
         EU: 0x238AAD4
         NA: 0x2389EB0
+        JP: 0x238B178
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: DUNGEON_SUBMENU_4
       address:
         EU: 0x238AAF4
         NA: 0x2389ED0
+        JP: 0x238B198
+        JP: 0x20
       length:
         EU: 0x20
         NA: 0x20
@@ -318,9 +328,11 @@ overlay31:
       address:
         EU: 0x238AD40
         NA: 0x238A11C
+        JP: 0x238B3E4
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: DUNGEON_D_BOX_LAYOUT_26
       address:
         NA: 0x238A134
@@ -355,9 +367,11 @@ overlay31:
       address:
         EU: 0x238ADC4
         NA: 0x238A1A0
+        JP: 0x238B468
       length:
         EU: 0x48
         NA: 0x48
+        JP: 0x48
     - name: DUNGEON_D_BOX_LAYOUT_29
       address:
         NA: 0x238A1E8

--- a/symbols/overlay34.yml
+++ b/symbols/overlay34.yml
@@ -40,9 +40,11 @@ overlay34:
       address:
         EU: 0x22DD8CC
         NA: 0x22DD024
+        JP: 0x22DE62C
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
       description: "Irdkwia's notes: 3*0x8"
     - name: OVERLAY34_UNKNOWN_STRUCT__NA_22DD03C
       address:
@@ -57,9 +59,11 @@ overlay34:
       address:
         EU: 0x22DD8F4
         NA: 0x22DD04C
+        JP: 0x22DE654
       length:
         EU: 0x28
         NA: 0x28
+        JP: 0x28
       description: "Irdkwia's notes: 5*0x8"
     - name: OVERLAY34_RESERVED_SPACE
       address:


### PR DESCRIPTION
Adds various JP symbols in some overlays (ranging from 18 to 34). Related to https://github.com/SkyTemple/skytemple-files/issues/235.