### PR TITLE
Further Arm7 documentation, as well as a note on FileRead limitations

### DIFF
--- a/headers/functions/arm7.h
+++ b/headers/functions/arm7.h
@@ -2,7 +2,7 @@
 #define HEADERS_FUNCTIONS_ARM7_H_
 
 void EntryArm7(void);
-void MainArm7(void);
+void NitroSpMain(void);
 int GetProcessorMode(void);
 
 #endif

--- a/headers/functions/arm7.h
+++ b/headers/functions/arm7.h
@@ -3,14 +3,6 @@
 
 void EntryArm7(void);
 void MainArm7(void);
-int ClearIrqFlag(void);
-int EnableIrqFlag(void);
-int SetIrqFlag(int new_value);
-int EnableIrqFiqFlags(void);
-int SetIrqFiqFlags(int new_value);
 int GetProcessorMode(void);
-unsigned long long __divsi3(int dividend, int divisor);
-unsigned long long __udivsi3(uint32_t dividend, uint32_t divisor);
-unsigned long long __udivsi3_no_zero_check(uint32_t dividend, uint32_t divisor);
 
 #endif

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -1,34 +1,34 @@
 arm7:
   versions:
-    - EU-ENTRY
-    - NA-ENTRY
-    - JP-ENTRY
+    - EU
+    - NA
+    - JP
     - EU-WRAM
     - NA-WRAM
     - JP-WRAM
-    - EU-SLOW
-    - NA-SLOW
-    - JP-SLOW
+    - EU-RAM
+    - NA-RAM
+    - JP-RAM
   address:
-    EU-ENTRY: 0x2380000
-    NA-ENTRY: 0x2380000
-    JP-ENTRY: 0x2380000
+    EU: 0x2380000
+    NA: 0x2380000
+    JP: 0x2380000
     EU-WRAM: 0x37F8000
     NA-WRAM: 0x37F8000
     JP-WRAM: 0x37F8000
-    EU-SLOW: 0x27E0000
-    NA-SLOW: 0x27E0000
-    JP-SLOW: 0x27E0000
+    EU-RAM: 0x27E0000
+    NA-RAM: 0x27E0000
+    JP-RAM: 0x27E0000
   length:
-    EU-ENTRY: 0x1E8
-    NA-ENTRY: 0x1E8
-    JP-ENTRY: 0x1E8
+    EU: 0x27080    #0x1E8 long ENTRY block
+    NA: 0x27080
+    JP: 0x27080
     EU-WRAM: 0xF608
     NA-WRAM: 0xF608
     JP-WRAM: 0xF608
-    EU-SLOW: 0x17878
-    NA-SLOW: 0x17878
-    JP-SLOW: 0x17878
+    EU-RAM: 0x17878
+    NA-RAM: 0x17878
+    JP-RAM: 0x17878
   description: |-
     The ARM7 binary.
     
@@ -54,36 +54,48 @@ arm7:
         No params.
     - name: MainArm7
       address:
-        EU: 0x37F8000
-        NA: 0x37F8000
-        JP: 0x37F8000
+        EU: 0x23801E8
+        NA: 0x23801E8
+        JP: 0x23801E8
+        EU-WRAM: 0x37F8000
+        NA-WRAM: 0x37F8000
+        JP-WRAM: 0x37F8000
       description: |-
         This main function for the ARM7 subsystem. Contains the main event loop.
 
         No params.
     - name: ClearIrqFlag
       address:
-        EU: 0x37FDCEC
-        NA: 0x37FDCEC
-        JP: 0x37FDCEC
+        EU: 0x2385ED4
+        NA: 0x2385ED4
+        JP: 0x2385ED4
+        EU-WRAM: 0x37FDCEC
+        NA-WRAM: 0x37FDCEC
+        JP-WRAM: 0x37FDCEC
       description: |-
         Copy of the ARM9 function. See arm9.yml for more information.
         
         return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were already enabled)
     - name: EnableIrqFlag
       address:
