### PR TITLE
Various JP symbols (arm9, ram, ov00 - ov17)

### DIFF
--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -10061,9 +10061,11 @@ arm9:
       address:
         EU: 0x20AFAD4
         NA: 0x20AF234
+        JP: 0x20B0674
       length:
         EU: 0x4
         NA: 0x4
+        JP: 0x4
       description: |-
         [Runtime] The overlay group ID of the overlay currently loaded in slot 1. A group ID of 0 denotes no overlay.
         
@@ -10116,14 +10118,17 @@ arm9:
       address:
         EU: 0x20AFF70
         NA: 0x20AF6B8
+        JP: 0x20B0AF8
       description: "[Runtime]"
     - name: BAG_ITEMS_PTR_MIRROR
       address:
         EU: 0x20AFF70
         NA: 0x20AF6B8
+        JP: 0x20B0AF8
       length:
         EU: 0x4
         NA: 0x4
+        JP: 0x4
       description: |-
         [Runtime] Probably a mirror of ram.yml::BAG_ITEMS_PTR?
         
@@ -10176,6 +10181,7 @@ arm9:
       address:
         EU: 0x20B05A8
         NA: 0x20AFCE8
+        JP: 0x20B1128
       description: "[Runtime]"
     - name: TBL_TALK_GROUP_STRING_ID_START
       address:

--- a/symbols/literals.yml
+++ b/symbols/literals.yml
@@ -17,24 +17,29 @@ arm9:
       address:
         EU: 0x20118B8
         NA: 0x2011810
+        JP: 0x20117E0
       length:
         EU: 0x1
         NA: 0x1
+        JP: 0x1
       description: IQ gain when ingesting nectar at the Juice Bar.
     - name: TEXT_SPEED
       address:
         EU: 0x2020DF0
         NA: 0x2020C98
+        JP: 0x2020CE8
       description: Controls text speed.
     - name: HERO_START_LEVEL
       address:
         EU: 0x2048B9C
         NA: 0x2048880
+        JP: 0x2048BEC
       description: Starting level of the hero.
     - name: PARTNER_START_LEVEL
       address:
         EU: 0x2048C0C
         NA: 0x20488F0
+        JP: 0x2048C5C
       description: Starting level of the partner.
 overlay0:
   versions:
@@ -56,6 +61,7 @@ overlay0:
       address:
         EU: 0x22BE9B4
         NA: 0x22BE1A0
+        JP: 0x22BF948
       description: Music ID to play in the top menu.
 overlay10:
   versions:
@@ -275,6 +281,7 @@ overlay9:
       address:
         EU: 0x233E080
         NA: 0x233D900
+        JP: 0x233F120
       description: Song playing in the main menu when returning from the Sky Jukebox.
 overlay30:
   versions:

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -627,11 +627,13 @@ overlay11:
       address:
         EU: 0x23257E4
         NA: 0x2324CA4
+        JP: 0x2326204
       description: "[Runtime]"
     - name: GROUND_STATE_MAP
       address:
         EU: 0x2325800
         NA: 0x2324CC0
+        JP: 0x2326220
       description: "[Runtime]"
     - name: GROUND_STATE_WEATHER
       address:
@@ -641,9 +643,11 @@ overlay11:
       address:
         EU: 0x2325834
         NA: 0x2324CF4
+        JP: 0x2326254
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
       description: |-
         Host pointers to multiple structure used for performing an overworld scene
         

--- a/symbols/overlay14.yml
+++ b/symbols/overlay14.yml
@@ -490,9 +490,11 @@ overlay14:
       address:
         EU: 0x238E640
         NA: 0x238DAA0
+        JP: 0x238F008
       length:
         EU: 0x48
         NA: 0x48
+        JP: 0x48
     - name: SENTRY_DUTY_PTR
       address:
         NA: 0x238DB80

--- a/symbols/overlay15.yml
+++ b/symbols/overlay15.yml
@@ -18,9 +18,11 @@ overlay15:
       address:
         EU: 0x238BBC0
         NA: 0x238B054
+        JP: 0x238C5CC
       length:
         EU: 0x28
         NA: 0x28
+        JP: 0x28
     - name: BANK_D_BOX_LAYOUT_1
       address:
         NA: 0x238B07C

