### PR TITLE
Some arm7 interrupt documentation

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -27,6 +27,7 @@ other parts of the project, feel free to add yourself to this file!
 - Jawshoeuh
 - Adex
 - Laioxy
+- Adakite
 - The rest of the contributors to Project Pokémon's technical documentation
   for the NDS Mystery Dungeon games, which can be found here:
   https://projectpokemon.org/home/docs/mystery-dungeon-nds/

--- a/headers/functions/arm7.h
+++ b/headers/functions/arm7.h
@@ -2,5 +2,10 @@
 #define HEADERS_FUNCTIONS_ARM7_H_
 
 void EntryArm7(void);
+int ClearIrqFlag(void);
+int EnableIrqFlag(void);
+int SetIrqFlag(int new_value);
+int EnableIrqFiqFlags(void);
+int SetIrqFiqFlags(int new_value);
 
 #endif

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -27,4 +27,51 @@ arm7:
         The entrypoint for the ARM7 CPU. This is like the "main" function for the ARM7 subsystem.
         
         No params.
+    - name: ClearIrqFlag
+      address:
+        EU: 0x2385ED4
+        NA: 0x2385ED4
+        JP: 0x2385ED4
+      description: |-
+        Enables processor interrupts by clearing the i flag in the program status register (cpsr).
+        
+        return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were already enabled)
+    - name: EnableIrqFlag
+      address:
+        EU: 0x2385EE8
+        NA: 0x2385EE8
+        JP: 0x2385EE8
+      description: |-
+        Disables processor interrupts by setting the i flag in the program status register (cpsr).
+        
+        return: Old value of cpsr & 0x80 (0x80 if interrupts were already disabled, 0x0 if they were enabled)
+    - name: SetIrqFlag
+      address:
+        EU: 0x2385EFC
+        NA: 0x2385EFC
+        JP: 0x2385EFC
+      description: |-
+        Sets the value of the processor's interrupt flag according to the specified parameter.
+        
+        r0: Value to set the flag to (0x80 to set it, which disables interrupts; 0x0 to unset it, which enables interrupts)
+        return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were enabled)
+    - name: EnableIrqFiqFlags
+      address:
+        EU: 0x2385F14
+        NA: 0x2385F14
+        JP: 0x2385F14
+      description: |-
+        Disables processor all interrupts (both standard and fast) by setting the i and f flags in the program status register (cpsr).
+        
+        return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
+    - name: SetIrqFiqFlags
+      address:
+        EU: 0x2385F28
+        NA: 0x2385F28
+        JP: 0x2385F28
+      description: |-
+        Sets the value of the processor's interrupt flags (i and f) according to the specified parameter.
+        
+        r0: Value to set the flags to (0xC0 to set both flags, 0x80 to set the i flag and clear the f flag, 0x40 to set the f flag and clear the i flag and 0x0 to clear both flags)
+        return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
   data: []


### PR DESCRIPTION
I was working on some arm7 reversing and found some mirrored code between arm9 and arm7 where `EnableIrqFlag` and `SetIrqFlag` were being used, and from there I was able to find a few more arm9 interrupt functions in the arm7 as well. Interestingly although all of these ones are identical, the last interrupt function `GetIrqFlag` is not, and it does an `and` with a different mask, so I didn't include it here.

Also a note for all future arm7 documentation: I did a checksum on the `arm7.bin` of all three editions of EoS and they are all identical (`SHA256 CB2A9B26D77A6E7D0ADD85C27E3642105918695D040D02F70D5EBC1D52C9495B`), and since they are also all loaded at `0x2380000`, addresses for all editions will be identical if the function is in the binary. There do appear to be some functions that seem to be written in during runtime though, so this might not apply for those ones.