### PR TITLE
Improve dev experience around header compiler errors

### DIFF
--- a/.github/workflows/check-headers.yml
+++ b/.github/workflows/check-headers.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Compile
-        run: make -C headers headers-aligned
+        run: make -C headers headers-aligned CFLAGS='-Wno-incompatible-library-redeclaration'
   implicit-padding-check:
     runs-on: ubuntu-latest
     needs: compile
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Compile with implicit packing
-        run: make -C headers headers-packed
+        run: make -C headers headers-packed CFLAGS='-Wno-incompatible-library-redeclaration'
   compile-no-builtin:
     runs-on: ubuntu-latest
     needs: compile

--- a/headers/Makefile
+++ b/headers/Makefile
@@ -9,8 +9,8 @@ else
 $(error C compiler not found)
 endif
 
-# All the possible files that can function as a top-level header
-TOP_LEVEL_HEADERS := pmdsky.h pmdsky_na.h pmdsky_eu.h pmdsky_jp.h
+# Top-level headers that define a version explicitly
+VERSIONED_HEADERS := pmdsky_na.h pmdsky_eu.h pmdsky_jp.h
 
 # Compile headers
 # Structs constrained by ASSERT_SIZE can only compile under both natural
@@ -22,26 +22,30 @@ headers: headers-aligned headers-packed headers-no-builtin
 .PHONY: headers-aligned
 headers-aligned:
 # -mno-ms-bitfields is needed for some Windows builds, e.g., MinGW's gcc/clang
-	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields $(TOP_LEVEL_HEADERS)
+	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields pmdsky.h
+	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields $(VERSIONED_HEADERS)
 
 # Compile headers with implicit packing by default
 .PHONY: headers-packed
 headers-packed:
 # -mno-ms-bitfields is needed for some Windows builds, e.g., MinGW's gcc/clang
-	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -Wno-pragma-pack -DIMPLICIT_STRUCT_PACKING $(TOP_LEVEL_HEADERS)
+	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DIMPLICIT_STRUCT_PACKING pmdsky.h
+	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DIMPLICIT_STRUCT_PACKING -Wno-pragma-pack $(VERSIONED_HEADERS)
 
 # Variant of the headers that excludes declarations for common builtin functions. This mode is
 # intended for dev use, if the builtin declarations cause unexpected compilation issues.
 .PHONY: headers-no-builtin
 headers-no-builtin:
-	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DPMDSKY_NO_BUILTIN $(TOP_LEVEL_HEADERS)
+	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DPMDSKY_NO_BUILTIN pmdsky.h
+	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DPMDSKY_NO_BUILTIN $(VERSIONED_HEADERS)
 
 # Unsized variant of the headers. This isn't included in the default target because it assumes
 # the presence of system headers. Don't use any funky options here, since this mode is intended
 # for normal dev use.
 .PHONY: headers-unsized
 headers-unsized:
-	$(CC) -fsyntax-only -DPMDSKY_UNSIZED_HEADERS $(TOP_LEVEL_HEADERS)
+	$(CC) -fsyntax-only -DPMDSKY_UNSIZED_HEADERS pmdsky.h
+	$(CC) -fsyntax-only -DPMDSKY_UNSIZED_HEADERS $(VERSIONED_HEADERS)
 
 .PHONY: format
 format:

--- a/headers/Makefile
+++ b/headers/Makefile
@@ -22,30 +22,30 @@ headers: headers-aligned headers-packed headers-no-builtin
 .PHONY: headers-aligned
 headers-aligned:
 # -mno-ms-bitfields is needed for some Windows builds, e.g., MinGW's gcc/clang
-	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields pmdsky.h
-	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields $(VERSIONED_HEADERS)
+	$(CC) $(CFLAGS) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields pmdsky.h
+	$(CC) $(CFLAGS) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields $(VERSIONED_HEADERS)
 
 # Compile headers with implicit packing by default
 .PHONY: headers-packed
 headers-packed:
 # -mno-ms-bitfields is needed for some Windows builds, e.g., MinGW's gcc/clang
-	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DIMPLICIT_STRUCT_PACKING pmdsky.h
-	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DIMPLICIT_STRUCT_PACKING -Wno-pragma-pack $(VERSIONED_HEADERS)
+	$(CC) $(CFLAGS) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DIMPLICIT_STRUCT_PACKING pmdsky.h
+	$(CC) $(CFLAGS) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DIMPLICIT_STRUCT_PACKING -Wno-pragma-pack $(VERSIONED_HEADERS)
 
 # Variant of the headers that excludes declarations for common builtin functions. This mode is
 # intended for dev use, if the builtin declarations cause unexpected compilation issues.
 .PHONY: headers-no-builtin
 headers-no-builtin:
-	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DPMDSKY_NO_BUILTIN pmdsky.h
-	$(CC) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DPMDSKY_NO_BUILTIN $(VERSIONED_HEADERS)
+	$(CC) $(CFLAGS) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DPMDSKY_NO_BUILTIN pmdsky.h
+	$(CC) $(CFLAGS) -m32 -fshort-wchar -fsyntax-only -mno-ms-bitfields -DPMDSKY_NO_BUILTIN $(VERSIONED_HEADERS)
 
 # Unsized variant of the headers. This isn't included in the default target because it assumes
 # the presence of system headers. Don't use any funky options here, since this mode is intended
 # for normal dev use.
 .PHONY: headers-unsized
 headers-unsized:
-	$(CC) -fsyntax-only -DPMDSKY_UNSIZED_HEADERS pmdsky.h
-	$(CC) -fsyntax-only -DPMDSKY_UNSIZED_HEADERS $(VERSIONED_HEADERS)
+	$(CC) $(CFLAGS) -fsyntax-only -DPMDSKY_UNSIZED_HEADERS pmdsky.h
+	$(CC) $(CFLAGS) -fsyntax-only -DPMDSKY_UNSIZED_HEADERS $(VERSIONED_HEADERS)
 
 .PHONY: format
 format:


### PR DESCRIPTION
Since introducing versioned headers, the header make targets were compiling the base pmdsky.h at the same time as the versioned variants. This means that if a version-agnostic error is introduced, building a make target would essentially print the same error 4 times, one for each header variant. This is annoying, especially since the vast majority of errors aren't going to be version-specific.

Now, compile the base pmdsky.h first, and only move onto the versioned headers if pmdsky.h is valid. This way, most errors will only be printed once.

Also suppress -Wincompatible-library-redeclaration in the automated workflows (caused by redefined builtins); these are unnecessarily noisy and aren't useful.