--- a/symbols/overlay16.yml
+++ b/symbols/overlay16.yml
@@ -18,25 +18,31 @@ overlay16:
       address:
         EU: 0x238D84C
         NA: 0x238CD08
+        JP: 0x238E288
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
       description: "Irdkwia's notes: 3*0x8"
     - name: EVO_SUBMENU
       address:
         EU: 0x238D864
         NA: 0x238CD20
+        JP: 0x238E2A0
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
       description: "Irdkwia's notes: 4*0x8"
     - name: EVO_MAIN_MENU
       address:
         EU: 0x238D884
         NA: 0x238CD40
+        JP: 0x238E2C0
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
       description: "Irdkwia's notes: 4*0x8"
     - name: EVO_MENU_STRING_IDS
       address:

--- a/symbols/overlay17.yml
+++ b/symbols/overlay17.yml
@@ -48,72 +48,92 @@ overlay17:
       address:
         EU: 0x238C6C4
         NA: 0x238BB84
+        JP: 0x238D0E0
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: ASSEMBLY_MAIN_MENU_1
       address:
         EU: 0x238C6DC
         NA: 0x238BB9C
+        JP: 0x238D0F8
       length:
         EU: 0x18
         NA: 0x18
+        JP: 0x18
     - name: ASSEMBLY_MAIN_MENU_2
       address:
         EU: 0x238C6F4
         NA: 0x238BBB4
+        JP: 0x238D110
       length:
         EU: 0x20
         NA: 0x20
+        JP: 0x20
     - name: ASSEMBLY_SUBMENU_1
       address:
         EU: 0x238C714
         NA: 0x238BBD4
+        JP: 0x238D130
       length:
         EU: 0x28
         NA: 0x28
+        JP: 0x28
     - name: ASSEMBLY_SUBMENU_2
       address:
         EU: 0x238C73C
         NA: 0x238BBFC
+        JP: 0x238D158
       length:
         EU: 0x30
         NA: 0x30
+        JP: 0x30
     - name: ASSEMBLY_SUBMENU_3
       address:
         EU: 0x238C76C
         NA: 0x238BC2C
+        JP: 0x238D188
       length:
         EU: 0x30
         NA: 0x30
+        JP: 0x30
     - name: ASSEMBLY_SUBMENU_4
       address:
         EU: 0x238C79C
         NA: 0x238BC5C
+        JP: 0x238D1B8
       length:
         EU: 0x38
         NA: 0x38
+        JP: 0x38
     - name: ASSEMBLY_SUBMENU_5
       address:
         EU: 0x238C7D4
         NA: 0x238BC94
+        JP: 0x238D1F0
       length:
         EU: 0x38
         NA: 0x38
+        JP: 0x38
     - name: ASSEMBLY_SUBMENU_6
       address:
         EU: 0x238C80C
         NA: 0x238BCCC
+        JP: 0x238D228
       length:
         EU: 0x38
         NA: 0x38
+        JP: 0x38
     - name: ASSEMBLY_SUBMENU_7
       address:
         EU: 0x238C844
         NA: 0x238BD04
+        JP: 0x238D260
       length:
         EU: 0x40
         NA: 0x40
+        JP: 0x40
     - name: OVERLAY17_FUNCTION_POINTER_TABLE
       address:
         NA: 0x238BD44

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -329,9 +329,11 @@ ram:
       address:
         EU: 0x22AB9EC
         NA: 0x22AB0AC
+        JP: 0x22AC868
       length:
         EU: 0x400
         NA: 0x400
+        JP: 0x400
       description: |-
         The table of game variable values. Its structure is determined by SCRIPT_VARS.
         
@@ -350,9 +352,11 @@ ram:
       address:
         EU: 0x22ABDEC
         NA: 0x22AB4AC
+        JP: 0x22ACC68
       length:
         EU: 0x1
         NA: 0x1
+        JP: 0x1
       description: |-
         The number of the special episode currently being played.
         


### PR DESCRIPTION
Adds various JP symbols in arm9, ram, and some overlays (ranging from 00 to 17; commit name is wrong, oops). Related to https://github.com/SkyTemple/skytemple-files/issues/235.