### PR TITLE
Corrected JP symbol for FIXED_ROOM_ENTITY_SPAWN_TABLE

### DIFF
--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -8582,7 +8582,7 @@ overlay29:
       address:
         EU: 0x2350EF8
         NA: 0x23502EC
-        JP: 0x2351374
+        JP: 0x235156C
       length:
         EU: 0xC9C
         NA: 0xC9C


### PR DESCRIPTION
Updated the JP symbol for FIXED_ROOM_ENTITY_SPAWN_TABLE to its proper address. Should hopefully fix https://github.com/SkyTemple/skytemple/issues/602?