### PR TITLE
Info dump 56-57/66: Overlay loading and scripting

### DIFF
--- a/headers/data/overlay11.h
+++ b/headers/data/overlay11.h
@@ -14,6 +14,7 @@ extern struct dungeon_id_16 RECRUITMENT_TABLE_LOCATIONS[22];
 extern int16_t RECRUITMENT_TABLE_LEVELS[22];
 extern struct monster_id_16 RECRUITMENT_TABLE_SPECIES[22];
 extern struct level_tilemap_list_entry LEVEL_TILEMAP_LIST[81];
+extern struct animation_data SETANIMATION_TABLE[84];
 extern struct overlay_load_entry OVERLAY11_OVERLAY_LOAD_TABLE[21];
 extern struct main_ground_data GROUND_STATE_PTRS;
 extern uint32_t WORLD_MAP_MODE;

--- a/headers/data/ram.h
+++ b/headers/data/ram.h
@@ -50,6 +50,7 @@ extern struct vram_banks_set ENABLED_VRAM_BANKS;
 extern uint32_t FRAMES_SINCE_LAUNCH_TIMES_THREE;
 extern struct mem_arena* GROUND_MEMORY_ARENA_1_PTR;
 extern struct mem_arena* GROUND_MEMORY_ARENA_2_PTR;
+extern bool LOCK_NOTIFY_ARRAY[20];
 extern struct mem_arena GROUND_MEMORY_ARENA_1;
 extern struct mem_block GROUND_MEMORY_ARENA_1_BLOCKS[52];
 extern uint8_t GROUND_MEMORY_ARENA_1_MEMORY[408324];

--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -815,7 +815,7 @@ bool IsMonsterIdInNormalRange(enum monster_id monster_id);
 void SetActiveTeam(enum team_id team_id);
 struct team_member* GetActiveTeamMember(int roster_idx);
 int GetActiveRosterIndex(int member_idx);
-int TryAddRosterMonsterToTeam(int roster_idx);
+int TryAddMonsterToActiveTeam(int member_idx);
 void RemoveActiveMembersFromMainTeam(void);
 void SetTeamSetupHeroAndPartnerOnly(void);
 void SetTeamSetupHeroOnly(void);

--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -815,6 +815,8 @@ bool IsMonsterIdInNormalRange(enum monster_id monster_id);
 void SetActiveTeam(enum team_id team_id);
 struct team_member* GetActiveTeamMember(int roster_idx);
 int GetActiveRosterIndex(int member_idx);
+int TryAddRosterMonsterToTeam(int roster_idx);
+void RemoveActiveMembersFromMainTeam(void);
 void SetTeamSetupHeroAndPartnerOnly(void);
 void SetTeamSetupHeroOnly(void);
 int GetPartyMembers(uint16_t* party_members);
@@ -914,6 +916,9 @@ void MemsetFast(void* ptr, char val, uint32_t len);
 void MemcpyFast(void* src, void* dest, uint32_t n);
 uint32_t AtomicExchange(uint32_t desired, void* ptr);
 void FileInit(struct file_stream* file);
+bool GetOverlayInfo(struct overlay_info_entry* overlay_info, undefined param_2, int overlay_id);
+bool LoadOverlayInternal(struct overlay_info_entry* overlay_info);
+void InitOverlay(struct overlay_info_entry* overlay_info);
 
 // If declaring these builtins causes issues, you can disable them
 #ifndef PMDSKY_NO_BUILTIN

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -4,8 +4,8 @@
 void UnlockScriptingLock(int lock_id);
 void FuncThatCallsRunNextOpcode(undefined* script_engine_state);
 void RunNextOpcode(undefined* script_engine_state);
-void LoadFileFromRomVeneer(struct iovec* iov, const char* filepath, uint32_t flags);
 void CheckUnlocks(void);
