### PR TITLE
Make docstring preamble a regular comment instead of a doc comment

### DIFF
--- a/headers/add_header_docstrings.py
+++ b/headers/add_header_docstrings.py
@@ -92,7 +92,7 @@ class TextWrapFormatter(Formatter):
 
 
 class HeaderDocstringAdder:
-    PREAMBLE_LINE = "/// THIS DOCSTRING WAS GENERATED AUTOMATICALLY\n"
+    PREAMBLE_LINE = "// THIS DOCSTRING WAS GENERATED AUTOMATICALLY\n"
 
     def __init__(
         self, symbol_list: HeaderSymbolList, *, formatter: Optional[Formatter] = None


### PR DESCRIPTION
Ensures that these lines are excluded in some IDEs and doc generation tools.