### PR TITLE
Correct CART_REMOVED_IMG_DATA NA size

### DIFF
--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -8801,7 +8801,7 @@ arm9:
         JP: 0x2092DD0
       length:
         EU: 0x2000
-        NA: 0x4000
+        NA: 0x2000
         JP: 0x2000
     - name: STRING_DEBUG_EMPTY
       address:


### PR DESCRIPTION
Double-checked `CART_REMOVED_IMG_DATA`'s size in the NA ROM; it should be the same size as its EU and JP counterparts.