### PR TITLE
Upgrade symbol-address-inference tools + auto-fill function addresses

### DIFF
--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -775,6 +775,8 @@ arm9:
     - name: Rgb8ToBgr5
       address:
         EU: 0x2004FCC
+        NA: 0x2004FCC
+        JP: 0x2004FCC
       description: |-
         Transform the input rgb8 color to a bgr5 color
         
@@ -1152,6 +1154,7 @@ arm9:
       address:
         EU: 0x200C584
         NA: 0x200C4FC
+        JP: 0x200C4FC
       description: |-
         Gets the message that is shown on the dungeon results ("The Last Outing") screen, right after the leader's name.
         
@@ -1256,7 +1259,9 @@ arm9:
         return: bool
     - name: IsLosableItem
       address:
+        EU: 0x200CCC0
         NA: 0x200CC38
+        JP: 0x200CC38
       description: |-
         Checks if an item can be lost after fainting in a dungeon. Specifically calls IsAuraBow and checks item::f_in_shop
         so that the player can't keep an aura bow they haven't paid for yet.
@@ -1267,6 +1272,7 @@ arm9:
       address:
         EU: 0x200CD0C
         NA: 0x200CC84
+        JP: 0x200CC84
       description: |-
         Checks if the given item ID is a treasure box
         
@@ -1276,7 +1282,9 @@ arm9:
         return: True if the item is a treasure box, false otherwise
     - name: IsStorableItem
       address:
+        EU: 0x200CD30
         NA: 0x200CCA8
+        JP: 0x200CCA8
       description: |-
         Checks if an item can be put into storage. Specifically checks for the Wonder Egg, Poke, and Used TMs. Used TMs
         likely can't be stored because the move the TM teaches would be lost when sent to storage.
@@ -1285,7 +1293,9 @@ arm9:
         return: bool
     - name: IsShoppableItem
       address:
+        EU: 0x200CD68
         NA: 0x200CCE0
+        JP: 0x200CCE0
       description: |-
         Checks if an item can be bought and sold from a Kecleon shop. Includes items like the Gold Thorn, Poke, Golden
         Mask, Amber Tear, etc. Also has a special check to make sure an item's buy and sell price is more than 0.
@@ -1294,7 +1304,9 @@ arm9:
         return: bool
     - name: IsValidTargetItem
       address:
+        EU: 0x200CE34
         NA: 0x200CDAC
+        JP: 0x200CDAC
       description: |-
         Checks if an item is a valid target item for missions. Returns true for any item less than ITEM_UNNAMED_0x16B.
         Appears to check a list for valid items above ITEM_UNNAMED_0x16B, but the list is empty?
@@ -1303,7 +1315,9 @@ arm9:
         return: bool
     - name: IsItemUsableNow
       address:
+        EU: 0x200CE80
         NA: 0x200CDF8
+        JP: 0x200CDF8
       description: |-
         Checks if an item can be used right now. Returns true for all items that are not in a shop. If the item is in a
         shop, specifically checks for TMs/HMs and items that provide permanent buffs (Gummis, Sitrus Berry, Ginseng, etc).
@@ -1312,7 +1326,9 @@ arm9:
         return: bool
     - name: IsTicketItem
       address:
+        EU: 0x200CEFC
         NA: 0x200CE74
+        JP: 0x200CE74
       description: |-
         Checks if an item is a ticket that can be used in the recycle shop (ITEM_PRIZE_TICKET, ITEM_SILVER_TICKET,
         ITEM_GOLD_TICKET, and ITEM_PRISM_TICKET).
@@ -1764,7 +1780,9 @@ arm9:
         r0: new value
     - name: AddMoneyCarried
       address:
+        EU: 0x200EE00
         NA: 0x200ED58
+        JP: 0x200ED88
       description: |-
         Adds the amount of money to the player's current amount of money. Just calls
         SetMoneyCarried with the current money + money gained.
@@ -2096,6 +2114,7 @@ arm9:
       address:
         EU: 0x200FF50
         NA: 0x200FEA8
+        JP: 0x200FE78
       description: |-
         Returns the number of items of the given kind in the storage
         
@@ -3018,6 +3037,7 @@ arm9:
       address:
         EU: 0x2017F0C
         NA: 0x2017E70
+        JP: 0x2017EC8
       description: |-
         Initializes some values and then calls SendAudioCommand.
         
@@ -3030,6 +3050,7 @@ arm9:
       address:
         EU: 0x2018C08
         NA: 0x2018B6C
+        JP: 0x2018BC4
       description: |-
         Searches for an entry in AUDIO_COMMANDS_BUFFER that's not currently in use (audio_command::status == 0). Returns the first entry not in use, or null if none was found.
         
@@ -3043,6 +3064,7 @@ arm9:
       address:
         EU: 0x2018C44
         NA: 0x2018BA8
+        JP: 0x2018C00
       description: |-
         Used to send commands to the audio engine (seems to be used mainly to play and stop music)
         
@@ -3051,7 +3073,9 @@ arm9:
         r0: Command to send
     - name: InitSoundSystem
       address:
+        EU: 0x2018CC4
         NA: 0x2018C28
+        JP: 0x2018C80
       description: |-
         Initialize the DSE sound engine?
         
@@ -3188,6 +3212,8 @@ arm9:
     - name: InitAnimationControl
       address:
         EU: 0x201C0EC
+        NA: 0x201C050
+        JP: 0x201C0A8
       description: |-
         Initialize the animation_control structure
         
@@ -3204,6 +3230,8 @@ arm9:
     - name: SetSpriteIdForAnimationControl
       address:
         EU: 0x201C184
+        NA: 0x201C0E8
+        JP: 0x201C140
       description: |-
         Set the sprite id (from WAN_TABLE) in the given animation control
         Also set field 0x72 to the sprite id if they differ
@@ -3214,6 +3242,8 @@ arm9:
     - name: SetAnimationForAnimationControlInternal
       address:
         EU: 0x201C218
+        NA: 0x201C17C
+        JP: 0x201C1D4
       description: |-
         Set the wan animation (and other related settings) of an animation_control
         Used by SetAnimationForAnimationControl
@@ -3230,6 +3260,8 @@ arm9:
     - name: SetAnimationForAnimationControl
       address:
         EU: 0x201C368
+        NA: 0x201C2CC
+        JP: 0x201C324
       description: |-
         Set the animation to play with this animation control, but do not start it.
         
@@ -3245,6 +3277,8 @@ arm9:
     - name: GetWanForAnimationControl
       address:
         EU: 0x201C484
+        NA: 0x201C3E8
+        JP: 0x201C440
       description: |-
         Return the WAN to use for the given animation control
         Return the override if it exists, otherwise look up the sprite id in WAN_TABLE
@@ -3254,6 +3288,8 @@ arm9:
     - name: SetAndPlayAnimationForAnimationControl
       address:
         EU: 0x201C4B4
+        NA: 0x201C418
+        JP: 0x201C470
       description: |-
         Set the animation to play with the animation control, and start it.
         
@@ -3268,6 +3304,8 @@ arm9:
     - name: SwitchAnimationControlToNextFrame
       address:
         EU: 0x201C4F4
+        NA: 0x201C458
+        JP: 0x201C4B0
       description: |-
         Handle switching to the next frame of an animation control, including looping.
         
@@ -3275,6 +3313,8 @@ arm9:
     - name: LoadAnimationFrameAndIncrementInAnimationControl
       address:
         EU: 0x201C5FC
+        NA: 0x201C560
+        JP: 0x201C5B8
       description: |-
         Read some value of the input animation frame, and update animation control with it.
         Also switch next_animation_frame of animation_control to the next animation frame
@@ -3286,6 +3326,8 @@ arm9:
     - name: AnimationControlGetAllocForMaxFrame
       address:
         EU: 0x201D20C
+        NA: 0x201D170
+        JP: 0x201D1C8
       description: |-
         Return the maximum allocation for a frame of this sprite, as stored in the WAN file
         Return 0 if missing and takes sprite override into account
@@ -3305,6 +3347,8 @@ arm9:
     - name: AllocateWanTableEntry
       address:
         EU: 0x201D2E0
+        NA: 0x201D244
+        JP: 0x201D29C
       description: |-
         Return the identifier to a free wan table entry (-1 if none are avalaible). The entry is zeroed.
         
@@ -3336,6 +3380,8 @@ arm9:
     - name: InitWanTable
       address:
         EU: 0x201D458
+        NA: 0x201D3BC
+        JP: 0x201D414
       description: |-
         Initialize the input WAN table with 0x60 free entries (it needs a length of 0x1510 bytes)
         
@@ -3355,6 +3401,8 @@ arm9:
     - name: LoadWanTableEntryFromPack
       address:
         EU: 0x201D520
+        NA: 0x201D484
+        JP: 0x201D4DC
       description: |-
         Return an already allocated entry for this sprite if it exists, otherwise allocate a new one and load the optionally compressed sprite.
         
@@ -3367,6 +3415,8 @@ arm9:
     - name: LoadWanTableEntryFromPackUseProvidedMemory
       address:
         EU: 0x201D62C
+        NA: 0x201D590
+        JP: 0x201D5E8
       description: |-
         Return an already allocated entry for this sprite if it exists, otherwise allocate a new one and load the optionally compressed sprite into the provided memory area. Mark the sprite as externally allocated.
         
@@ -3404,6 +3454,8 @@ arm9:
     - name: WanHasAnimationGroup
       address:
         EU: 0x201DAE0
+        NA: 0x201DA44
+        JP: 0x201DA9C
       description: |-
         Check if the input WAN file loaded in memory has an animation group with this ID
         Valid means that the animation group is in the range of existing animation, and that it has at least one animation.
@@ -3414,6 +3466,8 @@ arm9:
     - name: WanTableSpriteHasAnimationGroup
       address:
         EU: 0x201DB1C
+        NA: 0x201DA80
+        JP: 0x201DAD8
       description: |-
         Check if the sprite in the global WAN table has the given animation group
         see WanHasAnimationGroup for more detail
@@ -3424,6 +3478,8 @@ arm9:
     - name: SpriteTypeInWanTable
       address:
         EU: 0x201DD0C
+        NA: 0x201DC70
+        JP: 0x201DCC8
       description: |-
         Look up the sprite in the WAN table, and return its type
         
@@ -3488,6 +3544,8 @@ arm9:
     - name: GeomSetTexImageParam
       address:
         EU: 0x201E530
+        NA: 0x201E494
+        JP: 0x201E4EC
       description: |-
         Send the "TEXIMAGE_PARAM" geometry engine command, that defines some parameters for the texture
         See http://problemkaputt.de/gbatek.htm#ds3dtextureattributes for more information on the parameters
@@ -3503,6 +3561,8 @@ arm9:
     - name: GeomSetVertexCoord16
       address:
         EU: 0x201E570
+        NA: 0x201E4D4
+        JP: 0x201E52C
       description: |-
         Send the "VTX_16" geometry engine command, that defines the coordinate of a point of a polygon, using 16 bits.
         Inputs are clamped over their 16 lower bits
@@ -3513,6 +3573,8 @@ arm9:
     - name: InitRender3dData
       address:
         EU: 0x201E5A0
+        NA: 0x201E504
+        JP: 0x201E55C
       description: |-
         Initialize the global "RENDER_3D" structure.
         
@@ -3520,6 +3582,8 @@ arm9:
     - name: GeomSwapBuffers
       address:
         EU: 0x201E7B8
+        NA: 0x201E71C
+        JP: 0x201E774
       description: |-
         Call the "SWAP_BUFFERS" command. This will swap the geometry buffer. The parameter of 1 is provided, which enables manual Y-sorting of translucent polygons.
         
@@ -3528,6 +3592,7 @@ arm9:
       address:
         EU: 0x201E7CC
         NA: 0x201E730
+        JP: 0x201E788
       description: |-
         Initialize the render_3d_element structure (without performing any drawing or external data access)
         
@@ -3535,6 +3600,8 @@ arm9:
     - name: Generate3dCanvasBorder
       address:
         EU: 0x201EA88
+        NA: 0x201E9EC
+        JP: 0x201EA44
       description: |-
         Draw the border for dialogue box and other menus, using the 3D engine.
         The render_3d_element contains certain value that needs to be set to a correct value for it to work.
@@ -3785,6 +3852,7 @@ arm9:
       address:
         EU: 0x20250C8
         NA: 0x2024DFC
+        JP: 0x2024E4C
       description: |-
         Returns "One-Item Inventory" or "Treasure Bag" depending on the size of the bag.
         
@@ -3994,6 +4062,8 @@ arm9:
     - name: LoadCursors
       address:
         EU: 0x2029800
