### PR TITLE
Synced function symbols from decomp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 /out
 __pycache__
+.vscode

--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -3,7 +3,15 @@
 
 #include "arm9/itcm.h"
 
-void EntryArm9(void);
+void SvcWaitByLoop(void);
+void SvcSoftReset(void);
+void SvcCpuSet(void);
+void _start(void);
+void MIiUncompressBackward(void);
+void do_autoload(void);
+void StartAutoloadDoneCallback(void);
+void OSiReferSymbol(void);
+void NitroMain(void);
 void InitMemAllocTable(void);
 void SetMemAllocatorParams(get_alloc_arena_fn_t get_alloc_arena,
                            get_free_arena_fn_t get_free_arena);
@@ -390,6 +398,8 @@ int PreprocessString(char* output, int output_size, const char* format,
                      struct preprocessor_flags flags, struct preprocessor_args* args);
 int PreprocessStringFromMessageId(char* output, int output_size, int message_id,
                                   struct preprocessor_flags flags, struct preprocessor_args* args);
+bool StrcmpTagVeneer(const char* s1, const char* s2);
+int StoiTagVeneer(const char* s);
 void InitPreprocessorArgs(struct preprocessor_args* args);
 char* SetStringAccuracy(char* s, int param_2);
 char* SetStringPower(char* s, int param_2);
@@ -445,6 +455,7 @@ void PrintIqSkillsMenu(enum monster_id monster_id, uint32_t* iq_skills_flags, in
                        bool is_blinded);
 bool GetNotifyNote(void);
 void SetNotifyNote(bool flag);
+void EventFlagBackupVeneer(void);
 void InitMainTeamAfterQuiz(void);
 void ScriptSpecialProcess0x3(void);
 void ScriptSpecialProcess0x4(void);

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -1,6 +1,12 @@
 #ifndef HEADERS_FUNCTIONS_OVERLAY11_H_
 #define HEADERS_FUNCTIONS_OVERLAY11_H_
 
+void FuncThatCallsCommandParsing(void);
+void ScriptCommandParsing(void);
+void SsbLoad2(void);
+void StationLoadHanger(void);
+void ScriptStationLoadTalk(void);
+void SsbLoad1(void);
 int ScriptSpecialProcessCall(undefined4* param_1, enum special_process_id id, int arg1, int arg2);
 enum monster_id GetSpecialRecruitmentSpecies(int idx);
 void PrepareMenuAcceptTeamMember(int idx);

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -3,6 +3,7 @@
 
 void FuncThatCallsCommandParsing(void);
 void ScriptCommandParsing(void);
