### PR TITLE
Fix LEVEL_TILEMAP_LIST having no JP block length

### DIFF
--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -602,6 +602,7 @@ overlay11:
       length:
         EU: 0x288
         NA: 0x288
+        JP: 0x288
       description: |-
         Irdkwia's notes: FIXED_FLOOR_GROUND_ASSOCIATION
         


### PR DESCRIPTION
This fixes LEVEL_TILEMAP_LIST having no block length defined for JP. Note: I didn't actually check the block length.

Closes https://github.com/SkyTemple/skytemple-files/issues/411