+void LoadFileFromRomVeneer(struct iovec* iov, const char* filepath, uint32_t flags);
 void SsbLoad2(void);
 uint16_t ProcessScriptParam(uint16_t parameter);
 void StationLoadHanger(void);

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -4,7 +4,7 @@
 void UnlockScriptingLock(int lock_id);
 void FuncThatCallsRunNextOpcode(undefined* script_engine_state);
 void RunNextOpcode(undefined* script_engine_state);
-void CheckUnlocks(void);
+void HandleUnlocks(void);
 void LoadFileFromRomVeneer(struct iovec* iov, const char* filepath, uint32_t flags);
 void SsbLoad2(void);
 uint16_t ProcessScriptParam(uint16_t parameter);
@@ -12,7 +12,7 @@ void StationLoadHanger(void);
 void ScriptStationLoadTalk(void);
 void SsbLoad1(void);
 int ScriptSpecialProcessCall(undefined4* param_1, enum special_process_id id, int arg1, int arg2);
-bool GetCoroutineInfo(struct coroutine_info* coroutine_info, int coroutine_id);
+bool GetCoroutineInfo(struct coroutine_info* coroutine_info, enum coroutine_id);
 enum monster_id GetSpecialRecruitmentSpecies(int idx);
 void PrepareMenuAcceptTeamMember(int idx);
 void InitRandomNpcJobs(int job_type, undefined2 param_2);

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -12,7 +12,7 @@ void StationLoadHanger(void);
 void ScriptStationLoadTalk(void);
 void SsbLoad1(void);
 int ScriptSpecialProcessCall(undefined4* param_1, enum special_process_id id, int arg1, int arg2);
-bool GetCoroutineInfo(struct coroutine_info* coroutine_info, enum coroutine_id);
+bool GetCoroutineInfo(struct coroutine_info* coroutine_info, enum common_routine_id coroutine_id);
 enum monster_id GetSpecialRecruitmentSpecies(int idx);
 void PrepareMenuAcceptTeamMember(int idx);
 void InitRandomNpcJobs(int job_type, undefined2 param_2);

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -1,14 +1,18 @@
 #ifndef HEADERS_FUNCTIONS_OVERLAY11_H_
 #define HEADERS_FUNCTIONS_OVERLAY11_H_
 
-void FuncThatCallsCommandParsing(void);
-void ScriptCommandParsing(void);
+void UnlockScriptingLock(int lock_id);
+void FuncThatCallsRunNextOpcode(undefined* script_engine_state);
+void RunNextOpcode(undefined* script_engine_state);
 void LoadFileFromRomVeneer(struct iovec* iov, const char* filepath, uint32_t flags);
+void CheckUnlocks(void);
 void SsbLoad2(void);
+uint16_t ProcessScriptParam(uint16_t parameter);
 void StationLoadHanger(void);
 void ScriptStationLoadTalk(void);
 void SsbLoad1(void);
 int ScriptSpecialProcessCall(undefined4* param_1, enum special_process_id id, int arg1, int arg2);
+bool GetCoroutineInfo(struct coroutine_info* coroutine_info, int coroutine_id);
 enum monster_id GetSpecialRecruitmentSpecies(int idx);
 void PrepareMenuAcceptTeamMember(int idx);
 void InitRandomNpcJobs(int job_type, undefined2 param_2);
@@ -33,12 +37,14 @@ void SetAnimDataFields(struct animation* anim, uint16_t param_2);
 void SetAnimDataFieldsWrapper(struct animation* anim, uint32_t param_2);
 void InitAnimDataFromOtherAnimData(struct animation* dst, struct animation* src);
 void SetAnimDataFields2(struct animation* anim, uint32_t flags, uint32_t param_3);
+struct animation_data GetIdleAnimationType(enum monster_id, undefined* param_2);
 void LoadObjectAnimData(struct animation* anim, int16_t object_id, uint32_t flags);
 void InitAnimDataFromOtherAnimDataVeneer(struct animation* dst, struct animation* src);
 void AnimRelatedFunction(struct animation* anim, undefined4 param_2, undefined4 param_3);
 void AllocAndInitPartnerFollowDataAndLiveActorList(void);
 void InitPartnerFollowDataAndLiveActorList(void);
 void DeleteLiveActor(int16_t actor_id);
