### PR TITLE
Miscellaneous missed stuff from the last PR

### DIFF
--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -519,6 +519,7 @@ int NewWindowScreenCheck(struct window_params* params, uint8_t param_2);
 int NewWindow(struct window_params* params, uint8_t param_2);
 void SetScreenWindowsColor(int palette_idx, bool upper_screen);
 void SetBothScreensWindowsColor(int palette_idx);
+void UpdateWindow(int window_id);
 void ClearWindow(int window_id);
 void DeleteWindow(int window_id);
 void GetWindowRectangle(int window_id, struct window_rectangle* rect_out);

--- a/headers/types/common/window.h
+++ b/headers/types/common/window.h
@@ -10,7 +10,10 @@
 // These flags are shared with the function to display text inside windows
 // So they might need a rename once more information is found
 struct preprocessor_flags {
-    uint16_t flags_0 : 13;
+    bool timer_1 : 1; // Enabled when creating the play time string
+    uint16_t flags_1 : 9;
+    bool timer_2 : 1; // Enabled when creating the play time string
+    uint16_t flags_11 : 2;
     bool show_speaker : 1;
     uint16_t flags_14 : 2;
 };

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -1432,9 +1432,12 @@ enum top_screen_type {
 
 // Used in dungeon_fade to store what kind of fade a screen is currently in, if any.
 enum fade_status_dungeon {
+    DUNGEON_FADE_0x0 = 0,
     DUNGEON_FADE_NONE = 1,
     DUNGEON_FADE_IN = 2,
     DUNGEON_FADE_OUT = 3,
+    DUNGEON_FADE_0x4 = 4,
+    DUNGEON_FADE_0x5 = 5,
 };
 
 #endif

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -5008,6 +5008,15 @@ arm9:
         Sets the palette of the frames of windows in both screens
         
         r0: palette index
+    - name: UpdateWindow
+      address:
+        EU: 0x2027DE4
+      description: |-
+        Seems to cause updated window contents to be displayed.
+           
+        Gets called for example at the end of a text box window update and seems to "commit" the update, but in general also gets called with all kinds of window updates. 
+        
+        r0: window_id
     - name: ClearWindow
       address:
         EU: 0x2027E4C


### PR DESCRIPTION
- The function to update window contents was missing, even though it was referenced in a comment
- Added unknowns to `enum fade_status_dungeon`
- Added two bits to `struct preprocessor_flags`. Current only known purpose is that it's used when creating the play time string.