### PR TITLE
Fixed duplicate JP addresses

### DIFF
--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -11961,7 +11961,7 @@ arm9:
       address:
         EU: 0x20A1E28
         NA: 0x20A18A4
-        JP: 0x20A2C60
+        JP: 0x20A2C78
       length:
         EU: 0x4
         NA: 0x4

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -1313,7 +1313,7 @@ overlay10:
       address:
         EU: 0x22C5074
         NA: 0x22C471C
-        JP: 0x22C5E00
+        JP: 0x22C5E04
       length:
         NA: 0x4
         JP: 0x4


### PR DESCRIPTION
The following symbol addresses conflicted for JP. I inferred the fixed addresses based on the relative addresses of US/EU.
- `MIN_IQ_EXCLUSIVE_MOVE_USER` and `MIN_IQ_ITEM_MASTER` 
- `FACADE_DAMAGE_MULTIPLIER` and `IMPRISON_TURN_RANGE`