-        EU: 0x37FDD00
-        NA: 0x37FDD00
-        JP: 0x37FDD00
+        EU: 0x2385EE8
+        NA: 0x2385EE8
+        JP: 0x2385EE8
+        EU-WRAM: 0x37FDD00
+        NA-WRAM: 0x37FDD00
+        JP-WRAM: 0x37FDD00
       description: |-
         Copy of the ARM9 function. See arm9.yml for more information.
         
         return: Old value of cpsr & 0x80 (0x80 if interrupts were already disabled, 0x0 if they were enabled)
     - name: SetIrqFlag
       address:
-        EU: 0x37FDD14
-        NA: 0x37FDD14
-        JP: 0x37FDD14
+        EU: 0x2385EFC
+        NA: 0x2385EFC
+        JP: 0x2385EFC
+        EU-WRAM: 0x37FDD14
+        NA-WRAM: 0x37FDD14
+        JP-WRAM: 0x37FDD14
       description: |-
         Copy of the ARM9 function. See arm9.yml for more information.
         
@@ -91,18 +103,24 @@ arm7:
         return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were enabled)
     - name: EnableIrqFiqFlags
       address:
-        EU: 0x37FDD2C
-        NA: 0x37FDD2C
-        JP: 0x37FDD2C
+        EU: 0x2385F14
+        NA: 0x2385F14
+        JP: 0x2385F14
+        EU-WRAM: 0x37FDD2C
+        NA-WRAM: 0x37FDD2C
+        JP-WRAM: 0x37FDD2C
       description: |-
         Copy of the ARM9 function. See arm9.yml for more information.
         
         return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
     - name: SetIrqFiqFlags
       address:
-        EU: 0x37FDD40
-        NA: 0x37FDD40
-        JP: 0x37FDD40
+        EU: 0x2385F28
+        NA: 0x2385F28
+        JP: 0x2385F28
+        EU-WRAM: 0x37FDD40
+        NA-WRAM: 0x37FDD40
+        JP-WRAM: 0x37FDD40
       description: |-
         Copy of the ARM9 function. See arm9.yml for more information.
         
@@ -110,9 +128,12 @@ arm7:
         return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
     - name: GetProcessorMode
       address:
-        EU: 0x37FDD58
-        NA: 0x37FDD58
-        JP: 0x37FDD58
+        EU: 0x2385F40
+        NA: 0x2385F40
+        JP: 0x2385F40
+        EU-WRAM: 0x37FDD58
+        NA-WRAM: 0x37FDD58
+        JP-WRAM: 0x37FDD58
       description: |-
         Gets the processor's current operating mode.
 
@@ -121,9 +142,9 @@ arm7:
         return: cpsr & 0x1f (the cpsr mode bits M4-M0)
     - name: __divsi3
       address:
-        EU: 0x3806BC8
-        NA: 0x3806BC8
-        JP: 0x3806BC8
+        EU-WRAM: 0x3806BC8
+        NA-WRAM: 0x3806BC8
+        JP-WRAM: 0x3806BC8
       description: |-
         Copy of the ARM9 function. See arm9.yml for more information.
         
@@ -132,9 +153,9 @@ arm7:
         return: (quotient) | (remainder << 32)
     - name: __udivsi3
       address:
-        EU: 0x3806DD4
-        NA: 0x3806DD4
-        JP: 0x3806DD4
+        EU-WRAM: 0x3806DD4
+        NA-WRAM: 0x3806DD4
+        JP-WRAM: 0x3806DD4
       description: |-
         Copy of the ARM9 function. See arm9.yml for more information.
         
@@ -143,9 +164,9 @@ arm7:
         return: (quotient) | (remainder << 32)
     - name: __udivsi3_no_zero_check
       address:
-        EU: 0x3806DDC
-        NA: 0x3806DDC
-        JP: 0x3806DDC
+        EU-WRAM: 0x3806DDC
+        NA-WRAM: 0x3806DDC
+        JP-WRAM: 0x3806DDC
       description: |-
         Copy of the ARM9 function. See arm9.yml for more information.
         

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -1,8 +1,14 @@
 arm7:
   versions:
