### PR TITLE
Support more naming conventions for symbol names

### DIFF
--- a/.github/workflows/check-symbols.yml
+++ b/.github/workflows/check-symbols.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Install resymgen
         uses: ./.github/actions/build-resymgen
       - name: Test
-        run: resymgen check --recursive --complete-version-list --explicit-versions --in-bounds-symbols --no-overlap --nonempty-maps --unique-symbols --data-names SCREAMING_SNAKE_CASE --function-names PascalCase --function-names snake_case symbols/*.yml
+        run: resymgen check --recursive --complete-version-list --explicit-versions --in-bounds-symbols --no-overlap --nonempty-maps --unique-symbols --data-names SCREAMING_SNAKE_CASE --function-names Pascal_Snake_Case --function-names snake_case symbols/*.yml

--- a/check_and_format.sh
+++ b/check_and_format.sh
@@ -9,6 +9,6 @@ make -C headers
 make -C headers format
 make -C headers symbol-check
 
-cargo run --release -- check -r -Vvbomu -d screaming_snake_case -f pascalcase -f snake_case symbols/*.yml
+cargo run --release -- check -r -Vvbomu -d screaming_snake_case -f pascal_snake_case -f snake_case symbols/*.yml
 cargo run --release -- fmt -r symbols/*.yml
 

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -56,7 +56,7 @@ impl NamingConvention {
                         return false;
                     }
                 }
-                if let Some(c) = name.chars().rev().next() {
+                if let Some(c) = name.chars().next_back() {
                     if c.is_whitespace() {
                         return false;
                     }

--- a/src/data_formats/symgen_yml/merge.rs
+++ b/src/data_formats/symgen_yml/merge.rs
@@ -500,9 +500,9 @@ impl SymbolManager {
             let i = imap.get(symbol_name).copied();
             self.0
                 .entry(subregion_path.clone())
-                .or_insert_with(HashMap::new)
+                .or_default()
                 .entry(block_name.to_owned())
-                .or_insert_with(HashMap::new)
+                .or_default()
                 .entry(*symbol_type)
                 .or_insert(imap);
             i

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,17 @@ fn int_format(write_as_decimal: bool) -> resymgen::IntFormat {
     }
 }
 
-const SUPPORTED_NAMING_CONVENTIONS: [&str; 5] = [
+const SUPPORTED_NAMING_CONVENTIONS: [&str; 10] = [
     "identifier",
     "snake_case",
     "SCREAMING_SNAKE_CASE",
     "camelCase",
     "PascalCase",
+    "camel_Snake_Case",
+    "underscoreSeparated_camelCase",
+    "Pascal_Snake_Case",
+    "flatcase",
+    "UPPERFLATCASE",
 ];
 
 // name is assumed to be in SUPPORTED_NAMING_CONVENTIONS (case-insensitive)
@@ -36,6 +41,11 @@ fn naming_convention(name: &str) -> resymgen::NamingConvention {
         "screaming_snake_case" => resymgen::NamingConvention::ScreamingSnakeCase,
         "camelcase" => resymgen::NamingConvention::CamelCase,
         "pascalcase" => resymgen::NamingConvention::PascalCase,
+        "camel_snake_case" => resymgen::NamingConvention::CamelSnakeCase,
+        "underscoreseparated_camelcase" => resymgen::NamingConvention::UnderscoreSeparatedCamelCase,
+        "pascal_snake_case" => resymgen::NamingConvention::PascalSnakeCase,
+        "flatcase" => resymgen::NamingConvention::FlatCase,
+        "upperflatcase" => resymgen::NamingConvention::UpperFlatCase,
         _ => panic!("Unsupported naming convention '{}'", name), // control should never reach this point
     }
 }

--- a/symbols/README.md
+++ b/symbols/README.md
@@ -123,7 +123,7 @@ Refer to the [`resymgen` README](../docs/resymgen.md#usage) for a general overvi
       git rm --cached -r .
       git reset --hard
       ```
-- Run the tests: `resymgen check -r -Vvbomu -d screaming_snake_case -f pascalcase -f snake_case <symbol files>`
+- Run the tests: `resymgen check -r -Vvbomu -d screaming_snake_case -f pascal_snake_case -f snake_case <symbol files>`
     - On Unix shells that support globbing (the `*` operator), you can use `*.yml` in place of `<symbol files>` to test everything in the directory.
     - If you're wondering what all the flags mean, see the help text (`resymgen check --help`).
 - Bulk-merge symbols from a CSV file into the symbol tables: `resymgen merge -x -f csv -v <version> -i <CSV file> <YAML symbol file>`


### PR DESCRIPTION
Some other sources use symbol names with hybrid naming conventions. Add support for a few more sensible conventions in `resymgen`, and loosen the restrictions for pmdsky-debug function names to include `Pascal_Snake_Case` (multiple underscore-delimited `PascalCase` parts).

Support for the following new naming conventions has been added to `resymgen` for general use:
- `camel_Snake_Case` (`camelCase_Then_PascalCase`)
- `underscoreSeparated_camelCase`
- `Pascal_Snake_Case` (`UnderscoreSeparated_PascalCase`)
- `flatcase`
- `UPPERFLATCASE`