+void LoadFileFromRomVeneer(struct iovec* iov, const char* filepath, uint32_t flags);
 void SsbLoad2(void);
 void StationLoadHanger(void);
 void ScriptStationLoadTalk(void);

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -184,6 +184,8 @@ void TryActivateConversion2(struct entity* attacker, struct entity* defender, st
 void TryActivateTruant(struct entity* entity);
 void TryPointCameraToMonster(struct entity* entity, undefined param_2, undefined param_3);
 void RestorePpAllMovesSetFlags(struct entity* entity);
+bool CheckTeamMemberIdxVeneer(int member_idx);
+bool IsMonsterIdInNormalRangeVeneer(enum monster_id monster_id);
 void BoostIQ(struct entity* entity, int iq_boost, bool suppress_logs);
 bool ShouldMonsterHeadToStairs(struct entity* entity);
 bool MewSpawnCheck(enum monster_id monster_id, bool fail_if_mew);
@@ -755,6 +757,7 @@ void GenerateItemExplicit(struct item* item, enum item_id item_id, uint16_t quan
 void GenerateAndSpawnItem(enum item_id item_id, int16_t x, int16_t y, uint16_t quantity,
                           bool sticky, bool check_in_bag);
 bool IsHiddenStairsFloor(void);
+bool IsSecretBazaarVeneer(void);
 void GenerateStandardItem(struct item* item, enum item_id item_id,
                           enum gen_item_stickiness sticky_type);
 void GenerateCleanItem(struct item* item, enum item_id item_id);

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -53,19 +53,19 @@ arm9:
     - name: MIiUncompressBackward
       address:
         NA: 0x2000970
-      description: Startup routine in crt0.
+      description: "Startup routine in the program's crt0 (https://en.wikipedia.org/wiki/Crt0)."
     - name: do_autoload
       address:
         NA: 0x2000A1C
-      description: Startup routine in crt0.
+      description: "Startup routine in the program's crt0 (https://en.wikipedia.org/wiki/Crt0)."
     - name: StartAutoloadDoneCallback
       address:
         NA: 0x2000AAC
-      description: Startup routine in crt0.
+      description: "Startup routine in the program's crt0 (https://en.wikipedia.org/wiki/Crt0)."
     - name: OSiReferSymbol
       address:
         NA: 0x2000B9C
-      description: Startup routine in crt0.
+      description: "Startup routine in the program's crt0 (https://en.wikipedia.org/wiki/Crt0)."
     - name: NitroMain
       address:
         NA: 0x2000C6C

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -29,7 +29,19 @@ arm9:
   subregions:
     - itcm.yml
   functions:
-    - name: EntryArm9
+    - name: SvcWaitByLoop
+      address:
+        NA: 0x2000088
+      description: Software interrupt.
+    - name: SvcSoftReset
+      address:
+        NA: 0x2000566
+      description: Software interrupt.
+    - name: SvcCpuSet
+      address:
+        NA: 0x200078E
+      description: Software interrupt.
+    - name: _start
       address:
         EU: 0x2000800
         NA: 0x2000800
@@ -38,6 +50,26 @@ arm9:
         The entrypoint for the ARM9 CPU. This is like the "main" function for the ARM9 subsystem.
         
         No params.
+    - name: MIiUncompressBackward
+      address:
+        NA: 0x2000970
+      description: Startup routine in crt0.
+    - name: do_autoload
+      address:
+        NA: 0x2000A1C
+      description: Startup routine in crt0.
+    - name: StartAutoloadDoneCallback
+      address:
+        NA: 0x2000AAC
+      description: Startup routine in crt0.
+    - name: OSiReferSymbol
+      address:
+        NA: 0x2000B9C
+      description: Startup routine in crt0.
+    - name: NitroMain
+      address:
+        NA: 0x2000C6C
+      description: "Entrypoint into NitroSDK, the DS devkit library."
     - name: InitMemAllocTable
       address:
         EU: 0x2000DE0
@@ -3827,6 +3859,27 @@ arm9:
         r2: message ID
         r3: preprocessor flags
         stack[0]: pointer to preprocessor args
+    - name: StrcmpTagVeneer
+      address:
+        NA: 0x20235F8
+      description: |-
+        Likely a linker-generated veneer for StrcmpTag.
+        
+        See https://developer.arm.com/documentation/dui0474/k/image-structure-and-generation/linker-generated-veneers/what-is-a-veneer-
+        
+        r0: s1
+        r1: s2
+        return: bool
+    - name: StoiTagVeneer
+      address:
+        NA: 0x2023604
+      description: |-
+        Likely a linker-generated veneer for StoiTag.
+        
+        See https://developer.arm.com/documentation/dui0474/k/image-structure-and-generation/linker-generated-veneers/what-is-a-veneer-
+        
+        r0: s
+        return: int
     - name: InitPreprocessorArgs
       address:
         EU: 0x20238B4
@@ -4377,6 +4430,15 @@ arm9:
         Sets NOTIFY_NOTE to the given value.
         
         r0: bool
+    - name: EventFlagBackupVeneer
+      address:
+        NA: 0x2048758
+      description: |-
+        Likely a linker-generated veneer for EventFlagBackup.
+        
+        See https://developer.arm.com/documentation/dui0474/k/image-structure-and-generation/linker-generated-veneers/what-is-a-veneer-
+        
+        No params.
     - name: InitMainTeamAfterQuiz
       address:
         EU: 0x2048AE0

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -26,6 +26,17 @@ overlay11:
         EU: 0x22DE6A4
         NA: 0x22DDD64
         JP: 0x22DF404
+    - name: LoadFileFromRomVeneer
+      address:
+        NA: 0x22E46DC
+      description: |-
+        Likely a linker-generated veneer for LoadFileFromRom.
+        
+        See https://developer.arm.com/documentation/dui0474/k/image-structure-and-generation/linker-generated-veneers/what-is-a-veneer-
+        
+        r0: [output] pointer to an IO struct {ptr, len}
+        r1: file path string pointer
+        r2: flags
     - name: SsbLoad2
       address:
         EU: 0x22E503C

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -1974,6 +1974,26 @@ overlay29:
         Called when a monster is revived.
         
         r0: pointer to entity whose moves will be restored
+    - name: CheckTeamMemberIdxVeneer
+      address:
+        NA: 0x22F9C34
+      description: |-
+        Likely a linker-generated veneer for CheckTeamMemberIdx.
+        
+        See https://developer.arm.com/documentation/dui0474/k/image-structure-and-generation/linker-generated-veneers/what-is-a-veneer-
+        
+        r0: member index
+        return: True if the value is equal to 0x55AA or 0x5AA5
+    - name: IsMonsterIdInNormalRangeVeneer
+      address:
+        NA: 0x22F9C68
+      description: |-
+        Likely a linker-generated veneer for IsMonsterIdInNormalRange.
+        
+        See https://developer.arm.com/documentation/dui0474/k/image-structure-and-generation/linker-generated-veneers/what-is-a-veneer-
+        
+        r0: monster ID
+        return: bool
     - name: BoostIQ
       address:
         EU: 0x22FAB50
@@ -7329,6 +7349,15 @@ overlay29:
         JP: 0x23458D0
       description: |-
         Checks if the current floor is either the Secret Bazaar or a Secret Room.
+        
+        return: bool
+    - name: IsSecretBazaarVeneer
+      address:
+        NA: 0x2344538
+      description: |-
+        Likely a linker-generated veneer for IsSecretBazaar.
+        
+        See https://developer.arm.com/documentation/dui0474/k/image-structure-and-generation/linker-generated-veneers/what-is-a-veneer-
         
         return: bool
     - name: GenerateStandardItem


### PR DESCRIPTION
- Core functions that are standard across most DS/NitroSDK games (e.g., crt0 init functions).
- Veneers auto-detected by Ghidra while setting up the decomp.