-    - EU
-    - NA
-    - JP
+    - EU-ENTRY
+    - NA-ENTRY
+    - JP-ENTRY
+    - EU-WRAM
+    - NA-WRAM
+    - JP-WRAM
+    - EU-SLOW
+    - NA-SLOW
+    - JP-SLOW
   address:
     EU-ENTRY: 0x2380000
     NA-ENTRY: 0x2380000

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -35,12 +35,12 @@ arm7:
     This is the secondary binary that gets loaded when the game is launched.
     
     Speaking generally, this is the program run by the Nintendo DS's secondary ARM7TDMI CPU, which handles the audio I/O, the touch screen, Wi-Fi functions, cryptography, and more.
-
+    
     Memory map: (binary is initially loaded at 0x2380000)
     0x2380000-0x23801E8 => Contains EntryArm7 and two more methods, all related to memory mapping.
     0x23801E8-0x238F7F0 => Mapped to 0x37F8000, contains NitroSpMain and functions crucial to execution.
     0x238F7F0-0x23A7068 => Mapped to 0x27E0000, contains everything else that won't fit in the fast WRAM.
-
+    
     Note that while the length for the main EU/NA/JP block is defined as 0x27080 above, after memory mappings, the block located at that address is only a 0x1E8 long ENTRY block, containing 3 functions solely used for the initial memory mapping. The memory following this block is reused and its purpose is undocumented at the moment.
   functions:
     - name: EntryArm7
@@ -54,7 +54,7 @@ arm7:
         Handles mapping the ARM7 binary into the various memory areas that the program will be using.
         
         Once the memory mapping has been completed, a constant containing the address to NitroSpMain is loaded into a register (r1), and a `bx` branch will jump to NitroSpMain.
-
+        
         No params.
     - name: NitroSpMain
       address:
@@ -66,7 +66,7 @@ arm7:
         JP-WRAM: 0x37F8000
       description: |-
         This main function for the ARM7 subsystem. Contains the main event loop.
-
+        
         No params.
     - name: ClearIrqFlag
       address:
@@ -140,7 +140,7 @@ arm7:
         JP-WRAM: 0x37FDD58
       description: |-
         Gets the processor's current operating mode.
-
+        
         See https://problemkaputt.de/gbatek.htm#armcpuflagsconditionfieldcond
         
         return: cpsr & 0x1f (the cpsr mode bits M4-M0)

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -115,6 +115,8 @@ arm7:
         JP: 0x37FDD58
       description: |-
         Gets the processor's current operating mode.
+
+        See https://problemkaputt.de/gbatek.htm#armcpuflagsconditionfieldcond
         
         return: cpsr & 0x1f (the cpsr mode bits M4-M0)
     - name: __divsi3

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -38,7 +38,7 @@ arm7:
 
     Memory map: (binary is initially loaded at 0x2380000)
     0x2380000-0x23801E8 => Contains EntryArm7 and two more methods, all related to memory mapping.
-    0x23801E8-0x238F7F0 => Mapped to 0x37F8000, contains MainArm7 and functions crucial to execution.
+    0x23801E8-0x238F7F0 => Mapped to 0x37F8000, contains NitroSpMain and functions crucial to execution.
     0x238F7F0-0x23A7068 => Mapped to 0x27E0000, contains everything else that won't fit in the fast WRAM.
 
     Note that while the length for the main EU/NA/JP block is defined as 0x27080 above, after memory mappings, the block located at that address is only a 0x1E8 long ENTRY block, containing 3 functions solely used for the initial memory mapping. The memory following this block is reused and its purpose is undocumented at the moment.
@@ -53,10 +53,10 @@ arm7:
         
         Handles mapping the ARM7 binary into the various memory areas that the program will be using.
         
-        Once the memory mapping has been completed, a constant containing the address to MainArm7 is loaded into a register (r1), and a `bx` branch will jump to MainArm7.
+        Once the memory mapping has been completed, a constant containing the address to NitroSpMain is loaded into a register (r1), and a `bx` branch will jump to NitroSpMain.
 
         No params.
-    - name: MainArm7
+    - name: NitroSpMain
       address:
         EU: 0x23801E8
         NA: 0x23801E8

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -20,7 +20,7 @@ arm7:
     NA-RAM: 0x27E0000
     JP-RAM: 0x27E0000
   length:
-    EU: 0x27080    #0x1E8 long ENTRY block
+    EU: 0x27080
     NA: 0x27080
     JP: 0x27080
     EU-WRAM: 0xF608
@@ -35,6 +35,8 @@ arm7:
     This is the secondary binary that gets loaded when the game is launched.
     
     Speaking generally, this is the program run by the Nintendo DS's secondary ARM7TDMI CPU, which handles the audio I/O, the touch screen, Wi-Fi functions, cryptography, and more.
+
+    Note that while the length for the main EU/NA/JP block is defined as 0x27080 above, after memory mappings, the block located at that address is only a 0x1E8 long ENTRY block, containing 3 functions solely used for the initial memory mapping. The memory following this block is reused and its purpose is undocumented at the moment.
   functions:
     - name: EntryArm7
       address:

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -144,6 +144,9 @@ arm7:
         return: cpsr & 0x1f (the cpsr mode bits M4-M0)
     - name: __divsi3
       address:
+        EU: 0x238EDB0
+        NA: 0x238EDB0
+        JP: 0x238EDB0
         EU-WRAM: 0x3806BC8
         NA-WRAM: 0x3806BC8
         JP-WRAM: 0x3806BC8
@@ -155,6 +158,9 @@ arm7:
         return: (quotient) | (remainder << 32)
     - name: __udivsi3
       address:
+        EU: 0x238EFBC
+        NA: 0x238EFBC
+        JP: 0x238EFBC
         EU-WRAM: 0x3806DD4
         NA-WRAM: 0x3806DD4
         JP-WRAM: 0x3806DD4
@@ -166,6 +172,9 @@ arm7:
         return: (quotient) | (remainder << 32)
     - name: __udivsi3_no_zero_check
       address:
+        EU: 0x238EFC4
+        NA: 0x238EFC4
+        JP: 0x238EFC4
         EU-WRAM: 0x3806DDC
         NA-WRAM: 0x3806DDC
         JP-WRAM: 0x3806DDC

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -53,6 +53,8 @@ arm7:
         
         Handles mapping the ARM7 binary into the various memory areas that the program will be using.
         
+        Once the memory mapping has been completed, a constant containing the address to MainArm7 is loaded into a register (r1), and a `bx` branch will jump to MainArm7.
+
         No params.
     - name: MainArm7
       address:

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -67,7 +67,7 @@ arm7:
         NA: 0x37FDCEC
         JP: 0x37FDCEC
       description: |-
-        Enables processor interrupts by clearing the i flag in the program status register (cpsr).
+        Copy of the ARM9 function. See arm9.yml for more information.
         
         return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were already enabled)
     - name: EnableIrqFlag
@@ -76,7 +76,7 @@ arm7:
         NA: 0x37FDD00
         JP: 0x37FDD00
       description: |-
-        Disables processor interrupts by setting the i flag in the program status register (cpsr).
+        Copy of the ARM9 function. See arm9.yml for more information.
         
         return: Old value of cpsr & 0x80 (0x80 if interrupts were already disabled, 0x0 if they were enabled)
     - name: SetIrqFlag
@@ -85,7 +85,7 @@ arm7:
         NA: 0x37FDD14
         JP: 0x37FDD14
       description: |-
-        Sets the value of the processor's interrupt flag according to the specified parameter.
+        Copy of the ARM9 function. See arm9.yml for more information.
         
         r0: Value to set the flag to (0x80 to set it, which disables interrupts; 0x0 to unset it, which enables interrupts)
         return: Old value of cpsr & 0x80 (0x80 if interrupts were disabled, 0x0 if they were enabled)
@@ -95,7 +95,7 @@ arm7:
         NA: 0x37FDD2C
         JP: 0x37FDD2C
       description: |-
-        Disables processor all interrupts (both standard and fast) by setting the i and f flags in the program status register (cpsr).
+        Copy of the ARM9 function. See arm9.yml for more information.
         
         return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
     - name: SetIrqFiqFlags
@@ -104,7 +104,7 @@ arm7:
         NA: 0x37FDD40
         JP: 0x37FDD40
       description: |-