+void ChangeActorAnimation(undefined param_1, uint16_t setanimation_param);
 void InitPartnerFollowData(void);
 void GetDirectionLiveActor(struct live_actor* actor, struct direction_id_8* target);
 void SetDirectionLiveActor(struct live_actor* actor, struct direction_id_8 direction);

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -133,7 +133,7 @@ struct overlay_info_entry {
     int overlay_id;                // 0x0
     int ram_address;               // 0x4
     int size;                      // 0x8
-    int bss_size;                  // 0xC: "Size of BSS data region"
+    int bss_size;                  // 0xC: Size of BSS data region
     int static_init_start_address; // 0x10
     int static_init_end_address;   // 0x14
     int file_id;                   // 0x18: File ID of this overlay in the ROM's FAT

--- a/headers/types/common/common.h
+++ b/headers/types/common/common.h
@@ -128,6 +128,19 @@ struct overlay_load_entry {
 };
 ASSERT_SIZE(struct overlay_load_entry, 16);
 
+// Struct containing information about an overlay. The entries are copied from y9.bin.
+struct overlay_info_entry {
+    int overlay_id;                // 0x0
+    int ram_address;               // 0x4
+    int size;                      // 0x8
+    int bss_size;                  // 0xC: "Size of BSS data region"
+    int static_init_start_address; // 0x10
+    int static_init_end_address;   // 0x14
+    int file_id;                   // 0x18: File ID of this overlay in the ROM's FAT
+    int unused;                    // 0x1C: Always zero
+};
+ASSERT_SIZE(struct overlay_info_entry, 32);
+
 // This seems to be a simple structure used with utility functions related to managing items
 // in bulk, such as in the player's bag, storage, and Kecleon shops.
 struct bulk_item {

--- a/headers/types/ground_mode/enums.h
+++ b/headers/types/ground_mode/enums.h
@@ -2091,6 +2091,13 @@ enum rank {
     RANK_GUILDMASTER = 12,
 };
 
+enum animation_speed {
+    ANIMATION_SPEED_NORMAL = 0,
+    ANIMATION_SPEED_SLOW = 1,
+    ANIMATION_SPEED_FAST = 2,
+    ANIMATION_SPEED_FREEZE = 3,
+};
+
 // These are super long, so split them out into a separate file
 #include "version_dep_enums.h"
 

--- a/headers/types/ground_mode/ground_mode.h
+++ b/headers/types/ground_mode/ground_mode.h
@@ -5,36 +5,6 @@
 
 #include "enums.h"
 
-// Scripting coroutine located in unionall
-struct script_coroutine {
-    // 0x0: Offset (in halfwords) where the coroutine starts, relative to the start of unionall
-    uint16_t offset;
-    uint16_t type;      // 0x2: Not confirmed
-    uint16_t linked_to; // 0x4: From SkyTemple's source code. Purpose unknown.
-};
-ASSERT_SIZE(struct script_coroutine, 6);
-
-// Contains additional info about a scripting coroutine
-struct coroutine_info {
-    void* unionall_start;  // 0x0: RAM address where unionall starts
-    void* coroutine_start; // 0x4: RAM address where the coroutine starts
-    undefined4 field_0x8;
-    undefined field_0xc;
-    undefined field_0xd;
-    undefined field_0xe;
-    undefined field_0xf;
-    undefined field_0x10;
-    undefined field_0x11;
-    undefined field_0x12;
-    undefined field_0x13;
-    undefined2 field_0x14;
-    undefined field_0x16;
-    undefined field_0x17; // Likely padding
-    undefined2 field_0x18;
-    undefined padding[2];
-};
-ASSERT_SIZE(struct coroutine_info, 28);
-
 // Variables that track game state, available to the script engine.
 struct script_var {
     struct script_var_type_16 type; // 0x0: type of data contained in this variable
@@ -252,6 +222,37 @@ struct common_routine_table {
     struct common_routine routines[701];
 };
 ASSERT_SIZE(struct common_routine_table, 5608);
+
+// Scripting coroutine located in unionall.ssb. Seems to represent coroutines when they are loaded
+// in-RAM, unlike common_routine.
+struct script_coroutine {
+    // 0x0: Offset (in halfwords) where the coroutine starts, relative to the start of unionall
+    uint16_t offset;
+    uint16_t type;      // 0x2: Not confirmed
+    uint16_t linked_to; // 0x4: From SkyTemple's source code. Purpose unknown.
+};
+ASSERT_SIZE(struct script_coroutine, 6);
+
+// Contains additional info about a scripting coroutine loaded in RAM.
+struct coroutine_info {
+    void* unionall_start;  // 0x0: RAM address where unionall starts
+    void* coroutine_start; // 0x4: RAM address where the coroutine starts
+    undefined4 field_0x8;
+    undefined field_0xc;
+    undefined field_0xd;
+    undefined field_0xe;
+    undefined field_0xf;
+    undefined field_0x10;
+    undefined field_0x11;
+    undefined field_0x12;
+    undefined field_0x13;
+    undefined2 field_0x14;
+    undefined field_0x16;
+    undefined field_0x17; // Likely padding
+    undefined2 field_0x18;
+    undefined padding[2];
+};
+ASSERT_SIZE(struct coroutine_info, 28);
 
 // An object is a non-entity, usually inanimate object that can be statically placed in a scene.
 struct script_object {

--- a/headers/types/ground_mode/ground_mode.h
+++ b/headers/types/ground_mode/ground_mode.h
@@ -5,6 +5,35 @@
 
 #include "enums.h"
 
+// Scripting coroutine located in unionall
+struct script_coroutine {
+    uint16_t offset;    // 0x0: Offset (in halfwords) where the coroutine starts, relative to the start of unionall
+    uint16_t type;      // 0x2: Not confirmed
+    uint16_t linked_to; // 0x4: From SkyTemple's source code. Purpose unknown.
+};
+ASSERT_SIZE(struct script_coroutine, 6);
+
+// Contains additional info about a scripting coroutine
+struct coroutine_info {
+    void* unionall_start;  // 0x0: RAM address where unionall starts
+    void* coroutine_start; // 0x4: RAM address where the coroutine starts
+    undefined4 field_0x8;
+    undefined field_0xc;
+    undefined field_0xd;
+    undefined field_0xe;
+    undefined field_0xf;
+    undefined field_0x10;
+    undefined field_0x11;
+    undefined field_0x12;
+    undefined field_0x13;
+    undefined2 field_0x14;
+    undefined field_0x16;
+    undefined field_0x17; // Likely padding
+    undefined2 field_0x18;
+    undefined padding[2];
+};
+ASSERT_SIZE(struct coroutine_info, 28);
+
 // Variables that track game state, available to the script engine.
 struct script_var {
     struct script_var_type_16 type; // 0x0: type of data contained in this variable
@@ -242,6 +271,18 @@ struct animation {
 };
 ASSERT_SIZE(struct animation, 196);
 
+// Holds data about an animation and how it should be played
+struct animation_data {
+    uint8_t animation_id; // 0x0: ID of the animation in the monster's animation sheet
+    // 0x1: speed + flags: 1-byte bitfield
+    enum animation_speed animation_speed : 2;
+    bool f_unk1 : 1;
+    bool loop : 1;
+    bool f_unk3 : 1;
+    bool f_unused : 3;
+};
+ASSERT_SIZE(struct animation_data, 2);
+
 // represent an actor present in the scene in the overworld (both during cutscenes and free-roams)
 struct live_actor {
     struct monster_id_16
@@ -343,9 +384,9 @@ struct main_ground_data {
     undefined*
         partner_follow_data; // 0x4: pointer to the data related to the partner following the player
     struct live_actor_list* actors; // 0x8: pointer to the actors
-    undefined* objects;             // 0x12: pointer to the objects
-    undefined* performers;          // 0x16: pointer to the performers
-    undefined* events;              // 0x20: pointer to the events
+    undefined* objects;             // 0xC: pointer to the objects
+    undefined* performers;          // 0x10: pointer to the performers
+    undefined* events;              // 0x14: pointer to the events
 };
 ASSERT_SIZE(struct main_ground_data, 24);
 

--- a/headers/types/ground_mode/ground_mode.h
+++ b/headers/types/ground_mode/ground_mode.h
@@ -7,7 +7,8 @@
 
 // Scripting coroutine located in unionall
 struct script_coroutine {
-    uint16_t offset;    // 0x0: Offset (in halfwords) where the coroutine starts, relative to the start of unionall
+    // 0x0: Offset (in halfwords) where the coroutine starts, relative to the start of unionall
+    uint16_t offset;
     uint16_t type;      // 0x2: Not confirmed
     uint16_t linked_to; // 0x4: From SkyTemple's source code. Purpose unknown.
 };

--- a/headers/types/ground_mode/ground_mode.h
+++ b/headers/types/ground_mode/ground_mode.h
@@ -273,6 +273,7 @@ struct animation {
 ASSERT_SIZE(struct animation, 196);
 
 // Holds data about an animation and how it should be played
+#pragma pack(push, 2)
 struct animation_data {
     uint8_t animation_id; // 0x0: ID of the animation in the monster's animation sheet
     // 0x1: speed + flags: 1-byte bitfield
@@ -280,9 +281,10 @@ struct animation_data {
     bool f_unk1 : 1;
     bool loop : 1;
     bool f_unk3 : 1;
-    bool f_unused : 3;
+    uint8_t f_unused : 3;
 };
 ASSERT_SIZE(struct animation_data, 2);
+#pragma pack(pop)
 
 // represent an actor present in the scene in the overworld (both during cutscenes and free-roams)
 struct live_actor {

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -7799,6 +7799,25 @@ arm9:
         
         r0: team member index
         return: roster index if the team member is active, -1 otherwise
+    - name: TryAddRosterMonsterToTeam
+      address:
+        EU: 0x2056AD0
+        NA: 0x2056754
+      description: |-
+        Attempts to add a monster from the roster to the active team.
+        
+        Returns the team index of the newly added monster. If the monster was already on the team, returns its current team index. If the monster is not on the team and there's no space left, returns -1.
+        
+        r0: roster index
+        return: Team index
+    - name: RemoveActiveMembersFromMainTeam
+      address:
+        EU: 0x2056CDC
+        NA: 0x2056960
+      description: |-
+        Removes the active monsters on the Main Team from the team member table.
+        
+        No params.
     - name: SetTeamSetupHeroAndPartnerOnly
       address:
         EU: 0x2056D48
@@ -8696,6 +8715,7 @@ arm9:
         r2: len (# bytes)
     - name: MemcpyFast
       address:
+        EU: 0x207C860
         NA: 0x207C4C8
       description: |-
         Copies bytes from one buffer to another, similar to memcpy(3). Note that the source/destination buffer parameters swapped relative to the standard memcpy.
@@ -8729,6 +8749,36 @@ arm9:
         This function must always be called before opening a file.
         
         r0: file_stream pointer
+    - name: GetOverlayInfo
+      address:
+        EU: 0x2080034
+        NA: 0x207FC9C
+      description: |-
+        Returns the y9.bin entry for the specified overlay
+        
+        r0: [output] Overlay info struct
+        r1: ?
+        r2: Overlay ID
+        return: True if the entry could be loaded successfully?
+    - name: LoadOverlayInternal
+      address:
+        EU: 0x2080130
+        NA: 0x207FD98
+      description: |-
+        Called by LoadOverlay to load an overlay into RAM given its info struct
+        
+        r0: Overlay info struct
+        Return: True if the overlay was loaded successfully?
+    - name: InitOverlay
+      address:
+        EU: 0x2080254
+        NA: 0x207FEBC
+      description: |-
+        Performs overlay initialization right after loading an overlay with LoadOverlayInternal.
+        
+        This function is responsible for jumping to all the pointers located in the overlay's static init array, among other things.
+        
+        r0: Overlay info struct
     - name: abs
       address:
         EU: 0x20868F4
@@ -11318,7 +11368,7 @@ arm9:
         type: enum monster_id*[28]
     - name: TEAM_MEMBER_TABLE_PTR
       address:
-        EU: 0x20B1364
+        EU: 0x20B138C
         NA: 0x20B0A48
         JP: 0x20B22BC
       length:

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -7799,16 +7799,16 @@ arm9:
         
         r0: team member index
         return: roster index if the team member is active, -1 otherwise
-    - name: TryAddRosterMonsterToTeam
+    - name: TryAddMonsterToActiveTeam
       address:
         EU: 0x2056AD0
         NA: 0x2056754
       description: |-
-        Attempts to add a monster from the roster to the active team.
+        Attempts to add a monster from the team member table to the active team.
         
         Returns the team index of the newly added monster. If the monster was already on the team, returns its current team index. If the monster is not on the team and there's no space left, returns -1.
         
-        r0: roster index
+        r0: member index
         return: Team index
     - name: RemoveActiveMembersFromMainTeam
       address:

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -79,8 +79,7 @@ overlay11:
       description: |-
         Checks if the two most significant bits (0x8000 and 0x4000) are set on a given script opcode parameter, and modifies the value if so.
         
-        r0: Parameter
-        ret r0: Modified parameter if either of the two bits listed above is set, same parameter otherwise.
+        r0: On input, the parameter. On output, the modified parameter if either of the two bits listed above is set, same parameter otherwise.
     - name: StationLoadHanger
       address:
         EU: 0x22E5514

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -16,16 +16,36 @@ overlay11:
     
     This is the "main" overlay of ground mode. The script engine is what runs the ground mode scripts contained in the SCRIPT folder, which are written in a custom scripting language. These scripts encode things like cutscenes, screen transitions, ground mode events, and tons of other things related to ground mode.
   functions:
-    - name: FuncThatCallsCommandParsing
+    - name: UnlockScriptingLock
+      address:
+        EU: 0x22DDA70
+        NA: 0x22DD130
+      description: |-
+        Unlocks a scripting lock.
+        
+        Sets the corresponding byte to 1 on LOCK_NOTIFY_ARRAY. Also sets a global unlock flag, used to tell the scripting engine that the state of locks have changed and they should be checked again.
+        
+        r0: ID of the lock to unlock
+    - name: FuncThatCallsRunNextOpcode
       address:
         EU: 0x22DDAA4
         NA: 0x22DD164
         JP: 0x22DE804
-    - name: ScriptCommandParsing
+      description: |-
+        Called up to 16 times per frame. Exact purpose unknown.
+        
+        r0: Looks like a pointer to some struct containing data about the current state of scripting engine
+    - name: RunNextOpcode
       address:
         EU: 0x22DE6A4
         NA: 0x22DDD64
         JP: 0x22DF404
+      description: |-
+        Runs the next scripting opcode.
+        
+        Contains a switch statement based on the opcode ([r0+1C]).
+        
+        r0: Looks like a pointer to some struct containing data about the current state of scripting engine
     - name: LoadFileFromRomVeneer
       address:
         NA: 0x22E46DC
@@ -37,11 +57,30 @@ overlay11:
         r0: [output] pointer to an IO struct {ptr, len}
         r1: file path string pointer
         r2: flags
+    - name: CheckUnlocks
+      address:
+        EU: 0x22E4C90
+        NA: 0x22E4350
+      description: |-
+        Checks if an script unlock happened by reading entries from LOCK_NOTIFY_ARRAY.
+        
+        If the global unlock flag is not set, returns immediately. If it is, the function loops LOCK_NOTIFY_ARRAY, checking for true values. If it finds one, resets it back to 0 and handles the unlock.
+        
+        No params.
     - name: SsbLoad2
       address:
         EU: 0x22E503C
         NA: 0x22E46FC
         JP: 0x22E5D28
+    - name: ProcessScriptParam
+      address:
+        EU: 0x22E51EC
+        NA: 0x22E48AC
+      description: |-
+        Checks if the two most significant bits (0x8000 and 0x4000) are set on a given script opcode parameter, and modifies the value if so.
+        
+        r0: Parameter
+        ret r0: Modified parameter if either of the two bits listed above is set, same parameter otherwise.
     - name: StationLoadHanger
       address:
         EU: 0x22E5514
@@ -70,6 +109,18 @@ overlay11:
         r2: first argument, if relevant? Probably corresponds to the second parameter of OPCODE_PROCESS_SPECIAL
         r3: second argument, if relevant? Probably corresponds to the third parameter of OPCODE_PROCESS_SPECIAL
         return: return value of the special process if it has one, otherwise 0
+    - name: GetCoroutineInfo
+      address:
+        EU: 0x22E88F8
+        NA: 0x22E7FB8
+      description: |-
+        Returns information about a coroutine in unionall
+        
+        It's used by the CallCommon code to pull the data required to call the coroutine, so maybe the function returns data required to call a coroutine instead of info about the coroutine itself.
+        
+        r0: [output] Coroutine info
+        r1: Coroutine ID
+        return: True if the coroutine is valid? It's false only if the coroutine's offset is 0.
     - name: GetSpecialRecruitmentSpecies
       address:
         EU: 0x22E897C
@@ -309,6 +360,18 @@ overlay11:
         r0: animation pointer
         r1: flags
         r2: ?
+    - name: GetIdleAnimationType
+      address:
+        EU: 0x22F66F0
+        NA: 0x22F5D50
+      description: |-
+        Given a monster species, returns the type of idle animation it should have.
+        
+        Possible values are "freeze animation #0" (0x300), "loop animation #7" (0x807) and "freeze animation #7" (0x307).
+        
+        r0: Monster ID
+        r1: (?) Could contain data about the animation the monster is currently playing
+        return: Animation data
     - name: LoadObjectAnimData
       address:
         EU: 0x22F7800
@@ -371,6 +434,17 @@ overlay11:
         Remove the actor from the overworld actor list (in GROUND_STATE_PTRS)
         
         r0: the index of the actor in the live actor list
+    - name: ChangeActorAnimation
+      address:
+        EU: 0x22F9D68
+        NA: 0x22F93C8
+      description: |-
+        Used by the SetAnimation opcode to change the animation of an actor.
+        
+        It's responsible for breaking down the SetAnimation parameter and determining which animation to play and which flags to set.
+        
+        r0: ?
+        r1: SetAnimation parameter
     - name: InitPartnerFollowData
       address:
         EU: 0x22FC3C8
@@ -618,6 +692,17 @@ overlay11:
         Irdkwia's notes: FIXED_FLOOR_GROUND_ASSOCIATION
         
         type: struct level_tilemap_list_entry[81]
+    - name: SETANIMATION_TABLE
+      address:
+        EU: 0x23223FC
+        NA: 0x23218CC
+      length:
+        EU: 0xA8
+        NA: 0xA8
+      description: |-
+        Table that associates the parameter of the SetAnimation scripting opcode to animation data.
+        
+        The first entry is unused and has a value of 0xFFFF.
     - name: OVERLAY11_OVERLAY_LOAD_TABLE
       address:
         EU: 0x2323B9C

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -46,6 +46,16 @@ overlay11:
         Contains a switch statement based on the opcode ([r0+1C]).
         
         r0: Looks like a pointer to some struct containing data about the current state of scripting engine
+    - name: CheckUnlocks
+      address:
+        EU: 0x22E4C90
+        NA: 0x22E4350
+      description: |-
+        Checks if an script unlock happened by reading entries from LOCK_NOTIFY_ARRAY.
+        
+        If the global unlock flag is not set, returns immediately. If it is, the function loops LOCK_NOTIFY_ARRAY, checking for true values. If it finds one, resets it back to 0 and handles the unlock.
+        
+        No params.
     - name: LoadFileFromRomVeneer
       address:
         NA: 0x22E46DC
@@ -57,16 +67,6 @@ overlay11:
         r0: [output] pointer to an IO struct {ptr, len}
         r1: file path string pointer
         r2: flags
-    - name: CheckUnlocks
-      address:
-        EU: 0x22E4C90
-        NA: 0x22E4350
-      description: |-
-        Checks if an script unlock happened by reading entries from LOCK_NOTIFY_ARRAY.
-        
-        If the global unlock flag is not set, returns immediately. If it is, the function loops LOCK_NOTIFY_ARRAY, checking for true values. If it finds one, resets it back to 0 and handles the unlock.
-        
-        No params.
     - name: SsbLoad2
       address:
         EU: 0x22E503C

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -23,7 +23,7 @@ overlay11:
       description: |-
         Unlocks a scripting lock.
         
-        Sets the corresponding byte to 1 on LOCK_NOTIFY_ARRAY. Also sets a global unlock flag, used to tell the scripting engine that the state of locks have changed and they should be checked again.
+        Sets the corresponding byte to 1 on LOCK_NOTIFY_ARRAY to signal that the scripting engine should handle the unlock. Also sets a global unlock flag, used to tell the scripting engine that the state of locks have changed and they should be checked again.
         
         r0: ID of the lock to unlock
     - name: FuncThatCallsRunNextOpcode
@@ -46,12 +46,12 @@ overlay11:
         Contains a switch statement based on the opcode ([r0+1C]).
         
         r0: Looks like a pointer to some struct containing data about the current state of scripting engine
-    - name: CheckUnlocks
+    - name: HandleUnlocks
       address:
         EU: 0x22E4C90
         NA: 0x22E4350
       description: |-
-        Checks if an script unlock happened by reading entries from LOCK_NOTIFY_ARRAY.
+        Checks if a script unlock happened by reading entries from LOCK_NOTIFY_ARRAY and handles the ones that were set.
         
         If the global unlock flag is not set, returns immediately. If it is, the function loops LOCK_NOTIFY_ARRAY, checking for true values. If it finds one, resets it back to 0 and handles the unlock.
         

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -490,6 +490,17 @@ ram:
       length:
         NA: 0x4
       description: Pointer to GROUND_MEMORY_ARENA_2.
+    - name: LOCK_NOTIFY_ARRAY
+      address:
+        EU: 0x23259F4
+        NA: 0x2324EB4
+      length:
+        EU: 0x16
+        NA: 0x16
+      description: |-
+        Used to notify scripts waiting for a certain lock to unlock so they can resume their execution.
+        
+        1 byte per lock. Exact size isn't confirmed, it could potentially be longer.
     - name: GROUND_MEMORY_ARENA_1
       address:
         NA: 0x2324FC0

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -495,8 +495,8 @@ ram:
         EU: 0x23259F4
         NA: 0x2324EB4
       length:
-        EU: 0x16
-        NA: 0x16
+        EU: 0x14
+        NA: 0x14
       description: |-
         Used to notify scripts waiting for a certain lock to unlock so they can resume their execution.
         


### PR DESCRIPTION
Adds functions mostly related to how overlays are loaded and scripting/ground mode code.

I don't know what to do with the size check for `struct animation_data`. I defined the struct to better specify how the different bits in the value (which is just a halfword) work, but that pushes its size to 4 bytes due to padding.