+        NA: 0x202950C
+        JP: 0x2029864
       description: |-
         Load and initialise the cursor and cursor16 sprites, storing the result in CURSOR_ANIMATION_CONTROL and CURSOR_16_ANIMATION_CONTROL
         
@@ -4020,6 +4090,8 @@ arm9:
     - name: LoadAlert
       address:
         EU: 0x202A1DC
+        NA: 0x2029EE8
+        JP: 0x202A240
       description: |-
         Load and initialise the alert sprite, storing the result in ALERT_ANIMATION_CONTROL
         
@@ -4028,6 +4100,7 @@ arm9:
       address:
         EU: 0x202A6D8
         NA: 0x202A3E4
+        JP: 0x202A73C
       description: |-
         Prints the specified clear mark on the screen.
         
@@ -4655,6 +4728,7 @@ arm9:
       address:
         EU: 0x204CC70
         NA: 0x204C938
+        JP: 0x204CC98
       description: |-
         Gets the special episode type from the EXECUTE_SPECIAL_EPISODE_TYPE script variable.
         
@@ -4928,14 +5002,18 @@ arm9:
         r1: total_length
     - name: InitKaomadoStream
       address:
+        EU: 0x204DAB8
         NA: 0x204D780
+        JP: 0x204DAE0
       description: |-
         Initializes the stream used to load all Kaomado portraits, called once on game start!
         
         No params.
     - name: InitPortraitBox
       address:
+        EU: 0x204DAD4
         NA: 0x204D79C
+        JP: 0x204DAFC
       description: |-
         Initializes a struct portrait_box.
         
@@ -4988,7 +5066,9 @@ arm9:
         r1: (x, y) offset in tiles from the original offset, derived from the layout
     - name: AllowPortraitDefault
       address:
+        EU: 0x204DBCC
         NA: 0x204D894
+        JP: 0x204DBF4
       description: |-
         Allows the portrait to try and load the default emote (PORTRAIT_NORMAL) if it can't find the specified emote.
         
@@ -4996,7 +5076,9 @@ arm9:
         r1: allow default
     - name: IsValidPortrait
       address:
+        EU: 0x204DBD4
         NA: 0x204D89C
+        JP: 0x204DBFC
       description: |-
         Returns whether this portrait box represents a valid portrait.
         
@@ -5021,6 +5103,7 @@ arm9:
       address:
         EU: 0x204EC84
         NA: 0x204E94C
+        JP: 0x204ECA4
       description: |-
         Used to set the dungeon that will be accessed when switching from ground to dungeon mode.
         
@@ -5029,6 +5112,7 @@ arm9:
       address:
         EU: 0x204ED94
         NA: 0x204EA5C
+        JP: 0x204EDB4
       description: |-
         Initializes the dungeon_init struct before entering a dungeon.
         
@@ -5038,6 +5122,7 @@ arm9:
       address:
         EU: 0x204F318
         NA: 0x204EFE0
+        JP: 0x204F338
       description: |-
         Returns true if the specified dungeon shouldn't have a loss penalty.
         
@@ -5048,6 +5133,7 @@ arm9:
       address:
         EU: 0x204F6FC
         NA: 0x204F3C4
+        JP: 0x204F71C
       description: |-
         Seems to be used to check if you have any missions that have unmet restrictions when trying to access a dungeon.
         
@@ -5131,6 +5217,7 @@ arm9:
       address:
         EU: 0x204FB4C
         NA: 0x204F814
+        JP: 0x204FB68
       description: |-
         Gets the mission rank for the given dungeon and floor.
         
@@ -5169,6 +5256,7 @@ arm9:
       address:
         EU: 0x204FC18
         NA: 0x204F8E0
+        JP: 0x204FC34
       description: |-
         Adds a guest monster to the active team
         
@@ -5668,6 +5756,7 @@ arm9:
       address:
         EU: 0x2050EF0
         NA: 0x2050BB8
+        JP: 0x2050F08
       description: |-
         Returns the number of points required to reach the next rank.
         
@@ -5678,6 +5767,7 @@ arm9:
       address:
         EU: 0x2050FAC
         NA: 0x2050C74
+        JP: 0x2050FC4
       description: |-
         Returns the team's rank
         
@@ -6476,6 +6566,7 @@ arm9:
       address:
         EU: 0x20531CC
         NA: 0x2052E50
+        JP: 0x2053188
       description: |-
         Inits a ground_monster entry with the given guest_monster struct.
         
@@ -6511,6 +6602,7 @@ arm9:
       address:
         EU: 0x2053BC8
         NA: 0x205384C
+        JP: 0x2053B84
       description: |-
         Decodes a 2-byte value that may be encoded using 1 or 2 bytes and writes it to the specified buffer.
         
@@ -6821,7 +6913,9 @@ arm9:
         r0: recruit_str
     - name: IsValidTeamMember
       address:
+        EU: 0x205570C
         NA: 0x2055390
+        JP: 0x205572C
       description: |-
         Returns whether or not the team member at the given index is valid for the current game mode.
         
@@ -6831,7 +6925,9 @@ arm9:
         return: bool
     - name: IsMainCharacter
       address:
+        EU: 0x20558A4
         NA: 0x2055528
+        JP: 0x20558C4
       description: |-
         Returns whether or not the team member at the given index is a "main character".
         
@@ -6965,7 +7061,9 @@ arm9:
         return: team member index of the first available slot
     - name: IsMonsterNotNicknamed
       address:
+        EU: 0x20563EC
         NA: 0x2056070
+        JP: 0x205640C
       description: |-
         Checks if the string_buffer matches the name of the species
         
@@ -6995,7 +7093,9 @@ arm9:
         return: bool
     - name: SetActiveTeam
       address:
+        EU: 0x2056648
         NA: 0x20562CC
+        JP: 0x2056668
       description: |-
         Sets the specified team to active in TEAM_MEMBER_TABLE.
         
@@ -7545,6 +7645,7 @@ arm9:
       address:
         EU: 0x2066098
         NA: 0x2065D1C
+        JP: 0x2066004
       description: |-
         This function gets called shortly after the game is started. Contains a single infinite loop and has no return statement.
         
@@ -7573,6 +7674,7 @@ arm9:
       address:
         EU: 0x206AB04
         NA: 0x206A76C
+        JP: 0x206AA60
       description: |-
         Returns the status of the given dungeon, with some modifications.
         
@@ -7600,11 +7702,15 @@ arm9:
       description: "Note: unverified, ported from Irdkwia's notes"
     - name: ParseDseEvents
       address:
+        EU: 0x20715BC
         NA: 0x2071224
+        JP: 0x207150C
       description: "From https://projectpokemon.org/docs/mystery-dungeon-nds/procyon-studios-digital-sound-elements-r12/"
     - name: UpdateSequencerTracks
       address:
+        EU: 0x2071780
         NA: 0x20713E8
+        JP: 0x20716D0
       description: "From https://projectpokemon.org/docs/mystery-dungeon-nds/procyon-studios-digital-sound-elements-r12/"
     - name: UpdateChannels
       address:
@@ -7617,12 +7723,15 @@ arm9:
         No params.
     - name: UpdateTrackVolumeEnvelopes
       address:
+        EU: 0x20751A4
         NA: 0x2074E0C
+        JP: 0x20750F4
       description: "From https://projectpokemon.org/docs/mystery-dungeon-nds/procyon-studios-digital-sound-elements-r12/"
     - name: EnableVramBanksInSetDontSave
       address:
         EU: 0x2076744
         NA: 0x20763AC
+        JP: 0x2076694
       description: |-
         Enable the VRAM bank marked in the input set, but don’t mark them as enabled in ENABLED_VRAM_BANKS
         
@@ -7631,6 +7740,7 @@ arm9:
       address:
         EU: 0x2077460
         NA: 0x20770C8
+        JP: 0x20773B0
       description: |-
         Enable the VRAM banks in the input set. Will reset the pointed set to 0, and update ENABLED_VRAM_BANKS
         
@@ -7639,6 +7749,7 @@ arm9:
       address:
         EU: 0x207BB68
         NA: 0x207B7D0
+        JP: 0x207BAB8
       description: |-
         Enables processor interrupts by clearing the i flag in the program status register (cpsr).
         
@@ -7647,6 +7758,7 @@ arm9:
       address:
         EU: 0x207BB7C
         NA: 0x207B7E4
+        JP: 0x207BACC
       description: |-
         Disables processor interrupts by setting the i flag in the program status register (cpsr).
         
@@ -7655,6 +7767,7 @@ arm9:
       address:
         EU: 0x207BB90
         NA: 0x207B7F8
+        JP: 0x207BAE0
       description: |-
         Sets the value of the processor's interrupt flag according to the specified parameter.
         
@@ -7664,6 +7777,7 @@ arm9:
       address:
         EU: 0x207BBA8
         NA: 0x207B810
+        JP: 0x207BAF8
       description: |-
         Disables processor all interrupts (both standard and fast) by setting the i and f flags in the program status register (cpsr).
         
@@ -7672,6 +7786,7 @@ arm9:
       address:
         EU: 0x207BBBC
         NA: 0x207B824
+        JP: 0x207BB0C
       description: |-
         Sets the value of the processor's interrupt flags (i and f) according to the specified parameter.
         
@@ -7681,6 +7796,7 @@ arm9:
       address:
         EU: 0x207BBD4
         NA: 0x207B83C
+        JP: 0x207BB24
       description: |-
         Gets the current value of the processor's interrupt request (i) flag
         
@@ -7689,6 +7805,7 @@ arm9:
       address:
         EU: 0x207BFB8
         NA: 0x207BC20
+        JP: 0x207BF08
       description: |-
         Calls EnableIrqFlag and WaitForInterrupt in an infinite loop.
         

--- a/symbols/arm9/itcm.yml
+++ b/symbols/arm9/itcm.yml
@@ -32,7 +32,11 @@ itcm:
     - name: AllocateRender3dElement
       address:
         EU: 0x20B4938
+        NA: 0x20B3FF8
+        JP: 0x20B5858
         EU-ITCM: 0x1FF8C78
+        NA-ITCM: 0x1FF8C78
+        JP-ITCM: 0x1FF8C78
       description: |-
         Return a new render_3d_element from RENDER_3D, to be to draw a new element using the 3d render engine later in the frame.
         
@@ -40,7 +44,11 @@ itcm:
     - name: Render3dStack
       address:
         EU: 0x20B4A8C
+        NA: 0x20B414C
+        JP: 0x20B59AC
         EU-ITCM: 0x1FF8DCC
+        NA-ITCM: 0x1FF8DCC
+        JP-ITCM: 0x1FF8DCC
       description: |-
         Perform rendering of the render_stack of RENDER_3D structure. Does nothing if there are no elements, otherwise, sort them based on a value, and render them all consecutively.
         
@@ -179,7 +187,9 @@ itcm:
         EU: 0x20B7B1C
         NA: 0x20B71DC
         JP: 0x20B8AA4
+        EU-ITCM: 0x1FFBE5C
         NA-ITCM: 0x1FFBE5C
+        JP-ITCM: 0x1FFBEC4
       description: |-
         Appears to check whether LightningRod or Storm Drain should draw in a move.
         

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -122,6 +122,7 @@ overlay10:
       address:
         EU: 0x22C2ECC
         NA: 0x22C2574
+        JP: 0x22C3C5C
       description: |-
         Given a tileset ID, returns whether it's a background or a regular tileset
         

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -336,6 +336,8 @@ overlay11:
     - name: AllocAndInitPartnerFollowDataAndLiveActorList
       address:
         EU: 0x22F865C
+        NA: 0x22F7CBC
+        JP: 0x22F9340
       description: |-
         Allocate and initialize the partner follow data and the live actor list (in GROUND_STATE_PTRS)
         
@@ -343,6 +345,8 @@ overlay11:
     - name: InitPartnerFollowDataAndLiveActorList
       address:
         EU: 0x22F86B8
+        NA: 0x22F7D18
+        JP: 0x22F939C
       description: |-
         Initialize the partner follow data and the live actor list (in GROUND_STATE_PTRS, doesn’t perform the allocation of the structures)
         
@@ -350,6 +354,8 @@ overlay11:
     - name: DeleteLiveActor
       address:
         EU: 0x22F8F18
+        NA: 0x22F8578
+        JP: 0x22F9BFC
       description: |-
         Remove the actor from the overworld actor list (in GROUND_STATE_PTRS)
         
@@ -357,6 +363,8 @@ overlay11:
     - name: InitPartnerFollowData
       address:
         EU: 0x22FC3C8
+        NA: 0x22FBA28
+        JP: 0x22FD0AC
       description: |-
         Initialize the partner follow data structure, without allocating it (in GROUND_STATE_PTRS)
         