-        Sets the value of the processor's interrupt flags (i and f) according to the specified parameter.
+        Copy of the ARM9 function. See arm9.yml for more information.
         
         r0: Value to set the flags to (0xC0 to set both flags, 0x80 to set the i flag and clear the f flag, 0x40 to set the f flag and clear the i flag and 0x0 to clear both flags)
         return: Old value of cpsr & 0xC0 (contains the previous values of the i and f flags)
@@ -123,9 +123,7 @@ arm7:
         NA: 0x3806BC8
         JP: 0x3806BC8
       description: |-
-        This appears to be the libgcc implementation of __divsi3 (not sure which gcc version), which implements the division operator for signed ints.
-        
-        The return value is a 64-bit integer, with the quotient (dividend / divisor) in the lower 32 bits and the remainder (dividend % divisor) in the upper 32 bits. In accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return), this means that the quotient is returned in r0 and the remainder is returned in r1.
+        Copy of the ARM9 function. See arm9.yml for more information.
         
         r0: dividend
         r1: divisor
@@ -136,10 +134,7 @@ arm7:
         NA: 0x3806DD4
         JP: 0x3806DD4
       description: |-
-        This appears to be the libgcc implementation of __udivsi3 (not sure which gcc version), which implements the division operator for unsigned ints.
-        
-        The return value is a 64-bit integer, with the quotient (dividend / divisor) in the lower 32 bits and the remainder (dividend % divisor) in the upper 32 bits. In accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return), this means that the quotient is returned in r0 and the remainder is returned in r1.
-        Note: This function falls through to __udivsi3_no_zero_check.
+        Copy of the ARM9 function. See arm9.yml for more information.
         
         r0: dividend
         r1: divisor
@@ -150,10 +145,7 @@ arm7:
         NA: 0x3806DDC
         JP: 0x3806DDC
       description: |-
-        Subsidiary function to __udivsi3. Skips the initial check for divisor == 0.
-        
-        The return value is a 64-bit integer, with the quotient (dividend / divisor) in the lower 32 bits and the remainder (dividend % divisor) in the upper 32 bits. In accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return), this means that the quotient is returned in r0 and the remainder is returned in r1.
-        This function appears to only be called internally.
+        Copy of the ARM9 function. See arm9.yml for more information.
         
         r0: dividend
         r1: divisor

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -36,6 +36,11 @@ arm7:
     
     Speaking generally, this is the program run by the Nintendo DS's secondary ARM7TDMI CPU, which handles the audio I/O, the touch screen, Wi-Fi functions, cryptography, and more.
 
+    Memory map: (binary is initially loaded at 0x2380000)
+    0x2380000-0x23801E8 => Contains EntryArm7 and two more methods, all related to memory mapping.
+    0x23801E8-0x238F7F0 => Mapped to 0x37F8000, contains MainArm7 and functions crucial to execution.
+    0x238F7F0-0x23A7068 => Mapped to 0x27E0000, contains everything else that won't fit in the fast WRAM.
+
     Note that while the length for the main EU/NA/JP block is defined as 0x27080 above, after memory mappings, the block located at that address is only a 0x1E8 long ENTRY block, containing 3 functions solely used for the initial memory mapping. The memory following this block is reused and its purpose is undocumented at the moment.
   functions:
     - name: EntryArm7
@@ -46,12 +51,7 @@ arm7:
       description: |-
         The entrypoint for the ARM7 CPU.
         
-        Handles mapping the ARM7 binary into the various memory areas that the program will be using:
-
-        Memory map: (binary is initially loaded at 0x2380000)
-        0x2380000-0x23801E8 => Contains EntryArm7 and two more methods, all related to memory mapping.
-        0x23801E8-0x238F7F0 => Mapped to 0x37F8000, contains MainArm7 and functions crucial to execution.
-        0x238F7F0-0x23A7068 => Mapped to 0x27E0000, contains everything else that won't fit in the fast WRAM.
+        Handles mapping the ARM7 binary into the various memory areas that the program will be using.
         
         No params.
     - name: MainArm7

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -49,6 +49,8 @@ arm9:
       description: |-
         The entrypoint for the ARM9 CPU. This is like the "main" function for the ARM9 subsystem.
         
