### PR TITLE
Fixed some incorrect addresses

### DIFF
--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -3657,7 +3657,7 @@ arm9:
     - name: PlayBgmByIdVeneer
       address:
         EU: 0x2017BF4
-        NA: 0x2017BD4
+        NA: 0x2017B58
       description: |-
         Likely a linker-generated veneer for PlayBgmById.
         
@@ -3667,7 +3667,7 @@ arm9:
     - name: PlayBgmByIdVolumeVeneer
       address:
         EU: 0x2017C00
-        NA: 0x2017BE0
+        NA: 0x2017B64
       description: |-
         Likely a linker-generated veneer for PlayBgmByIdVolume.
         
@@ -3688,7 +3688,7 @@ arm9:
     - name: PlayBgmById
       address:
         EU: 0x2017E90
-        NA: 0x2018024
+        NA: 0x2017DF4
       description: |-
         Initializes some values and then calls SendAudioCommand to play a BGM track.
         
@@ -3698,7 +3698,7 @@ arm9:
     - name: PlayBgmByIdVolume
       address:
         EU: 0x2017F0C
-        NA: 0x20180A0
+        NA: 0x2017E70
         JP: 0x2017EC8
       description: |-
         Initializes some values and then calls SendAudioCommand to play a BGM track.
@@ -8413,7 +8413,7 @@ arm9:
     - name: CheckTeamMemberIdx
       address:
         EU: 0x20565E0
-        NA: 0x2056228
+        NA: 0x2056264
         JP: 0x20565C4
       description: |-
         Checks if a team member's member index (team_member::member_idx) is equal to certain values.
@@ -12125,7 +12125,7 @@ arm9:
       description: "Irdkwia's notes: 26*0x4, uses MISSION_FLOOR_RANKS_AND_ITEM_LISTS"
     - name: UNOWN_SPECIES_ADDITIONAL_CHAR_PTR_TABLE
       address:
-        EU: 0x20B12F4
+        EU: 0x20B131C
         NA: 0x20B09D8
         JP: 0x20B224C
       length:

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -1428,7 +1428,7 @@ overlay10:
       description: "The default damage multiplier for SolarBeam, as a fixed-point number with 8 fraction bits (2)."
     - name: SKY_ATTACK_DAMAGE_MULTIPLIER
       address:
-        NA: 0x22C48B0
+        NA: 0x22C48A8
         JP: 0x22C5F90
       length:
         NA: 0x4

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -392,7 +392,7 @@ overlay11:
     - name: InitAnimDataFromOtherAnimDataVeneer
       address:
         EU: 0x22F78A8
-        NA: 0x22F6F0C
+        NA: 0x22F6F08
       description: |-
         Likely a linker-generated veneer for InitAnimDataFromOtherAnimData.
         

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -1986,7 +1986,7 @@ overlay29:
         r0: pointer to entity whose moves will be restored
     - name: CheckTeamMemberIdxVeneer
       address:
-        NA: 0x22F9C34
+        NA: 0x22F9C40
       description: |-
         Likely a linker-generated veneer for CheckTeamMemberIdx.
         
@@ -2466,7 +2466,7 @@ overlay29:
     - name: CannotStandOnTile
       address:
         EU: 0x23006C8
-        NA: 0x22FF764
+        NA: 0x22FFC9C
         JP: 0x2300B54
       description: |-
         Checks if a given monster cannot stand on a given tile.
@@ -2674,7 +2674,7 @@ overlay29:
     - name: CanMonsterMoveInDirection
       address:
         EU: 0x23018A4
-        NA: 0x230105C
+        NA: 0x2300E78
       description: |-
         Checks if the given monster can move in the specified direction
         
@@ -8842,7 +8842,7 @@ overlay29:
         Each entry is 2 bytes long.
     - name: FRACTIONAL_TURN_SEQUENCE
       address:
-        EU: 0x2352EC2
+        EU: 0x2352E90
         NA: 0x2352284
       length:
         EU: 0xFA

--- a/symbols/overlay30.yml
+++ b/symbols/overlay30.yml
@@ -16,7 +16,7 @@ overlay30:
     - name: WriteQuicksaveData
       address:
         EU: 0x2383868
-        NA: 0x2382C6C
+        NA: 0x2382C68
         JP: 0x2383EDC
       description: |-
         Function responsible for writing dungeon data when quicksaving.


### PR DESCRIPTION
While syncing NA and EU with the decomp, I ran into a number of incorrect addresses that conflicted between versions. I manually resolved each of these, attempting to favor the version that the original contributor used.