@@ -364,6 +372,8 @@ overlay11:
     - name: GetDirectionLiveActor
       address:
         EU: 0x22FDB48
+        NA: 0x22FD1A8
+        JP: 0x22FE820
       description: |-
         Put the direction of the actor in the destination
         
@@ -372,6 +382,8 @@ overlay11:
     - name: SetDirectionLiveActor
       address:
         EU: 0x22FDB58
+        NA: 0x22FD1B8
+        JP: 0x22FE830
       description: |-
         Store the direction in the actor structure
         -1 input is ignored
@@ -395,6 +407,7 @@ overlay11:
       address:
         EU: 0x230B8D4
         NA: 0x230AF38
+        JP: 0x230C4DC
       description: |-
         Used to calculate the items required to get a certain exclusive item in the swap shop.
         
@@ -404,6 +417,7 @@ overlay11:
       address:
         EU: 0x230F6E4
         NA: 0x230ED48
+        JP: 0x23102F4
       description: |-
         Checks if a dungeon should be displayed on the map and the position where it should be displayed if so.
         
@@ -414,6 +428,7 @@ overlay11:
       address:
         EU: 0x230F9A0
         NA: 0x230F004
+        JP: 0x23105B0
       description: |-
         Function called by the script function "worldmap_SetMode"
         Define the mode of the world map, which can among other things be used to decide if the player character should appear on the world map
@@ -424,6 +439,7 @@ overlay11:
       address:
         EU: 0x230FA60
         NA: 0x230F0C4