+        Once the entry function reaches the end, a constant containing the address to NitroMain is loaded into a register (r1), and a `bx` branch will jump to NitroMain.
+
         No params.
     - name: MIiUncompressBackward
       address:

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -50,7 +50,7 @@ arm9:
         The entrypoint for the ARM9 CPU. This is like the "main" function for the ARM9 subsystem.
         
         Once the entry function reaches the end, a constant containing the address to NitroMain is loaded into a register (r1), and a `bx` branch will jump to NitroMain.
-
+        
         No params.
     - name: MIiUncompressBackward
       address:
@@ -942,7 +942,7 @@ arm9:
         Reads the contents of a file into the given buffer, and moves the file cursor accordingly.
         
         Data transfer mode must have been initialized (with DataTransferInit) prior to calling this function. This function looks like it's doing something akin to calling read(2) or fread(3) in a loop until all the bytes have been successfully read.
-
+        
         Note: If code is running from IRQ mode, it appears that FileRead hangs the game. When the processor mode is forced into SYSTEM mode FileRead once again works, so it appears that ROM access only works in certain processor modes. Note that forcing the processor into a different mode is generally a bad idea and should be avoided as it will easily corrupt that processor mode's states.
         
         r0: file_stream pointer


### PR DESCRIPTION
Note: I'd appreciate advice on how I should structure this! I've looked at how the ITCM documentation is done which I guess would be the closest parallel to this but how the addresses are documented I don't quite understand.

Changed the arm7 addresses to reflect addresses after the memory map inside of the entry function as these addresses are the ones used by function calls and accessing constants.

I'm not quite sure what to name these areas, but for now I have them named as ENTRY, WRAM, and SLOW.
ENTRY is the very small chunk of code used solely for mapping the memory.
WRAM is where a lot of important functions like the irq functions, the stdlib math functions, and the arm7 main event loop reside. (Interestingly the copy seems to copy partially into the Shared WRAM instead of just into the ARM7 only WRAM)
SLOW is named as such since its the rest of arm7 that couldn't possibly fit into the WRAM and so is placed in the main memory instead.

I haven't had a chance to take a closer look at the 0x27E0000 area since most of the code I've had to work with for arm7 patching has been within the 0x37F8000 area, but given that 0xF608 is just under 64kB which is the amount of WRAM reserved specifically for arm7 (see https://problemkaputt.de/gbatek.htm#dsmemorymaps), and the 0x27E0000 area has a much larger size than the WRAM area, I think this is a good hypothesis for now.

There were also some small changes I've made:
- **[arm7]** The DSE audio engine is entirely on the arm9 and does IPC with arm7 only as a way to get the audio chip to kick in, so in this way, the arm7 just handles audio I/O with the mitsumi MM3205B sound chip, setting a few registers when called. Apparently Nintendo didn't allow anyone to touch arm7 and add stuff to it? I've changed the note on the binary description to reflect this.
- **[arm7]** While working on arm7 patches, at one point, I found a need for a __divsi3 function, and so after some fuzzing I've found __divsi3, __udivsi3, and __udivsi3_no_zero_check on arm7. They worked as intended in the patch, and appears to be identical to the arm9 version as well bar a few constant accesses. It might be possible to extrapolate some more standard library functions from here.
- **[arm9]** In early versions of adpcm streaming, I had the decoder on arm7 ipc arm9 for new ADPCM chunks since only arm9 can read nitrofs files, but when arm7 called arm9, the call would go through but after all the read parameters had been calculated and once it was time to actually read the next block from the rom, it would freeze on FileRead (this is with or without calling DataTransferInit and DataTransferStop). I was confused for a while, but noticed that the irq handler runs in the irq processor mode, not the usual SYSTEM mode where FileReads are generally done. Lo-and-behold I could get FileRead to work once again by forcing cpsr into SYSTEM mode. This corrupts states of course and crashes the game after a few seconds, but the file read itself worked. So I'm not entirely sure why, but FileRead appears to only work in some processor mode, so I've added a note on that.