+        JP: 0x2310670
       description: |-
         Function called with the script function "worldmap_SetCamera".
         Set the map marker the world map should try to center on (while still ensuring it doesn't go over the background border)

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -22,6 +22,7 @@ overlay29:
       address:
         EU: 0x22DEF60
         NA: 0x22DE620
+        JP: 0x22DFCC0
       description: |-
         Gets a pointer to the floor's color table given the current weather.
         
@@ -281,6 +282,7 @@ overlay29:
       address:
         EU: 0x22E15F8
         NA: 0x22E0CB8
+        JP: 0x22E2348
       description: |-
         Checks if the currently pressed touchscreen position is within the specified area.
         
@@ -293,6 +295,7 @@ overlay29:
       address:
         EU: 0x22E1F48
         NA: 0x22E1608
+        JP: 0x22E2C98
       description: |-
         Given a trap entity, returns the pointer to the trap info struct it contains.
         
@@ -302,6 +305,7 @@ overlay29:
       address:
         EU: 0x22E1F50
         NA: 0x22E1610
+        JP: 0x22E2CA0
       description: |-
         Given an item entity, returns the pointer to the item info struct it contains.
         
@@ -321,6 +325,7 @@ overlay29:
       address:
         EU: 0x22E2380
         NA: 0x22E1A40
+        JP: 0x22E30D0
       description: |-
         Updates an entity's pixel_pos field using the specified pixel_position struct, or its own pos field if it's null.
         
@@ -330,6 +335,7 @@ overlay29:
       address:
         EU: 0x22E2A00
         NA: 0x22E20C0
+        JP: 0x22E3750
       description: |-
         Creates and initializes the entity struct of a newly spawned enemy monster. Fails if there's 16 enemies on the floor already.
         
@@ -367,6 +373,7 @@ overlay29:
       address:
         EU: 0x22E2DD8
         NA: 0x22E2498
+        JP: 0x22E3B2C
       description: |-
         Checks if a given entity should be displayed on the minimap
         
@@ -376,6 +383,7 @@ overlay29:
       address:
         EU: 0x22E2EB4
         NA: 0x22E2574
+        JP: 0x22E3C08
       description: |-
         Checks if an entity should be displayed or not.
         
@@ -554,6 +562,7 @@ overlay29:
       address:
         EU: 0x22E418C
         NA: 0x22E37DC
+        JP: 0x22E4E4C
       description: |-
         Takes a position struct in r0 and converts it to a pixel position struct before calling PlayEffectAnimationPixelPos
         
@@ -565,6 +574,7 @@ overlay29:
       address:
         EU: 0x22E41D0
         NA: 0x22E3820
+        JP: 0x22E4E90
       description: |-
         Seems like a variant of PlayEffectAnimationEntity that uses pixel coordinates as its first parameter instead of an entity pointer.
         
@@ -576,6 +586,7 @@ overlay29:
       address:
         EU: 0x22E4290
         NA: 0x22E38E0
+        JP: 0x22E4F50
       description: |-
         Called whenever most (all?) animations are played. Does not return until the animation is over.
         
@@ -662,6 +673,7 @@ overlay29:
       address:
         EU: 0x22E8474
         NA: 0x22E7AC4
+        JP: 0x22E9130
       description: |-
         Randomly picks an item to spawn using one of the floor's item spawn lists and returns its ID.
         
@@ -673,6 +685,7 @@ overlay29:
       address:
         EU: 0x22E8610
         NA: 0x22E7C60
+        JP: 0x22E92CC
       description: |-
         Copies all entries in the floor's monster spawn list that have a sprite size >= 6 to the specified buffer.
         
@@ -1007,6 +1020,7 @@ overlay29:
       address:
         EU: 0x22EB6B0
         NA: 0x22EAD00
+        JP: 0x22EC368
       description: |-
         Used to convert an index that refers to a MUSIC_ID_TABLE entry to a regular music ID.
         
@@ -1037,6 +1051,7 @@ overlay29:
       address:
         EU: 0x22EBD78
         NA: 0x22EB3C8
+        JP: 0x22ECA30
       description: |-
         Sets the leader's monster::action::action_id to the specified value.
         
@@ -1078,6 +1093,7 @@ overlay29:
       address:
         EU: 0x22EBDFC
         NA: 0x22EB44C
+        JP: 0x22ECAB4
       description: |-
         Returns a pointer to the item that is about to be used by a monster given its index.
         
@@ -1088,6 +1104,7 @@ overlay29:
       address:
         EU: 0x22EBEFC
         NA: 0x22EB54C
+        JP: 0x22ECBB4
       description: |-
         Returns a pointer to the item that is about to be used by a monster.
         
@@ -1112,6 +1129,7 @@ overlay29:
       address:
         EU: 0x22EBFBC
         NA: 0x22EB60C
+        JP: 0x22ECC74
       description: |-
         Removes an item from the bag or from the floor after using it
         
@@ -1150,6 +1168,7 @@ overlay29:
       address:
         EU: 0x22EC648
         NA: 0x22EBC98
+        JP: 0x22ED300
       description: |-
         Sets a monster's action to action::ACTION_USE_MOVE_PLAYER, with a specified monster and move index.
         
@@ -1261,7 +1280,9 @@ overlay29:
         stack[0]: visibility flag
     - name: PrepareTrapperTrap
       address:
+        EU: 0x22EE584
         NA: 0x22EDBD4
+        JP: 0x22EF238
       description: |-
         Saves the relevant information in the dungeon struct to later place a trap at the
         location of the entity. (Only called with trap ID 0x19 (TRAP_NONE), but could be used 
@@ -1272,7 +1293,9 @@ overlay29:
         r2: team (see struct trap::team)
     - name: TrySpawnTrap
       address:
+        EU: 0x22EE66C
         NA: 0x22EDCBC
+        JP: 0x22EF320
       description: |-
         Checks if the a trap can be placed on the tile. If the trap ID is >= TRAP_NONE (the
         last value for a trap), randomly select another trap (except for wonder tile). After
@@ -1286,7 +1309,9 @@ overlay29:
         return: true if a trap was spawned succesfully
     - name: TrySpawnTrapperTrap
       address:
+        EU: 0x22EE784
         NA: 0x22EDDD4
+        JP: 0x22EF438
       description: |-
         If the flag for a trapper trap is set, handles spawning a trap based upon the
         information inside the dungeon struct. Uses the entity for logging a message
@@ -1309,7 +1334,9 @@ overlay29:
         r3: ?
     - name: ApplyMudTrapEffect
       address:
+        EU: 0x22EED1C
         NA: 0x22EE36C
+        JP: 0x22EF9C8
       description: |-
         Randomly lowers attack, special attack, defense, or special defense of the defender by 3 stages.
         
@@ -1317,7 +1344,9 @@ overlay29:
         r1: defender entity pointer
     - name: ApplyStickyTrapEffect
       address:
+        EU: 0x22EEDE4
         NA: 0x22EE434
+        JP: 0x22EFA90
       description: |-
         If the defender is the leader, randomly try to make something in the bag sticky. Otherwise, try to make the item the monster is holding sticky.
         
@@ -1325,7 +1354,9 @@ overlay29:
         r1: defender entity pointer
     - name: ApplyGrimyTrapEffect
       address:
+        EU: 0x22EEFE0
         NA: 0x22EE62C
+        JP: 0x22EFC8C
       description: |-
         If the defender is the leader, randomly try to turn food items in the toolbox into
         grimy food. Otherwise, try to make the food item the monster is holding grimy food.
@@ -1334,6 +1365,7 @@ overlay29:
         r1: defender entity pointer
     - name: ApplyPitfallTrapEffect
       address:
+        EU: 0x22EF1D4
         NA: 0x22EE820
       description: |-
         If the defender is the leader, end the current floor unless it has a rescue point.
@@ -1346,7 +1378,9 @@ overlay29:
         r3: bool caused by random trap
     - name: ApplySummonTrapEffect
       address:
+        EU: 0x22EF348
         NA: 0x22EE994
+        JP: 0x22EFFE8
       description: |-
         Randomly spawns 2-4 enemy monsters around the position. The entity is only used for
         logging messages.
@@ -1355,7 +1389,9 @@ overlay29:
         r1: position
     - name: ApplyPpZeroTrapEffect
       address:
+        EU: 0x22EF3E4
         NA: 0x22EEA30
+        JP: 0x22F0084
       description: |-
         Tries to reduce the PP of one of the defender's moves to 0.
         
@@ -1363,7 +1399,9 @@ overlay29:
         r1: defender entity pointer
     - name: ApplyPokemonTrapEffect
       address:
+        EU: 0x22EF4CC
         NA: 0x22EEB18
+        JP: 0x22F016C
       description: |-
         Turns item in the same room as the tile at the position (usually just the entities's
         position) into monsters. If the position is in a hallway, convert items in a 3x3 area
@@ -1373,7 +1411,9 @@ overlay29:
         r1: position
     - name: ApplyTripTrapEffect
       address:
+        EU: 0x22EF6E0
         NA: 0x22EED2C
+        JP: 0x22F0380
       description: |-
         Tries to drop the defender's item and places it on the floor.
         
@@ -1381,6 +1421,7 @@ overlay29:
         r1: defender entity pointer
     - name: ApplyStealthRockTrapEffect
       address:
+        EU: 0x22EF804
         NA: 0x22EEE50
       description: |-
         Tries to apply the damage from the stealth rock trap but does nothing if the defender is a rock type.
@@ -1389,6 +1430,7 @@ overlay29:
         r1: defender entity pointer
     - name: ApplyToxicSpikesTrapEffect
       address:
+        EU: 0x22EF8A0
         NA: 0x22EEEEC
       description: |-
         Tries to inflict 10 damage on the defender and then tries to poison them.
@@ -1397,6 +1439,7 @@ overlay29:
         r1: defender entity pointer
     - name: ApplyRandomTrapEffect
       address:
+        EU: 0x22EF8F4
         NA: 0x22EEF40
       description: |-
         Selects a random trap that isn't a wonder tile and isn't a random trap and calls
@@ -1409,6 +1452,7 @@ overlay29:
         stack[0]: position
     - name: ApplyGrudgeTrapEffect
       address:
+        EU: 0x22EFA28
         NA: 0x22EF074
       description: |-
         Spawns several monsters around the position and gives all monsters on the floor the
@@ -1420,6 +1464,7 @@ overlay29:
       address:
         EU: 0x22EFB08
         NA: 0x22EF154
+        JP: 0x22F0730
       description: |-
         Performs the effect of a triggered trap.
         
@@ -1435,14 +1480,18 @@ overlay29:
         return: True if the trap should be destroyed after the effect is applied
     - name: RevealTrapsNearby
       address:
+        EU: 0x22EFF8C
         NA: 0x22EF5D8
+        JP: 0x22F0BDC
       description: |-
         Reveals traps within the monster's viewing range.
         
         r0: entity pointer
     - name: ShouldRunMonsterAi
       address:
+        EU: 0x22F03A0
         NA: 0x22EF9EC
+        JP: 0x22F0FF0
       description: |-
         Checks a monster's monster_behavior to see whether or not the monster should use AI. Only called on monsters with
         a monster_behavior greater than or equal to BEHAVIOR_FIXED_ENEMY. Returns false for BEHAVIOR_FIXED_ENEMY, 
@@ -1464,7 +1513,9 @@ overlay29:
         return: true
     - name: TryActivateIqBooster
       address:
+        EU: 0x22F0428
         NA: 0x22EFA74
+        JP: 0x22F1078
       description: |-
         Increases the IQ of all team members holding the IQ Booster by floor_properties::iq_booster_value amount unless the
         value is 0.
@@ -1493,6 +1544,7 @@ overlay29:
       address:
         EU: 0x22F1560
         NA: 0x22F0BAC
+        JP: 0x22F21AC
       description: |-
         Returns the area on the touchscreen that contains the sprite of the specified entity
         
@@ -1514,6 +1566,7 @@ overlay29:
       address:
         EU: 0x22F3A44
         NA: 0x22F308C
+        JP: 0x22F4684
       description: |-
         Determines if the leader should keep running. Returns false if the leader bumps into something, or if an action that should stop the leader takes place.
         
@@ -1522,6 +1575,7 @@ overlay29:
       address:
         EU: 0x22F3FEC
         NA: 0x22F3634
+        JP: 0x22F4C2C
       description: |-
         Checks the tile the leader just stepped on and performs any required actions, such as picking up items, triggering traps, etc.
         
@@ -1543,6 +1597,7 @@ overlay29:
       address:
         EU: 0x22F5C88
         NA: 0x22F52CC
+        JP: 0x22F68C4
       description: |-
         Same as UseSingleUseItem, but the second parameter is determined automatically from monster::action_data::action_parameter[1]::action_use_idx.
         
@@ -1551,6 +1606,7 @@ overlay29:
       address:
         EU: 0x22F5CB4
         NA: 0x22F52F8
+        JP: 0x22F68F0
       description: |-
         Makes a monster use a single-use item. The item is deleted afterwards.
         
@@ -1562,6 +1618,7 @@ overlay29:
       address:
         EU: 0x22F5E78
         NA: 0x22F54BC
+        JP: 0x22F6AB4
       description: |-
         Makes a monster use a throwable item.
         
@@ -1581,6 +1638,8 @@ overlay29:
     - name: FreeLoadedAttackSpriteAndMore
       address:
         EU: 0x22F78C8
+        NA: 0x22F6F10
+        JP: 0x22F84DC
       description: |-
         Among other things, free another data structure in the attack sprite storage area/data
         
@@ -1588,6 +1647,8 @@ overlay29:
     - name: SetAndLoadCurrentAttackAnimation
       address:
         EU: 0x22F7920
+        NA: 0x22F6F68
+        JP: 0x22F8534
       description: |-
         Load given sprite into the currently loaded attack sprite structure, replacing the previous one if already loaded.
         
@@ -1597,6 +1658,8 @@ overlay29:
     - name: ClearLoadedAttackSprite
       address:
         EU: 0x22F79C0
+        NA: 0x22F7008
+        JP: 0x22F85D4
       description: |-
         Delete the data of the currently loaded attack sprite, if any.
         Doesn’t free the structure, which can continue to be used.
@@ -1605,6 +1668,8 @@ overlay29:
     - name: GetLoadedAttackSpriteId
       address:
         EU: 0x22F7A08
+        NA: 0x22F7050
+        JP: 0x22F861C
       description: |-
         Get the sprite ID (in the loaded WAN list) of the currently loaded attack sprite, or 0 if none.
         
@@ -1743,6 +1808,7 @@ overlay29:
       address:
         EU: 0x22F8FFC
         NA: 0x22F85F0
+        JP: 0x22F9BB4
       description: |-
         Moves a monster to the target position. Used both for regular movement and special movement (like teleportation).
         
@@ -1801,7 +1867,9 @@ overlay29:
         return: ?
     - name: TryActivateTraceAndColorChange
       address:
+        EU: 0x22F9EFC
         NA: 0x22F94F0
+        JP: 0x22FAAB4
       description: |-
         Tries to activate the abilities trace and color change if possible. Called after using
         a move.
@@ -1865,7 +1933,9 @@ overlay29:
         return: bool
     - name: TryActivateConversion2
       address:
+        EU: 0x22FA150
         NA: 0x22F9744
+        JP: 0x22FACFC
       description: |-
         Checks for the conversion2 status and applies the type change if applicable. Called
         after using a move.
@@ -1906,7 +1976,9 @@ overlay29:
         r0: pointer to entity whose moves will be restored
     - name: BoostIQ
       address:
+        EU: 0x22FAB50
         NA: 0x22FA144
+        JP: 0x22FB6EC
       description: |-
         Tries to boost the target's IQ.
         
@@ -1938,7 +2010,9 @@ overlay29:
         return: bool
     - name: TryEndStatusWithAbility
       address:
+        EU: 0x22FB1E8
         NA: 0x22FA7DC
+        JP: 0x22FBD84
       description: |-
         Checks if any of the defender's active abilities would end one of their current status
         conditions. For example, if the ability Own Tempo will stop confusion.
@@ -2040,6 +2114,7 @@ overlay29:
       address:
         EU: 0x22FBC20
         NA: 0x22FB214
+        JP: 0x22FC79C
       description: |-
         The user attempts to eat an item from the target.
         
@@ -2112,6 +2187,7 @@ overlay29:
       address:
         EU: 0x22FC854
         NA: 0x22FBE58
+        JP: 0x22FD248
       description: |-
         Initializes stats, IQ skills and moves for a given monster
         
@@ -2124,6 +2200,7 @@ overlay29:
       address:
         EU: 0x22FC954
         NA: 0x22FBF58
+        JP: 0x22FD348
       description: |-
         Initializes dungeon::enemy_spawn_stats. Might do something else too.
         
@@ -2132,6 +2209,7 @@ overlay29:
       address:
         EU: 0x22FCC30
         NA: 0x22FC234
+        JP: 0x22FD624
       description: |-
         Initializes the HP, Atk, Sp. Atk, Def, Sp. Def and moveset of a newly spawned enemy. Might do something else too.
         
@@ -2191,6 +2269,7 @@ overlay29:
       address:
         EU: 0x22FE3D0
         NA: 0x22FD9D4
+        JP: 0x22FEDC4
       description: |-
         Initializes the monster struct within the provided entity struct.
         
@@ -2235,6 +2314,7 @@ overlay29:
       address:
         EU: 0x22FECF8
         NA: 0x22FE2FC
+        JP: 0x22FF6E4
       description: |-
         Returns the max HP of a monster given its level.
         
@@ -2245,6 +2325,7 @@ overlay29:
       address:
         EU: 0x22FED4C
         NA: 0x22FE350
+        JP: 0x22FF738
       description: |-
         Returns the Atk / Sp. Atk of a monster given its level, capped to 255.
         
@@ -2256,6 +2337,7 @@ overlay29:
       address:
         EU: 0x22FEDB4
         NA: 0x22FE3B8
+        JP: 0x22FF7A0
       description: |-
         Returns the Def / Sp. Def of a monster given its level, capped to 255.
         
@@ -2283,7 +2365,9 @@ overlay29:
         r0: Pointer to monster entity
     - name: TryActivateFlashFireOnAllMonsters
       address:
+        EU: 0x22FFB94
         NA: 0x22FF168
+        JP: 0x2300558
       description: |-
         Checks every monster for apply_flash_fire_boost. If it's true, activates Flash Fire for the monster and sets
         apply_flash_fire_boost back to false.
@@ -2303,6 +2387,7 @@ overlay29:
       address:
         EU: 0x2300058
         NA: 0x22FF62C
+        JP: 0x2300A1C
       description: |-
         Returns the mobility type of a monster species, accounting for STATUS_SLIP.
         
@@ -2315,6 +2400,7 @@ overlay29:
       address:
         EU: 0x23000A0
         NA: 0x22FF674
+        JP: 0x2300A64
       description: |-
         Returns the mobility type of a monster, accounting for STATUS_SLIP and the result of a call to IsFloating.
         
@@ -2351,6 +2437,7 @@ overlay29:
       address:
         EU: 0x23006C8
         NA: 0x22FF764
+        JP: 0x2300B54
       description: |-
         Checks if a given monster cannot stand on a given tile.
         
@@ -2639,7 +2726,9 @@ overlay29:
         return: Result of the call to ShouldMonsterRunAway
     - name: SafeguardIsActive
       address:
+        EU: 0x230236C
         NA: 0x2301940
+        JP: 0x2302EAC
       description: |-
         Checks if the monster is under the effect of Safeguard.
         
@@ -2649,7 +2738,9 @@ overlay29:
         return: bool
     - name: LeafGuardIsActive
       address:
+        EU: 0x23023C0
         NA: 0x2301994
+        JP: 0x2302F00
       description: |-
         Checks if the monster is protected by the ability Leaf Guard.
         
@@ -2659,7 +2750,9 @@ overlay29:
         return: bool
     - name: IsProtectedFromStatDrops
       address:
+        EU: 0x2302558
         NA: 0x2301B2C
+        JP: 0x230308C
       description: |-
         Checks if the target monster is protected from getting their stats dropped by the user.
         
@@ -2837,7 +2930,9 @@ overlay29:
         return: whether or not any of the masked bits changed from the previous state
     - name: IsProtectedFromNegativeStatus
       address:
+        EU: 0x2302E5C
         NA: 0x2302430
+        JP: 0x2303980
       description: |-
         Checks if the target monster is protected from getting a negative status condition.
         
@@ -2873,7 +2968,9 @@ overlay29:
         r0: entity pointer
     - name: LevelUpItemEffect
       address:
+        EU: 0x2303488
         NA: 0x2302A5C
+        JP: 0x2303FAC
       description: |-
         Attempts to level up the the target. Calls LevelUp with a few extra checks and messages
         for using as an item. Used for the Joy Seed and Golden Seed.
@@ -2912,6 +3009,7 @@ overlay29:
       address:
         EU: 0x2304544
         NA: 0x2303B18
+        JP: 0x2305068
       description: |-
         Determines the moveset of a newly spawned monster given its species and level.
         
@@ -2958,6 +3056,7 @@ overlay29:
       address:
         EU: 0x23060C0
         NA: 0x2305694
+        JP: 0x2306BE4
       description: |-
         Similar to CheckLeaderTile, but for other monsters.
         
@@ -2966,7 +3065,9 @@ overlay29:
         r0: Entity pointer
     - name: EndNegativeStatusCondition
       address:
+        EU: 0x23062F0
         NA: 0x23058C4
+        JP: 0x2306E14
       description: |-
         Cures the target's negative status conditions. The game rarely (if not never) calls
         this function with the bool to remove the wrapping status false.
@@ -2979,7 +3080,9 @@ overlay29:
         return: bool succesfully removed negative status
     - name: EndNegativeStatusConditionWrapper
       address:
+        EU: 0x2306654
         NA: 0x2305C28
+        JP: 0x2307178
       description: |-
         Calls EndNegativeStatusCondition with remove wrapping status false.
         
@@ -2990,7 +3093,9 @@ overlay29:
         return: bool succesfully removed negative status
     - name: TransferNegativeStatusCondition
       address:
+        EU: 0x2306668
         NA: 0x2305C3C
+        JP: 0x230718C
       description: |-
         Transfers all negative status conditions the user has and gives then to the target.
         
@@ -2998,7 +3103,9 @@ overlay29:
         r1: target entity pointer
     - name: EndSleepClassStatus
       address:
+        EU: 0x2306A08
         NA: 0x2305FDC
+        JP: 0x230752C
       description: |-
         Cures the target's sleep, sleepless, nightmare, yawn or napping status due to the action of the user, and prints the event to the log.
         
@@ -3006,7 +3113,9 @@ overlay29:
         r1: pointer to target
     - name: EndBurnClassStatus
       address:
+        EU: 0x2306BD4
         NA: 0x23061A8
+        JP: 0x23076F8
       description: |-
         Cures the target's burned, poisoned, badly poisoned or paralysis status due to the action of the user, and prints the event to the log.
         
@@ -3035,7 +3144,9 @@ overlay29:
         r1: pointer to target
     - name: EndReflectClassStatus
       address:
+        EU: 0x2306F20
         NA: 0x23064F4
+        JP: 0x2307A24
       description: |-
         Removes the target's reflect, safeguard, light screen, counter, magic coat, wish, protect, mirror coat, endure, mini counter?, mirror move, conversion 2, vital throw, mist, metal burst, aqua ring or lucky chant status due to the action of the user, and prints the event to the log.
         
@@ -3043,7 +3154,9 @@ overlay29:
         r1: pointer to target
     - name: TryRemoveSnatchedMonsterFromDungeonStruct
       address:
+        EU: 0x2307104
         NA: 0x23066D8
+        JP: 0x2307C08
       description: |-
         If the target is afflicted with snatch, change dungeon::snatch_monster and dungeon::snatch_status_unique_id back
         to NULL and 0 respectively. This function does not actually remove the status and visual flags for snatch from
@@ -3054,7 +3167,9 @@ overlay29:
         r1: pointer to target
     - name: EndCurseClassStatus
       address:
+        EU: 0x2307154
         NA: 0x2306728
+        JP: 0x2307C58
       description: |-
         Removes the target's curse (1), decoy (2), snatch (3), gastro acid (4), heal block (5), or embargo (6) status
         due to the action of the user, and prints the event to the log.
@@ -3065,7 +3180,9 @@ overlay29:
         r3: flag to log a message
     - name: EndLeechSeedClassStatus
       address:
+        EU: 0x23072F0
         NA: 0x23068C4
+        JP: 0x2307DF4
       description: |-
         Cures the target's leech seed or destiny bond status due to the action of the user, and prints the event to the log.
         
@@ -3073,7 +3190,9 @@ overlay29:
         r1: pointer to target
     - name: EndSureShotClassStatus
       address:
+        EU: 0x230737C
         NA: 0x2306950
+        JP: 0x2307E80
       description: |-
         Removes the target's sure shot, whiffer, set damage or focus energy status due to the action of the user, and prints the event to the log.
         
@@ -3081,7 +3200,9 @@ overlay29:
         r1: pointer to target
     - name: EndInvisibleClassStatus
       address:
+        EU: 0x230742C
         NA: 0x2306A00
+        JP: 0x2307F30
       description: |-
         Removes the target's invisible, transformed, mobile, or slip status due to the action of the user, and prints
         the event to the log.
@@ -3091,7 +3212,9 @@ overlay29:
         r2: flag to not log a message when removing slip status
     - name: EndBlinkerClassStatus
       address:
+        EU: 0x2307554
         NA: 0x2306B28
+        JP: 0x2308058
       description: |-
         Removes the target's blinker, cross-eyed, eyedrops, or dropeye status due to the action of the user, and
         prints the event to the log.
@@ -3100,7 +3223,9 @@ overlay29:
         r1: pointer to target
     - name: EndMuzzledStatus
       address:
+        EU: 0x2307624
         NA: 0x2306BF8
+        JP: 0x2308128
       description: |-
         Removes the target's muzzled status due to the action of the user, and prints the event to the log.
         
@@ -3108,7 +3233,9 @@ overlay29:
         r1: pointer to target
     - name: EndMiracleEyeStatus
       address:
+        EU: 0x2307690
         NA: 0x2306C64
+        JP: 0x2308194
       description: |-
         Removes the target's miracle eye status due to the action of the user, and prints the event to the log.
         
@@ -3116,7 +3243,9 @@ overlay29:
         r1: pointer to target
     - name: EndMagnetRiseStatus
       address:
+        EU: 0x23076FC
         NA: 0x2306CD0
+        JP: 0x2308200
       description: |-
         Removes the target's magnet rise status due to the action of the user, and prints the event to the log.
         
@@ -3124,7 +3253,9 @@ overlay29:
         r1: pointer to target
     - name: TransferNegativeBlinkerClassStatus
       address:
+        EU: 0x2308318
         NA: 0x23078EC
+        JP: 0x2308E1C
       description: |-
         Tries to transfer the the negative blinker class status conditions from the user to
         the target.
@@ -3134,7 +3265,9 @@ overlay29:
         return: Whether or not the status could be transferred
     - name: EndFrozenStatus
       address:
+        EU: 0x23086A4
         NA: 0x2307C78
+        JP: 0x23091A8
       description: |-
         Cures the target's freeze status due to the action of the user.
         
@@ -3142,7 +3275,9 @@ overlay29:
         r1: target entity pointer
     - name: EndProtectStatus
       address:
+        EU: 0x2308744
         NA: 0x2307D18
+        JP: 0x2309248
       description: |-
         Ends the target's protect status due to the action of the user.
         
@@ -3150,7 +3285,9 @@ overlay29:
         r1: target entity pointer
     - name: TryRestoreRoostTyping
       address:
+        EU: 0x2308780
         NA: 0x2307D54
+        JP: 0x2309284
       description: |-
         Tries to restore the target's original typings before the Roost effect took place. Does nothing if the target
         is not affected by Roost.
@@ -3343,7 +3480,9 @@ overlay29:
         stack[4]: flag to account for certain effects (Flash Fire, Reflect, Light Screen, aura bows, Def. Scarf, Zinc Band). Only ever set to false when computing recoil damage for Jump Kick/Hi Jump Kick missing, which is based on the damage that would have been done if the move didn't miss.
     - name: ApplyDamageAndEffectsWrapper
       address:
+        EU: 0x230DB90
         NA: 0x230D11C
+        JP: 0x230E65C
       description: |-
         A wrapper for ApplyDamageAndEffects used for applying damage from sources such as statuses, traps, liquid ooze,
         hunger, and possibly more.
@@ -3438,7 +3577,9 @@ overlay29:
         r1: defender pointer
     - name: UpdateShopkeeperModeAfterTrap
       address:
+        EU: 0x230DEF0
         NA: 0x230D47C
+        JP: 0x230E9B8
       description: |-
         Updates the shopkeeper mode of a monster in response to stepping on a trap.
         
@@ -3543,7 +3684,9 @@ overlay29:
         return: boost
     - name: TeamMemberHasItemActive
       address:
+        EU: 0x231020C
         NA: 0x230F798
+        JP: 0x2310CD4
       description: |-
         Checks if any team member is holding a certain item and puts them into the array given.
         
@@ -3614,7 +3757,9 @@ overlay29:
         r3: flag to log a message on failure
     - name: IsProtectedFromSleepClassStatus
       address:
+        EU: 0x2312444
         NA: 0x23119E4
+        JP: 0x2312EFC
       description: |-
         Checks if the monster is immune to sleep class status conditions.
         
@@ -3886,7 +4031,9 @@ overlay29:
         return: 2 if Flash Fire should activate and raise the defender's boost level, 1 if Flash Fire should activate but the defender's boost level is maxed out, 0 otherwise.
     - name: ActivateFlashFire
       address:
+        EU: 0x2314744
         NA: 0x2313CE4
+        JP: 0x23151C8
       description: |-
         Actually applies the Flash Fire boost with a message log and animation. Passes the same monster for attacker and
         defender, but the attacker goes unused.
@@ -4072,7 +4219,9 @@ overlay29:
         return: bool, whether or not the ability was activated
     - name: TryInflictTerrifiedStatus
       address:
+        EU: 0x23158C0
         NA: 0x2314E60
+        JP: 0x2316334
       description: |-
         Inflicts the Terrified status condition on a target monster if possible.
         
@@ -4080,7 +4229,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictGrudgeStatus
       address:
+        EU: 0x2315918
         NA: 0x2314EB8
+        JP: 0x231638C
       description: |-
         Inflicts the Grudge status condition on a target monster if possible.
         
@@ -4195,7 +4346,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictSureShotStatus
       address:
+        EU: 0x23165D0
         NA: 0x2315B70
+        JP: 0x2317048
       description: |-
         Inflicts the Sure Shot status condition on a target monster if possible.
         
@@ -4203,7 +4356,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictWhifferStatus
       address:
+        EU: 0x2316660
         NA: 0x2315C00
+        JP: 0x23170D8
       description: |-
         Inflicts the Whiffer status condition on a target monster if possible.
         
@@ -4211,7 +4366,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictSetDamageStatus
       address:
+        EU: 0x2316748
         NA: 0x2315CE8
+        JP: 0x23171C0
       description: |-
         Inflicts the Set Damage status condition on a target monster if possible.
         
@@ -4219,7 +4376,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictFocusEnergyStatus
       address:
+        EU: 0x23167E4
         NA: 0x2315D84
+        JP: 0x231725C
       description: |-
         Inflicts the Focus Energy status condition on a target monster if possible.
         
@@ -4227,7 +4386,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictDecoyStatus
       address:
+        EU: 0x2316884
         NA: 0x2315E24
+        JP: 0x23172FC
       description: |-
         Inflicts the Decoy status condition on a target monster if possible.
         
@@ -4236,7 +4397,9 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictCurseStatus
       address:
+        EU: 0x2316B3C
         NA: 0x23160DC
+        JP: 0x23175B4
       description: |-
         Inflicts the Curse status condition on a target monster if possible and if the user is
         a ghost type. Otherwise, just boost the user's defense and attack then lower the user's
@@ -4246,7 +4409,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictSnatchStatus
       address:
+        EU: 0x2316CE0
         NA: 0x2316280
+        JP: 0x2317758
       description: |-
         Inflicts the Snatch status condition on a target monster if possible.
         
@@ -4254,7 +4419,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictTauntStatus
       address:
+        EU: 0x2316E08
         NA: 0x23163A8
+        JP: 0x2317880
       description: |-
         Inflicts the Taunt status condition on a target monster if possible.
         
@@ -4263,7 +4430,9 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictStockpileStatus
       address:
+        EU: 0x2316F38
         NA: 0x23164D8
+        JP: 0x23179AC
       description: |-
         Inflicts the Stockpile condition on a target monster if possible. Won't boost the level
         of stockpiling above 3.
@@ -4275,6 +4444,7 @@ overlay29:
       address:
         EU: 0x2316FDC
         NA: 0x231657C
+        JP: 0x2317A50
       description: |-
         Attempts to turn the target invisible.
         
@@ -4284,7 +4454,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictPerishSongStatus
       address:
+        EU: 0x231708C
         NA: 0x231662C
+        JP: 0x2317B00
       description: |-
         Inflicts the Perish Song status condition on a target monster if possible.
         
@@ -4294,7 +4466,9 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictEncoreStatus
       address:
+        EU: 0x2317180
         NA: 0x2316720
+        JP: 0x2317BF4
       description: |-
         Inflicts the Encore status condition on a target monster if possible.
         
@@ -4304,7 +4478,9 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryDecreaseBelly
       address:
+        EU: 0x2317338
         NA: 0x23168D8
+        JP: 0x2317DA8
       description: |-
         Tries to reduce the belly size of the target. Only when max belly shrink is 0, the
         current belly is reduced by belly to lose. If both are non-zero, only the max belly
@@ -4316,7 +4492,9 @@ overlay29:
         r3: max belly shrink
     - name: TryIncreaseBelly
       address:
+        EU: 0x2317610
         NA: 0x2316BB0
+        JP: 0x2318080
       description: |-
         Restore belly and possibly boost max belly of the target monster if possible.
         
@@ -4327,7 +4505,9 @@ overlay29:
         stack[0]: flag to log a message
     - name: TryInflictMuzzledStatus
       address:
+        EU: 0x2317B84
         NA: 0x2317124
+        JP: 0x23185F4
       description: |-
         Inflicts the Muzzled status condition on a target monster if possible.
         
@@ -4339,6 +4519,7 @@ overlay29:
       address:
         EU: 0x2317C7C
         NA: 0x231721C
+        JP: 0x23186EC
       description: |-
         Attempts to transform the target into the species of a random monster contained in the list returned by MonsterSpawnListPartialCopy.
         
@@ -4348,7 +4529,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictMobileStatus
       address:
+        EU: 0x2317E6C
         NA: 0x231740C
+        JP: 0x23188DC
       description: |-
         Inflicts the Mobile status condition on a target monster if possible.
         
@@ -4356,7 +4539,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictExposedStatus
       address:
+        EU: 0x2317F28
         NA: 0x23174C8
+        JP: 0x2318998
       description: |-
         Inflicts the Exposed status condition on a target monster if possible. Only applies to
         Ghost types and monsters with raised evasion. If the animation effect ID is 0,
@@ -4370,7 +4555,9 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryActivateIdentifyCondition
       address:
+        EU: 0x23180A8
         NA: 0x2317648
+        JP: 0x2318B18
       description: |-
         Sets the flag for the identify orb which causes monsters holding items to be shown with
         a blue exclamation mark status icon.
@@ -4379,7 +4566,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictBlinkerStatus
       address:
+        EU: 0x231812C
         NA: 0x23176CC
+        JP: 0x2318B9C
       description: |-
         Inflicts the Blinker status condition on a target monster if possible.
         
@@ -4401,7 +4590,9 @@ overlay29:
         return: bool
     - name: TryInflictCrossEyedStatus
       address:
+        EU: 0x23182A4
         NA: 0x2317844
+        JP: 0x2318D14
       description: |-
         Inflicts the Cross-Eyed status condition on a target monster if possible.
         
@@ -4411,7 +4602,9 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictEyedropStatus
       address:
+        EU: 0x23183BC
         NA: 0x231795C
+        JP: 0x2318E2C
       description: |-
         Inflicts the Eyedrop status condition on a target monster if possible.
         
@@ -4419,7 +4612,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictSlipStatus
       address:
+        EU: 0x231846C
         NA: 0x2317A0C
+        JP: 0x2318EDC
       description: |-
         Inflicts the Slip status condition on a target monster if possible.
         
@@ -4428,7 +4623,9 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictDropeyeStatus
       address:
+        EU: 0x2318554
         NA: 0x2317AF4
+        JP: 0x2318FC4
       description: |-
         Inflicts the Dropeye status condition on a target monster if possible.
         
@@ -4449,7 +4646,9 @@ overlay29:
         r3: flag to suppress message logging
     - name: RestoreOneMovePP
       address:
+        EU: 0x23187B8
         NA: 0x2317D58
+        JP: 0x2319228
       description: |-
         Restores the PP the target's move in the specified move slot by the specified amount.
         
@@ -4460,7 +4659,9 @@ overlay29:
         stack[0]: flag to log message
     - name: RestoreRandomMovePP
       address:
+        EU: 0x23188E8
         NA: 0x2317E88
+        JP: 0x2319358
       description: |-
         Restores the PP of a random one of the target's moves by the specified amount.
         
@@ -4470,7 +4671,9 @@ overlay29:
         r3: flag to log message
     - name: ApplyProteinEffect
       address:
+        EU: 0x23189B0
         NA: 0x2317F50
+        JP: 0x2319420
       description: |-
         Tries to boost the target's attack stat.
         
@@ -4479,7 +4682,9 @@ overlay29:
         r2: attack boost
     - name: ApplyCalciumEffect
       address:
+        EU: 0x2318A44
         NA: 0x2317FE4
+        JP: 0x23194B4
       description: |-
         Tries to boost the target's special attack stat.
         
@@ -4488,7 +4693,9 @@ overlay29:
         r2: special attack boost
     - name: ApplyIronEffect
       address:
+        EU: 0x2318AD8
         NA: 0x2318078
+        JP: 0x2319548
       description: |-
         Tries to boost the target's defense stat.
         
@@ -4497,7 +4704,9 @@ overlay29:
         r2: defense boost
     - name: ApplyZincEffect
       address:
+        EU: 0x2318B6C
         NA: 0x231810C
+        JP: 0x23195DC
       description: |-
         Tries to boost the target's special defense stat.
         
@@ -4506,7 +4715,9 @@ overlay29:
         r2: special defense boost
     - name: TryInflictLongTossStatus
       address:
+        EU: 0x2318C00
         NA: 0x23181A0
+        JP: 0x2319670
       description: |-
         Inflicts the Long Toss status condition on a target monster if possible.
         
@@ -4514,7 +4725,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictPierceStatus
       address:
+        EU: 0x2318C70
         NA: 0x2318210
+        JP: 0x23196E0
       description: |-
         Inflicts the Pierce status condition on a target monster if possible.
         
@@ -4522,7 +4735,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictGastroAcidStatus
       address:
+        EU: 0x2318CDC
         NA: 0x231827C
+        JP: 0x231974C
       description: |-
         Inflicts the Gastro Acid status condition on a target monster if possible.
         
@@ -4542,14 +4757,18 @@ overlay29:
         r0: pointer to entity
     - name: ApplyAquaRingHealing
       address:
+        EU: 0x2318E48
         NA: 0x23183E8
+        JP: 0x23198B8
       description: |-
         Applies the passive healing gained from the Aqua Ring status.
         
         r0: pointer to entity
     - name: TryInflictAquaRingStatus
       address:
+        EU: 0x2318EBC
         NA: 0x231845C
+        JP: 0x231992C
       description: |-
         Inflicts the Aqua Ring status condition on a target monster if possible.
         
@@ -4557,7 +4776,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictLuckyChantStatus
       address:
+        EU: 0x2318F68
         NA: 0x2318508
+        JP: 0x23199D8
       description: |-
         Inflicts the Lucky Chant status condition on a target monster if possible.
         
@@ -4565,7 +4786,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictHealBlockStatus
       address:
+        EU: 0x2319008
         NA: 0x23185A8
+        JP: 0x2319A78
       description: |-
         Inflicts the Heal Block status condition on a target monster if possible.
         
@@ -4578,6 +4801,7 @@ overlay29:
       address:
         EU: 0x231912C
         NA: 0x23186CC
+        JP: 0x2319B9C
       description: |-
         Returns true if the monster has the Embargo status condition.
         
@@ -4587,13 +4811,16 @@ overlay29:
       address:
         EU: 0x2319160
         NA: 0x2318700
+        JP: 0x2319BD0
       description: |-
         Logs the error message when the usage of an item is blocked by Embargo.
         
         r0: pointer to entity
     - name: TryInflictEmbargoStatus
       address:
+        EU: 0x231918C
         NA: 0x231872C
+        JP: 0x2319BFC
       description: |-
         Inflicts the Embargo status condition on a target monster if possible.
         
@@ -4604,7 +4831,9 @@ overlay29:
         return: Whether or not the status could be inflicted
     - name: TryInflictMiracleEyeStatus
       address:
+        EU: 0x23192B0
         NA: 0x2318850
+        JP: 0x2319D20
       description: |-
         Inflicts the Miracle Eye status condition on a target monster if possible.
         
@@ -4613,7 +4842,9 @@ overlay29:
         r2: flag to only perform the check for inflicting without actually inflicting
     - name: TryInflictMagnetRiseStatus
       address:
+        EU: 0x23193E4
         NA: 0x2318984
+        JP: 0x2319E54
       description: |-
         Inflicts the Magnet Rise status condition on a target monster if possible.
         
@@ -4633,7 +4864,9 @@ overlay29:
         return: bool
     - name: TryInflictSafeguardStatus
       address:
+        EU: 0x23198D0
         NA: 0x2318E70
+        JP: 0x231A340
       description: |-
         Inflicts the Safeguard status condition on a target monster if possible.
         
@@ -4641,7 +4874,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictMistStatus
       address:
+        EU: 0x2319970
         NA: 0x2318F10
+        JP: 0x231A3E0
       description: |-
         Inflicts the Mist status condition on a target monster if possible.
         
@@ -4649,7 +4884,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictWishStatus
       address:
+        EU: 0x2319A0C
         NA: 0x2318FAC
+        JP: 0x231A47C
       description: |-
         Inflicts the Wish status condition on a target monster if possible.
         
@@ -4657,7 +4894,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictMagicCoatStatus
       address:
+        EU: 0x2319AAC
         NA: 0x231904C
+        JP: 0x231A51C
       description: |-
         Inflicts the Magic Coat status condition on a target monster if possible.
         
@@ -4665,7 +4904,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictLightScreenStatus
       address:
+        EU: 0x2319B4C
         NA: 0x23190EC
+        JP: 0x231A5BC
       description: |-
         Inflicts the Light Screen status condition on a target monster if possible.
         
@@ -4673,7 +4914,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictReflectStatus
       address:
+        EU: 0x2319BEC
         NA: 0x231918C
+        JP: 0x231A65C
       description: |-
         Inflicts the Reflect status condition on a target monster if possible.
         
@@ -4681,7 +4924,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictProtectStatus
       address:
+        EU: 0x2319C8C
         NA: 0x231922C
+        JP: 0x231A6FC
       description: |-
         Inflicts the Protect status condition on a target monster if possible.
         
@@ -4689,7 +4934,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictMirrorCoatStatus
       address:
+        EU: 0x2319D3C
         NA: 0x23192DC
+        JP: 0x231A7AC
       description: |-
         Inflicts the Mirror Coat status condition on a target monster if possible.
         
@@ -4697,7 +4944,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictEndureStatus
       address:
+        EU: 0x2319DD8
         NA: 0x2319378
+        JP: 0x231A848
       description: |-
         Inflicts the Endure status condition on a target monster if possible.
         
@@ -4705,7 +4954,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictMirrorMoveStatus
       address:
+        EU: 0x2319E78
         NA: 0x2319418
+        JP: 0x231A8E8
       description: |-
         Inflicts the Mirror Move status condition on a target monster if possible.
         
@@ -4713,7 +4964,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictConversion2Status
       address:
+        EU: 0x2319F18
         NA: 0x23194B8
+        JP: 0x231A988
       description: |-
         Inflicts the Conversion2 status condition on a target monster if possible.
         
@@ -4721,7 +4974,9 @@ overlay29:
         r1: target entity pointer
     - name: TryInflictVitalThrowStatus
       address:
+        EU: 0x2319FE4
         NA: 0x2319584
+        JP: 0x231AA54
       description: |-
         Inflicts the Vital Throw status condition on a target monster if possible.
         
@@ -4729,7 +4984,9 @@ overlay29:
         r1: target entity pointer
     - name: TryResetStatChanges
       address:
+        EU: 0x231A084
         NA: 0x2319624
+        JP: 0x231AAF4
       description: |-
         Tries to reset the stat changes of the defender.
         
@@ -4738,7 +4995,9 @@ overlay29:
         r3: bool to force animation
     - name: MirrorMoveIsActive
       address:
+        EU: 0x231A1A8
         NA: 0x2319748
+        JP: 0x231AC18
       description: |-
         Checks if the monster is under the effect of Mirror Move.
         
@@ -4748,7 +5007,9 @@ overlay29:
         return: int
     - name: MistIsActive
       address:
+        EU: 0x231A22C
         NA: 0x23197CC
+        JP: 0x231AC9C
       description: |-
         Checks if the monster is under the effect of Mist.
         
@@ -4871,6 +5132,7 @@ overlay29:
         return: type ID
     - name: ActivateMotorDrive
       address:
+        EU: 0x231BAC0
         NA: 0x231B060
       description: |-
         Displays the message and applies the speed boost for the ability Motor Drive.
@@ -4878,7 +5140,9 @@ overlay29:
         r0: monster pointer
     - name: TryActivateFrisk
       address:
+        EU: 0x231BB04
         NA: 0x231B0A4
+        JP: 0x231C570
       description: |-
         Tries to activate the Frisk ability on the defender. The attacker has to be on the team and the defender has to be
         holding an item or be able to drop a treasure box.
@@ -4887,21 +5151,27 @@ overlay29:
         r1: defender pointer
     - name: TryActivateBadDreams
       address:
+        EU: 0x231BC18
         NA: 0x231B1B8
+        JP: 0x231C684
       description: |-
         Tries to apply the damage from Bad Dreams to all sleeping monsters in the room.
         
         r0: monster pointer
     - name: ActivateStench
       address:
+        EU: 0x231BD9C
         NA: 0x231B33C
+        JP: 0x231C808
       description: |-
         Activate the Stench ability on the monster.
         
         r0: monster pointer
     - name: TryActivateSteadfast
       address:
+        EU: 0x231BDC4
         NA: 0x231B364
+        JP: 0x231C830
       description: |-
         Activate the Steadfast ability on the defender, if the monster has it and it's active.
         
@@ -4952,7 +5222,9 @@ overlay29:
         others: ?
     - name: ApplyCheriBerryEffect
       address:
+        EU: 0x231D654
         NA: 0x231CBEC
+        JP: 0x231E0B8
       description: |-
         Tries to heal the paralysis status condition. Prints a message on failure.
         
@@ -4960,7 +5232,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyPechaBerryEffect
       address:
+        EU: 0x231D680
         NA: 0x231CC18
+        JP: 0x231E0E4
       description: |-
         Tries to heal the poisoned and badly poisoned status condition. Prints a message on
         failure.
@@ -4969,7 +5243,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyRawstBerryEffect
       address:
+        EU: 0x231D6B4
         NA: 0x231CC4C
+        JP: 0x231E118
       description: |-
         Tries to heal the burn status condition. Prints a message on failure.
         
@@ -4977,7 +5253,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyHungerSeedEffect
       address:
+        EU: 0x231D6FC
         NA: 0x231CC94
+        JP: 0x231E160
       description: |-
         Empties the targets belly to cause Hungry Pal status in non-leader monsters and
         Famished in the leader monster.
@@ -4986,7 +5264,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyVileSeedEffect
       address:
+        EU: 0x231D7E8
         NA: 0x231CD80
+        JP: 0x231E24C
       description: |-
         Reduces the targets defense and special defense stages to the lowest level.
         
@@ -5003,7 +5283,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyGinsengEffect
       address:
+        EU: 0x231D8D0
         NA: 0x231CE68
+        JP: 0x231E32C
       description: |-
         Boosts the power of the move at the top of the target's Move List. Appears to have a
         leftover check to boost the power of a move by 3 instead of 1 that always fails because
@@ -5013,7 +5295,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyBlastSeedEffect
       address:
+        EU: 0x231D9EC
         NA: 0x231CF84
+        JP: 0x231E44C
       description: |-
         If thrown, unfreeze and deal fixed damage to the defender. If not thrown, try to find 
         a monster in front of the attacker. If a monster is found unfreeze and dedal fixed 
@@ -5039,6 +5323,7 @@ overlay29:
       address:
         EU: 0x231DF0C
         NA: 0x231D4A4
+        JP: 0x231E96C
       description: |-
         Checks whether a monster can use a certain item.
         
@@ -5050,7 +5335,9 @@ overlay29:
         return: True if the monster can use the item, false otherwise
     - name: ApplyGrimyFoodEffect
       address:
+        EU: 0x231DF9C
         NA: 0x231D534
+        JP: 0x231E9FC
       description: |-
         Randomly inflicts poison, shadow hold, burn, paralysis, or an offensive stat debuff
         to the target. If the survivalist iq skill or gluttony ability is active, the target
@@ -5060,7 +5347,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyMixElixirEffect
       address:
+        EU: 0x231E0E8
         NA: 0x231D680
+        JP: 0x231EB48
       description: |-
         If the target monster is a Linoone, restores all the PP of all the target's moves.
         
@@ -5068,7 +5357,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyDoughSeedEffect
       address:
+        EU: 0x231E148
         NA: 0x231D6E0
+        JP: 0x231EBA8
       description: |-
         If the target monster is a team member, set dough_seed_extra_poke_flag to true to 
         make extra poke spawn on the next floor. Otherwise, do nothing.
@@ -5077,7 +5368,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyViaSeedEffect
       address:
+        EU: 0x231E1B4
         NA: 0x231D74C
+        JP: 0x231EC14
       description: |-
         Tries to randomly teleport the target with a message for eating the seed.
         
@@ -5085,7 +5378,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyGravelyrockEffect
       address:
+        EU: 0x231E228
         NA: 0x231D7C0
+        JP: 0x231EC88
       description: |-
         Restores 10 hunger to the target and will raise the target's IQ if they are a bonsly
         or sudowoodo.
@@ -5094,7 +5389,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyGonePebbleEffect
       address:
+        EU: 0x231E2A0
         NA: 0x231D838
+        JP: 0x231ED00
       description: |-
         Causes a few visual effects, temporarily changes the dungeon music to the Goodnight
         track, and gives the target the enduring status.
@@ -5103,7 +5400,9 @@ overlay29:
         r1: target entity pointer
     - name: ApplyGracideaEffect
       address:
+        EU: 0x231E428
         NA: 0x231D9C0
+        JP: 0x231EE7C
       description: |-
         If the target is Shaymin, attempt to change the target's form to Shaymin Sky Forme. Otherwise, do nothing.
         
@@ -5113,6 +5412,7 @@ overlay29:
       address:
         EU: 0x231F3F8
         NA: 0x231E990
+        JP: 0x231FE3C
       description: |-
         Checks if a given item should be eaten by the TryEatItem effect.
         
@@ -5154,6 +5454,7 @@ overlay29:
       address:
         EU: 0x231FFFC
         NA: 0x231F594
+        JP: 0x2320A40
       description: |-
         Attempts to drain all water from the current floor.
         
@@ -5230,13 +5531,16 @@ overlay29:
       address:
         EU: 0x2321B6C
         NA: 0x2321104
+        JP: 0x23225B0
       description: |-
         Checks that the given monster is standing on a tile it can stand on given its movement type, and warps it to a random location if it's not.
         
         r0: Entity pointer
     - name: TryActivateNondamagingDefenderAbility
       address:
+        EU: 0x23224E0
         NA: 0x2321A78
+        JP: 0x2322F24
       description: |-
         Applies the effects of a defender's ability on an attacker. After a move is used,
         this function is called to see if any of the bitflags for an ability were set and
@@ -5246,7 +5550,9 @@ overlay29:
         r0: entity pointer
     - name: TryActivateNondamagingDefenderExclusiveItem
       address:
+        EU: 0x2322758
         NA: 0x2321CF0
+        JP: 0x232319C
       description: |-
         Applies the effects of a defender's item on an attacker. After a move is used,
         this function is called to see if any of the bitflags for an item were set and
@@ -5258,6 +5564,7 @@ overlay29:
       address:
         EU: 0x2322D0C
         NA: 0x23222A4
+        JP: 0x2323750
       description: |-
         Returns the maximum reach distance of a move, based on its AI range value.
         
@@ -5298,6 +5605,7 @@ overlay29:
       address:
         EU: 0x232500C
         NA: 0x23245A4
+        JP: 0x2325A34
       description: |-
         Checks if a monster is currently charging the specified two-turn move.
         
@@ -5411,7 +5719,9 @@ overlay29:
         return: (short) x
     - name: PlayMoveAnimation
       address:
+        EU: 0x232611C
         NA: 0x23256B4
+        JP: 0x2326B40
       description: |-
         Handles the process of getting and playing all the animations for a move. Waits
         until the animation has no more frames before returning.
@@ -5589,6 +5899,7 @@ overlay29:
       address:
         EU: 0x2335F04
         NA: 0x23354C4
+        JP: 0x23368B0
       description: |-
         Tries to change the weather based upon the information for each weather type in the
         dungeon struct. Returns whether the weather was succesfully changed or not.
@@ -5696,7 +6007,9 @@ overlay29:
         return: True if the current dungeon tileset is a background, false if it's a regular tileset.
     - name: TrySpawnGoldenChamber
       address:
+        EU: 0x2336DF4
         NA: 0x2336224
+        JP: 0x23375F4
       description: |-
         Changes the tileset and fixed room id of the floor for the Golden Chamber if the floor should be a
         Golden Chamber.
@@ -5704,7 +6017,9 @@ overlay29:
         No params.
     - name: CountItemsOnFloorForAcuteSniffer
       address:
+        EU: 0x2336E30
         NA: 0x2336260
+        JP: 0x2337630
       description: |-
         Counts the number of items on the floor by checking every tile for an item and stores it into
         dungeon::item_sniffer_item_count
@@ -5712,6 +6027,7 @@ overlay29:
         No params.
     - name: GetStairsSpawnPosition
       address:
+        EU: 0x2336F90
         NA: 0x23363C0
       description: |-
         Gets the spawn position for the stairs and stores it at the passed pointers.
@@ -5720,7 +6036,9 @@ overlay29:
         r1: [output] pointer to y coordinate
     - name: PositionIsOnStairs
       address:
+        EU: 0x2336FBC
         NA: 0x23363EC
+        JP: 0x23377BC
       description: |-
         Checks if this location is on top of the staircase. In the game it is only used to check if an outlaw has reached
         the staircase.
@@ -5746,14 +6064,18 @@ overlay29:
         return: texture_id
     - name: DetermineAllTilesWalkableNeighbors
       address:
+        EU: 0x233761C
         NA: 0x2336A4C
+        JP: 0x2337E14
       description: |-
         Evaluates the walkable_neighbor_flags for all tiles.
         
         No params.
     - name: DetermineTileWalkableNeighbors
       address:
+        EU: 0x2337654
         NA: 0x2336A84
+        JP: 0x2337E4C
       description: |-
         Evaluates the walkable_neighbor_flags for the this tile by checking the 8 adjacent tiles.
         
@@ -5763,6 +6085,7 @@ overlay29:
       address:
         EU: 0x2337B1C
         NA: 0x2336F4C
+        JP: 0x2338314
       description: |-
         Exact purpose unknown. Gets called whenever a trap tile is shown or hidden.
         
@@ -5771,6 +6094,7 @@ overlay29:
       address:
         EU: 0x2337FF8
         NA: 0x2337428
+        JP: 0x23387F0
       description: |-
         Draws a grid on the nearby walkable tiles. Triggered by pressing Y.
         
@@ -5782,6 +6106,7 @@ overlay29:
       address:
         EU: 0x233836C
         NA: 0x233779C
+        JP: 0x2338B60
       description: |-
         Hides the grid on the nearby walkable tiles. Triggered by releasing Y.
         
@@ -5790,6 +6115,7 @@ overlay29:
       address:
         EU: 0x233860C
         NA: 0x2337A3C
+        JP: 0x2338E00
       description: |-
         Discovers the tiles around the specified position on the minimap.
         
@@ -5798,7 +6124,9 @@ overlay29:
         r0: Position around which the map should be discovered
     - name: PositionHasItem
       address:
+        EU: 0x23386FC
         NA: 0x2337B2C
+        JP: 0x2338EF0
       description: |-
         Checks if the tile at the position has an item on it.
         
@@ -5806,7 +6134,9 @@ overlay29:
         return: bool
     - name: PositionHasMonster
       address:
+        EU: 0x2338738
         NA: 0x2337B68
+        JP: 0x2338F2C
       description: |-
         Checks if the tile at the position has a monster on it.
         
@@ -5814,7 +6144,9 @@ overlay29:
         return: bool
     - name: TrySmashWall
       address:
+        EU: 0x233876C
         NA: 0x2337B9C
+        JP: 0x2338F60
       description: |-
         Checks if the tile at the position is a wall. If so, smash it (turn it into a floor tile), play an animation
         
@@ -5892,6 +6224,7 @@ overlay29:
         No params.
     - name: SetDoughSeedFlag
       address:
+        EU: 0x2339118
         NA: 0x2338548
       description: |-
         Sets the dough_seed_extra_money_flag field on the dungeon struct to the given value.
@@ -5899,7 +6232,9 @@ overlay29:
         r0: bool to set the flag to
     - name: TrySpawnDoughSeedPoke
       address:
+        EU: 0x2339130
         NA: 0x2338560
+        JP: 0x2339924
       description: |-
         Checks the dough_seed_extra_money_flag field on the dungeon struct and tries to spawn
         extra poke if it is set.
@@ -5959,6 +6294,7 @@ overlay29:
       address:
         EU: 0x23392A8
         NA: 0x23386D8
+        JP: 0x2339A9C
       description: |-
         Checks if the hidden stairs are present on this floor.
         
@@ -5969,6 +6305,7 @@ overlay29:
       address:
         EU: 0x2339364
         NA: 0x2338794
+        JP: 0x2339B58
       description: |-
         Called whenever the leader steps on the hidden stairs.
         
@@ -5992,6 +6329,7 @@ overlay29:
       address:
         EU: 0x2339DBC
         NA: 0x23391EC
+        JP: 0x233A5B0
       description: |-
         Draws a single tile on the minimap.
         
@@ -6001,6 +6339,7 @@ overlay29:
       address:
         EU: 0x233A8B8
         NA: 0x2339CE8
+        JP: 0x233B0AC
       description: |-
         Graphically updates the minimap
         
@@ -6034,6 +6373,7 @@ overlay29:
       address:
         EU: 0x233AE74
         NA: 0x233A290
+        JP: 0x233B654
       description: |-
         Initializes the matrix at minimap_display_data+0xE000. Seems to overflow said matrix when doing so.
         
@@ -6042,6 +6382,7 @@ overlay29:
       address:
         EU: 0x233AED4
         NA: 0x233A2F0
+        JP: 0x233B6B4
       description: |-
         Used to initialize an instance of struct minimap_display_tile
         
@@ -6707,6 +7048,7 @@ overlay29:
       address:
         EU: 0x23430B4
         NA: 0x23424D0
+        JP: 0x2343890
       description: |-
         Returns the next action that needs to be performed when spawning a fixed room tile.
         
@@ -6769,7 +7111,9 @@ overlay29:
         return: enum hidden_stairs_type
     - name: GetFinalKecleonShopSpawnChance
       address:
+        EU: 0x2343AA0
         NA: 0x2342EBC
+        JP: 0x2344280
       description: |-
         Gets the kecleon shop spawn chance for the floor.
         
@@ -6790,6 +7134,7 @@ overlay29:
       address:
         EU: 0x2343B14
         NA: 0x2342F30
+        JP: 0x23442F4
       description: |-
         Used to spawn a single tile when generating a fixed room. The tile might contain an item or a monster.
         
@@ -6801,6 +7146,7 @@ overlay29:
       address:
         EU: 0x2344550
         NA: 0x234396C
+        JP: 0x2344D30
       description: |-
         Converts the parameter stored in a fixed room action value to a direction ID.
         
@@ -6812,6 +7158,7 @@ overlay29:
       address:
         EU: 0x23448BC
         NA: 0x2343CD8
+        JP: 0x234509C
       description: |-
         Attempts to open a locked door in front of the target if a locked door has not already
         been open on the floor.
@@ -7033,6 +7380,7 @@ overlay29:
       address:
         EU: 0x23462A8
         NA: 0x23456BC
+        JP: 0x2346A80
       description: |-
         Removes an item lying on the ground.
         
@@ -7117,6 +7465,7 @@ overlay29:
       address:
         EU: 0x2347B10
         NA: 0x2346F14
+        JP: 0x23482D4
       description: |-
         Adds the monster's held item to the bag. This is only called on monsters on the exploration team.
         monster::is_not_team_member should be checked to be false before calling.
@@ -7126,6 +7475,7 @@ overlay29:
       address:
         EU: 0x2347C2C
         NA: 0x2347030
+        JP: 0x23483F0
       description: |-
         Calls RemoveEmptyItemsInBag, then some other function that seems to update the minimap, the map surveyor flag, and other stuff.
         
@@ -7558,6 +7908,8 @@ overlay29:
     - name: InitPortraitDungeon
       address:
         EU: 0x234C6C0
+        NA: 0x234BAC0
+        JP: 0x234CD24
       description: |-
         Initialize the portrait box structure for the given monster and expression
         

--- a/symbols/overlay30.yml
+++ b/symbols/overlay30.yml
@@ -17,6 +17,7 @@ overlay30:
       address:
         EU: 0x2383868
         NA: 0x2382C6C
+        JP: 0x2383EDC
       description: |-
         Function responsible for writing dungeon data when quicksaving.
         

--- a/tools/symbols_vfill.py
+++ b/tools/symbols_vfill.py
@@ -142,9 +142,9 @@ class FillCounter:
     """Counters for printed summary statistics"""
 
     def __init__(self, filled: int = 0, unfilled: int = 0, skipped: int = 0):
-        self.filled = 0
-        self.unfilled = 0
-        self.skipped = 0
+        self.filled = filled
+        self.unfilled = unfilled
+        self.skipped = skipped
 
     def __iadd__(self, other: "FillCounter") -> "FillCounter":
         self.filled += other.filled

--- a/tools/symbols_vfill.py
+++ b/tools/symbols_vfill.py
@@ -32,6 +32,8 @@ binary files. It uses the following strategies to this end:
     - Imposing a minimum instruction count on matches based on adaptive symbol
       length inference. By default, the inferred length will always be at least
       the length of 4 instructions.
+    - By default (can be disabled), discarding inferred addresses that are out
+      of order relative to existing addresses of neighboring functions.
 
 Note that this program has a "fast mode", which can be enabled with the --fast
 flag. The only thing this changes is the number of times the formatter is run.
@@ -59,7 +61,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
-from typing import Dict, Generator, Iterable, List, Optional, Union
+from typing import Dict, Generator, Iterable, List, NamedTuple, Optional, Union
 import yaml
 
 import arm5find
@@ -141,26 +143,97 @@ def find_binary_files(dirname: str, binaries: Iterable[str]) -> Dict[str, str]:
 class FillCounter:
     """Counters for printed summary statistics"""
 
-    def __init__(self, filled: int = 0, unfilled: int = 0, skipped: int = 0):
+    def __init__(
+        self, filled: int = 0, unfilled: int = 0, discarded: int = 0, skipped: int = 0
+    ):
         self.filled = filled
         self.unfilled = unfilled
+        self.discarded = discarded
         self.skipped = skipped
 
     def __iadd__(self, other: "FillCounter") -> "FillCounter":
         self.filled += other.filled
         self.unfilled += other.unfilled
+        self.discarded += other.discarded
         self.skipped += other.skipped
         return self
 
     def __add__(self, other: "FillCounter") -> "FillCounter":
-        s = FillCounter(self.filled, self.unfilled, self.skipped)
+        s = FillCounter(self.filled, self.unfilled, self.discarded, self.skipped)
         s += other
         return s
 
     def summary(self, indent=2):
         print(f"{' ' * indent}{self.filled} addresses filled")
         print(f"{' ' * indent}{self.unfilled} filling failures")
+        print(f"{' ' * indent}{self.discarded} filling discards")
         print(f"{' ' * indent}{self.skipped} symbols skipped")
+
+
+class AddressBounds(NamedTuple):
+    """Bounds for inferred symbol addresses."""
+
+    lower: Optional[int] = None
+    upper: Optional[int] = None
+
+    def __str__(self) -> str:
+        lower_str = f"0x{self.lower:X}" if self.lower is not None else str(None)
+        upper_str = f"0x{self.upper:X}" if self.upper is not None else str(None)
+        return f"({lower_str}, {upper_str})"
+
+
+def calc_symbol_addr_bounds(symbol_list: List[dict]) -> List[Dict[str, AddressBounds]]:
+    """Calculate bounds for inferred addresses of each symbol in the list.
+
+    Bounds are per-version, and are based on the addresses of immediate
+    neighbors of a symbol.
+
+    Args:
+        symbol_list (List[dict]): resymgen symbol list
+
+    Returns:
+        List[Dict[str, AddressBounds]]: List of per-version address bounds
+            corresponding to each symbol in the input list
+    """
+
+    bounds_list: List[Dict[str, AddressBounds]] = [{} for _ in symbol_list]
+
+    last_addr_by_vers = {}
+    # First pass, iterate forward to establish lower bounds
+    for symbol, bounds in zip(symbol_list, bounds_list):
+        for vers, addr in last_addr_by_vers.items():
+            # Use the first address if there are multiple, since that's the
+            # expected list sorting key
+            if isinstance(addr, list):
+                if not addr:
+                    continue
+                addr = addr[0]
+            bounds[vers] = AddressBounds(lower=addr)
+        last_addr_by_vers.update(symbol["address"])
+
+    # Second pass, iterate backwards to establish upper bounds. Also
+    # simultaneously perform validation; if upper < lower, it means the
+    # existing symbol list had an out-of-order jump, so force no bounds.
+    last_addr_by_vers = {}
+    for symbol, bounds in zip(reversed(symbol_list), reversed(bounds_list)):
+        for vers, addr in last_addr_by_vers.items():
+            # Use the first address if there are multiple, since that's the
+            # expected list sorting key
+            if isinstance(addr, list):
+                if not addr:
+                    continue
+                addr = addr[0]
+
+            if vers not in bounds:
+                bounds[vers] = AddressBounds(upper=addr)
+            elif bounds[vers].lower <= addr:
+                bounds[vers] = bounds[vers]._replace(upper=addr)
+            else:
+                # Out of order jump; delete the bound
+                del bounds[vers]
+        last_addr_by_vers.update(symbol["address"])
+
+    return bounds_list
 
 
 def function_fill_versions(
@@ -170,6 +243,7 @@ def function_fill_versions(
     bin_name: str,
     *,
     min_instr_count: int = 4,
+    addr_bounds: Optional[Dict[str, AddressBounds]] = None,
     verbosity: int = 0,
     dry_run: bool = False,
 ) -> FillCounter:
@@ -183,6 +257,8 @@ def function_fill_versions(
         bin_name (str): short name of the binary containing the function
         min_instr_count (int, optional): minimum instruction count for adaptive
             length search. Defaults to 4.
+        addr_bounds (Optional[Dict[str, AddressBounds]], optional): per-version
+            bounds on inferred addresses. Defaults to None.
         verbosity (int, optional): verbosity (0-4). Defaults to 0.
         dry_run (bool, optional): enable dry run mode. Defaults to False.
 
@@ -351,6 +427,22 @@ def function_fill_versions(
             match_addr = offsets.convert_offsets(dst_vers, [bin_name], [match.start()])[
                 0
             ].get_mapped()[0]
+
+            if addr_bounds is not None and dst_vers in addr_bounds:
+                # Check that the inferred address falls in the expected bounds
+                bounds = addr_bounds[dst_vers]
+                debug(f"{log_prefix}verifying against address bounds {bounds}")
+                if not (
+                    (bounds.lower is None or bounds.lower < match_addr)
+                    and (bounds.upper is None or match_addr < bounds.upper)
+                ):
+                    report(
+                        f"{log_prefix}discarding out-of-order inferred address 0x{match_addr:X}",
+                        1,
+                    )
+                    counter.discarded += 1
+                    continue
+
             report(
                 f"{log_prefix}found address 0x{match_addr:X}",
                 0 if dry_run else 2,
@@ -369,6 +461,7 @@ def symbols_fill_versions(
     binaries: Dict[str, Dict[str, str]],
     *,
     min_instr_count: int = 4,
+    respect_sort_order: bool = False,
     verbosity: int = 0,
     dry_run: bool = False,
     fast_mode: bool = False,
@@ -380,6 +473,8 @@ def symbols_fill_versions(
             name (outer key) and game version (inner key)
         min_instr_count (int, optional): minimum instruction count for adaptive
             length search. Defaults to 4.
+        respect_sort_order(bool, optional): respect the sort ordering of
+            existing symbols when filling new addresses. Defaults to False.
         verbosity (int, optional): verbosity (0-4). Defaults to 0.
         dry_run (bool, optional): enable dry run mode. Defaults to False.
         fast_mode (bool, optional): enable fast mode. Defaults to False.
@@ -407,13 +502,25 @@ def symbols_fill_versions(
                 # could pretty easily be used in multiple different contexts
                 # (which we would consider to be different symbols). So, only
                 # try to fill in function addresses.
-                for function in block["functions"]:
+                functions = block["functions"]
+
+                # If we need to respect sort order, build a list of by-version
+                # lower/upper bounds from the existing symbol addresses
+                functions_addr_bounds = None
+                if respect_sort_order:
+                    functions_addr_bounds = calc_symbol_addr_bounds(functions)
+
+                for i, function in enumerate(functions):
+                    addr_bounds = None
+                    if functions_addr_bounds is not None:
+                        addr_bounds = functions_addr_bounds[i]
                     table_counter += function_fill_versions(
                         function,
                         binary_contents,
                         file_by_version,
                         bin_name,
                         min_instr_count=min_instr_count,
+                        addr_bounds=addr_bounds,
                         verbosity=verbosity,
                         dry_run=dry_run,
                     )
@@ -456,6 +563,14 @@ if __name__ == "__main__":
         help="minimum instruction count for adaptive symbol lengths",
     )
     parser.add_argument(
+        "-S",
+        "--ignore-sort-order",
+        action="store_true",
+        default=False,
+        help="allow inferred addresses that violate the existing address"
+        + "ordering of existing symbols for the corresponding version",
+    )
+    parser.add_argument(
         "-v", "--verbose", action="count", default=0, help="verbosity level"
     )
     parser.add_argument("-n", "--dry-run", action="store_true", help="dry run")
@@ -494,6 +609,7 @@ if __name__ == "__main__":
     counters = symbols_fill_versions(
         files_by_version,
         min_instr_count=args.min_instr_count,
+        respect_sort_order=not args.ignore_sort_order,
         verbosity=args.verbose,
         dry_run=args.dry_run,
         fast_mode=args.fast,

--- a/tools/symbols_vfill.py
+++ b/tools/symbols_vfill.py
@@ -68,6 +68,8 @@ import arm5find
 import offsets
 from resymgen import resymgen
 
+REAL_BINARY_NAMES = [b for b in offsets.BINARY_NAMES if not b.endswith(".itcm")]
+
 
 class SymbolTable:
     """A symbol table from pmdsky-debug"""
@@ -79,7 +81,7 @@ class SymbolTable:
             self.path = arg
             return
         binary: str = arg
-        if binary not in offsets.BINARY_NAMES:
+        if binary not in REAL_BINARY_NAMES:
             raise ValueError(f'Invalid binary: "{binary}"')
         if binary.startswith("overlay"):
             # overlay0 -> overlay00, etc.
@@ -551,7 +553,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-b",
         "--binary",
-        choices=offsets.BINARY_NAMES,
+        choices=REAL_BINARY_NAMES,
         action="append",
         help="EoS binary",
     )
@@ -584,7 +586,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if not args.binary:
-        args.binary = offsets.BINARY_NAMES
+        args.binary = REAL_BINARY_NAMES
 
     data_dirs = {
         vers: getattr(args, f"dir_{vers.lower()}")


### PR DESCRIPTION
- Check symbol order in `symbols_vfill.py` by default to reduce false positives
- Add ITCM support to `offsets.py` and `symbols_vfill.py`
- Fill in 491 function addresses for unknown versions found by `symbols_vfill.py`
- Miscellaneous bug fixes