### PR TITLE
Add aliases for relevant old symbol names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - check-headers
       - check-symbol-header-sync
     env:
-      RELEASE_VERSION: '0.9.0'
+      RELEASE_VERSION: '0.10.0'
       OUTPUT_DIR: out
       RELEASE_INSTALL_DIR: release-install
       RELEASE_ASSETS_DIR: release-assets

--- a/symbols/arm7.yml
+++ b/symbols/arm7.yml
@@ -236,6 +236,8 @@ arm7:
         
         return: cpsr & 0x1f (the cpsr mode bits M4-M0)
     - name: _s32_div_f
+      aliases:
+        - __divsi3
       address:
         EU: 0x238EDB0
         NA: 0x238EDB0
@@ -250,6 +252,8 @@ arm7:
         r1: divisor
         return: (quotient) | (remainder << 32)
     - name: _u32_div_f
+      aliases:
+        - __udivsi3
       address:
         EU: 0x238EFBC
         NA: 0x238EFBC
@@ -264,6 +268,8 @@ arm7:
         r1: divisor
         return: (quotient) | (remainder << 32)
     - name: _u32_div_not_0_f
+      aliases:
+        - __udivsi3_no_zero_check
       address:
         EU: 0x238EFC4
         NA: 0x238EFC4

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -10403,6 +10403,8 @@ arm9:
         
         type: enum item_id[4]
     - name: EXCLUSIVE_ITEM_STAT_BOOST_DATA
+      aliases:
+        - EXCLUSIVE_ITEM_ATTACK_BOOSTS
       address:
         EU: 0x209852C
         NA: 0x20980E8
@@ -10417,16 +10419,6 @@ arm9:
         Each 4-byte entry contains the boost data for (attack, defense, special attack, special defense), 1 byte each, for a specific exclusive item class, indexed according to the stat boost data index list.
         
         type: struct exclusive_item_stat_boost_entry[15]
-    - name: EXCLUSIVE_ITEM_ATTACK_BOOSTS
-      address:
-        EU: 0x209852C
-        NA: 0x20980E8
-        JP: 0x20983DC
-      length:
-        EU: 0x39
-        NA: 0x39
-        JP: 0x39
-      description: "EXCLUSIVE_ITEM_STAT_BOOST_DATA, offset by 0"
     - name: EXCLUSIVE_ITEM_DEFENSE_BOOSTS
       address:
         EU: 0x209852D

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -904,6 +904,8 @@ arm9:
         
         No params.
     - name: DataTransferInit
+      aliases:
+        - FileRom_InitDataTransfer
       address:
         EU: 0x2008168
         NA: 0x2008168
@@ -913,6 +915,8 @@ arm9:
         
         No params.
     - name: DataTransferStop
+      aliases:
+        - FileRom_StopDataTransfer
       address:
         EU: 0x2008194
         NA: 0x2008194
@@ -924,6 +928,8 @@ arm9:
         
         No params.
     - name: FileInitVeneer
+      aliases:
+        - FileRom_Veneer_FileInit
       address:
         EU: 0x2008204
         NA: 0x2008204
@@ -935,6 +941,8 @@ arm9:
         
         r0: file_stream pointer
     - name: FileOpen
+      aliases:
+        - FileRom_HandleOpen
       address:
         EU: 0x2008210
         NA: 0x2008210
@@ -955,6 +963,8 @@ arm9:
         r0: file_stream pointer
         return: file size
     - name: FileRead
+      aliases:
+        - FileRom_HandleRead
       address:
         EU: 0x2008254
         NA: 0x2008254
@@ -971,6 +981,8 @@ arm9:
         r2: number of bytes to read
         return: number of bytes read
     - name: FileSeek
+      aliases:
+        - FileRom_HandleSeek
       address:
         EU: 0x20082A8
         NA: 0x20082A8
@@ -1052,6 +1064,8 @@ arm9:
         r0: screen_fade
         return: int
     - name: InitDebug
+      aliases:
+        - Debug_Init
       address:
         EU: 0x200C15C
         NA: 0x200C0D4
@@ -1060,6 +1074,8 @@ arm9:
         Would have initialized debugging-related things, if they were not removed.
         As for the release version, does nothing but set DEBUG_IS_INITIALIZED to true.
     - name: InitDebugFlag
+      aliases:
+        - Debug_InitDebugFlag
       address:
         EU: 0x200C194
         NA: 0x200C10C
@@ -1068,6 +1084,8 @@ arm9:
         Would have initialized the debug flags.
         Does nothing in release binary.
     - name: GetDebugFlag
+      aliases:
+        - Debug_GetDebugFlag
       address:
         EU: 0x200C198
         NA: 0x200C110
@@ -1078,6 +1096,8 @@ arm9:
         r0: flag ID
         return: flag value
     - name: SetDebugFlag
+      aliases:
+        - Debug_SetDebugFlag
       address:
         EU: 0x200C1A0
         NA: 0x200C118
@@ -1088,6 +1108,8 @@ arm9:
         r0: flag ID
         r1: flag value
     - name: InitDebugStripped6
+      aliases:
+        - Debug_Stripped6
       address:
         EU: 0x200C1A4
         NA: 0x200C11C
@@ -1108,12 +1130,16 @@ arm9:
         r2: base message
         return: number of characters printed, excluding the null-terminator
     - name: InitDebugStripped5
+      aliases:
+        - Debug_Stripped5
       address:
         EU: 0x200C1F0
         NA: 0x200C168
         JP: 0x200C168
       description: "Does nothing, only called in the debug initialization function."
     - name: DebugPrintTrace
+      aliases:
+        - Debug_PrintTrace
       address:
         EU: 0x200C1F4
         NA: 0x200C16C
@@ -1142,6 +1168,8 @@ arm9:
         r0: format
         ...: variadic
     - name: DebugPrint0
+      aliases:
+        - Debug_Print0
       address:
         EU: 0x200C284
         NA: 0x200C1FC
@@ -1156,6 +1184,8 @@ arm9:
         r0: format
         ...: variadic
     - name: InitDebugLogFlag
+      aliases:
+        - Debug_InitLogFlag
       address:
         EU: 0x200C2B8
         NA: 0x200C230
@@ -1164,6 +1194,8 @@ arm9:
         Would have initialized the debug log flags.
         Does nothing in release binary.
     - name: GetDebugLogFlag
+      aliases:
+        - Debug_GetLogFlag
       address:
         EU: 0x200C2BC
         NA: 0x200C234
@@ -1174,6 +1206,8 @@ arm9:
         r0: flag ID
         return: flag value
     - name: SetDebugLogFlag
+      aliases:
+        - Debug_SetLogFlag
       address:
         EU: 0x200C2C4
         NA: 0x200C23C
@@ -1184,6 +1218,8 @@ arm9:
         r0: flag ID
         r1: flag value
     - name: DebugPrint
+      aliases:
+        - Debug_Print
       address:
         EU: 0x200C2C8
         NA: 0x200C240
@@ -1195,30 +1231,40 @@ arm9:
         r1: format
         ...: variadic
     - name: InitDebugStripped4
+      aliases:
+        - Debug_Stripped4
       address:
         EU: 0x200C2D4
         NA: 0x200C24C
         JP: 0x200C24C
       description: "Does nothing, only called in the debug initialization function."
     - name: InitDebugStripped3
+      aliases:
+        - Debug_Stripped3
       address:
         EU: 0x200C2D8
         NA: 0x200C250
         JP: 0x200C250
       description: "Does nothing, only called in the debug initialization function."
     - name: InitDebugStripped2
+      aliases:
+        - Debug_Stripped2
       address:
         EU: 0x200C2DC
         NA: 0x200C254
         JP: 0x200C254
       description: "Does nothing, only called in the debug initialization function."
     - name: InitDebugStripped1
+      aliases:
+        - Debug_Stripped1
       address:
         EU: 0x200C2E0
         NA: 0x200C258
         JP: 0x200C258
       description: "Does nothing, only called in the debug initialization function."
     - name: FatalError
+      aliases:
+        - Debug_FatalError
       address:
         EU: 0x200C2E4
         NA: 0x200C25C
@@ -1232,6 +1278,8 @@ arm9:
         r1: format
         ...: variadic
     - name: OpenAllPackFiles
+      aliases:
+        - DirectoryFileMngr_ExtractAllDirectoryFiles
       address:
         EU: 0x200C364
         NA: 0x200C2DC
@@ -1241,6 +1289,8 @@ arm9:
         
         No params.
     - name: GetFileLengthInPackWithPackNb
+      aliases:
+        - DirectoryFileMngr_GetDirectoryFileSize
       address:
         EU: 0x200C3C4
         NA: 0x200C33C
@@ -1252,6 +1302,8 @@ arm9:
         r1: file number
         return: size of the file in bytes from the Pack Table of Content
     - name: LoadFileInPackWithPackId
+      aliases:
+        - DirectoryFileMngr_LoadDirectoryFile
       address:
         EU: 0x200C3E4
         NA: 0x200C35C
@@ -1264,6 +1316,8 @@ arm9:
         r2: [output] target buffer
         return: number of read bytes (identical to the length of the pack from the Table of Content)
     - name: AllocAndLoadFileInPack
+      aliases:
+        - DirectoryFileMngr_OpenDirectoryFile
       address:
         EU: 0x200C410
         NA: 0x200C388
@@ -1277,6 +1331,8 @@ arm9:
         r2: [output] result struct (will contain length and pointer)
         r3: allocation flags
     - name: OpenPackFile
+      aliases:
+        - DirectoryFile_ExtractDirectoryFile
       address:
         EU: 0x200C468
         NA: 0x200C3E0
@@ -1287,6 +1343,8 @@ arm9:
         r0: [output] pack file struct
         r1: file name
     - name: GetFileLengthInPack
+      aliases:
+        - DirectoryFile_GetDirectoryFileSize
       address:
         EU: 0x200C4FC
         NA: 0x200C474
@@ -1298,6 +1356,8 @@ arm9:
         r1: file index
         return: size of the file in bytes from the Pack Table of Content
     - name: LoadFileInPack
+      aliases:
+        - DirectoryFile_LoadDirectoryFile
       address:
         EU: 0x200C50C
         NA: 0x200C484
@@ -12180,6 +12240,8 @@ arm9:
       length:
         NA: 0x1
     - name: PACK_FILES_OPENED
+      aliases:
+        - DIRECTORY_FILES_EXTRACTED
       address:
         EU: 0x20AFF54
         NA: 0x20AF69C
@@ -12191,6 +12253,8 @@ arm9:
         
         type: struct pack_file_opened*
     - name: PACK_FILE_PATHS_TABLE
+      aliases:
+        - DIRECTORY_FILE_TABLE
       address:
         EU: 0x20AFF58
         NA: 0x20AF6A0

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -1129,12 +1129,9 @@ arm9:
         r1: program position info (can be null)
     - name: DebugDisplay
       address:
-        EU:
-          - 0x200C250
-        NA:
-          - 0x200C1C8
-        JP:
-          - 0x200C1C8
+        EU: 0x200C250
+        NA: 0x200C1C8
+        JP: 0x200C1C8
       description: |-
         Would display a printf format string on the top screen in the debug binary.
         
@@ -1146,12 +1143,9 @@ arm9:
         ...: variadic
     - name: DebugPrint0
       address:
-        EU:
-          - 0x200C284
-        NA:
-          - 0x200C1FC
-        JP:
-          - 0x200C1FC
+        EU: 0x200C284
+        NA: 0x200C1FC
+        JP: 0x200C1FC
       description: |-
         Would log a printf format string in the debug binary.
         

--- a/symbols/arm9/libs.yml
+++ b/symbols/arm9/libs.yml
@@ -1471,6 +1471,8 @@ libs:
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
         
+        Analogous to __adddf3 in libgcc.
+        
         r0: a (low bits)
         r1: a (high bits)
         r2: b (low bits)
@@ -1482,6 +1484,8 @@ libs:
         NA: 0x208E1E0
       description: |-
         Implements the double to float cast operator for IEEE 754 floating-point numbers.
+        
+        Analogous to __truncdfsf2 in libgcc.
         
         r0: double (low bits)
         r1: double (high bits)
@@ -1495,6 +1499,8 @@ libs:
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
         
+        Analogous to __fixunsdfti in libgcc.
+        
         r0: double (low bits)
         r1: double (high bits)
         return: (unsigned long long)double
@@ -1507,6 +1513,8 @@ libs:
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
         
+        Analogous to __floatsidf in libgcc.
+        
         r0: int
         return: (double)int
     - name: _dfltu
@@ -1518,6 +1526,8 @@ libs:
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
         
+        Analogous to __floatunsidf in libgcc.
+        
         r0: uint
         return: (double)uint
     - name: _dmul
@@ -1528,6 +1538,8 @@ libs:
         Implements the multiplication operator for IEEE 754 double-precision floating-point numbers.
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
+        
+        Analogous to __muldf3 in libgcc.
         
         r0: a (low bits)
         r1: a (high bits)
@@ -1555,12 +1567,16 @@ libs:
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
         
+        Analogous to __subdf3 in libgcc.
+        
         r0: a (low bits)
         r1: a (high bits)
         r2: b (low bits)
         r3: b (high bits)
         return: a - b
     - name: _fadd
+      aliases:
+        - __addsf3
       address:
         EU: 0x208F050
         NA: 0x208ECB8
@@ -1644,6 +1660,8 @@ libs:
         r1: b
         return: a < b
     - name: _fdiv
+      aliases:
+        - __divsf3
       address:
         EU: 0x208F5CC
         NA: 0x208F234
@@ -1657,6 +1675,8 @@ libs:
         r1: divisor
         return: dividend / divisor
     - name: _f2d
+      aliases:
+        - __extendsfdf2
       address:
         EU: 0x208F984
         NA: 0x208F5EC
@@ -1671,6 +1691,8 @@ libs:
         r0: float
         return: (double)float
     - name: _ffix
+      aliases:
+        - __fixsfsi
       address:
         EU: 0x208FA08
         NA: 0x208F670
@@ -1683,6 +1705,8 @@ libs:
         r0: float
         return: (int)float
     - name: _fflt
+      aliases:
+        - __floatsisf
       address:
         EU: 0x208FA3C
         NA: 0x208F6A4
@@ -1695,6 +1719,8 @@ libs:
         r0: int
         return: (float)int
     - name: _ffltu
+      aliases:
+        - __floatunsisf
       address:
         EU: 0x208FA84
         NA: 0x208F6EC
@@ -1707,6 +1733,8 @@ libs:
         r0: uint
         return: (float)uint
     - name: _fmul
+      aliases:
+        - __mulsf3
       address:
         EU: 0x208FACC
         NA: 0x208F734
@@ -1730,6 +1758,8 @@ libs:
         r0: x
         return: sqrt(x)
     - name: _fsub
+      aliases:
+        - __subsf3
       address:
         EU: 0x208FD9C
         NA: 0x208FA04
@@ -1751,6 +1781,8 @@ libs:
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
         
+        Analogous to __modti3 in libgcc.
+        
         r0: dividend (low bits)
         r1: dividend (high bits)
         r2: divisor (low bits)
@@ -1764,6 +1796,8 @@ libs:
         Implements the division operator for signed long longs.
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
+        
+        Analogous to __divti3 in libgcc.
         
         r0: dividend (low bits)
         r1: dividend (high bits)
@@ -1779,6 +1813,8 @@ libs:
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
         
+        Analogous to __udivti3 in libgcc.
+        
         r0: dividend (low bits)
         r1: dividend (high bits)
         r2: divisor (low bits)
@@ -1792,6 +1828,8 @@ libs:
         Implements the modulus operator for unsigned long longs.
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
+        
+        Analogous to __umodti3 in libgcc.
         
         r0: dividend (low bits)
         r1: dividend (high bits)
@@ -1807,12 +1845,16 @@ libs:
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
         
+        Analogous to __multi3 in libgcc.
+        
         r0: a (low bits)
         r1: a (high bits)
         r2: b (low bits)
         r3: b (high bits)
         return: a * b
     - name: _s32_div_f
+      aliases:
+        - __divsi3
       address:
         EU: 0x209023C
         NA: 0x208FEA4
@@ -1828,6 +1870,8 @@ libs:
         r1: divisor
         return: (quotient) | (remainder << 32)
     - name: _u32_div_f
+      aliases:
+        - __udivsi3
       address:
         EU: 0x2090448
         NA: 0x20900B0
@@ -1844,6 +1888,8 @@ libs:
         r1: divisor
         return: (quotient) | (remainder << 32)
     - name: _u32_div_not_0_f
+      aliases:
+        - __udivsi3_no_zero_check
       address:
         EU: 0x2090450
         NA: 0x20900B8
@@ -1881,6 +1927,8 @@ libs:
         Implements the division operator for IEEE 754 double-precision floating-point numbers.
         
         The result is returned in r0 and r1, in accordance with the Procedure Call Standard for the Arm Architecture (see https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aapcs32/aapcs32.rst#result-return).
+        
+        Analogous to __divdf3 in libgcc.
         
         r0: dividend (low bits)
         r1: dividend (high bits)

--- a/tools/symcompat.py
+++ b/tools/symcompat.py
@@ -18,21 +18,21 @@ python3 symcompat.py HEAD~5 HEAD~2 -- </path/to/arm9.yml> </path/to/overlay29.ym
 
 import argparse
 from pathlib import Path
-from typing import Dict, Optional
+from typing import List, Optional
 
 import ansi
 import symdiff
 
 
-def get_symbols(table: symdiff.SymbolTable) -> Dict[str, symdiff.Symbol]:
+def get_symbols(table: symdiff.SymbolTable) -> List[str]:
     """Get all symbols in a given a SymbolTable, including aliases."""
-    return {
-        name: s
+    return [
+        name
         for block in table.blocks.values()
         for l in [block.functions, block.data]
         for s in l
         for name in [s.name] + s.aliases
-    }
+    ]
 
 
 def print_help_text():
@@ -64,8 +64,9 @@ def check_symbol_compatibility(
         return True
 
     old_symbols = get_symbols(old_table)
-    new_symbols = get_symbols(new_table)
-    removed_symbols = old_symbols.keys() - new_symbols.keys()
+    new_symbols_set = set(get_symbols(new_table))
+    # Maintain symbol order for reporting determinism
+    removed_symbols = [s for s in old_symbols if s not in new_symbols_set]
     if not removed_symbols:
         return True
 


### PR DESCRIPTION
Alias symbols with name changes in https://github.com/UsernameFodder/pmdsky-debug/pull/230 and https://github.com/UsernameFodder/pmdsky-debug/pull/236. Also collapse the weird `EXCLUSIVE_ITEM_ATTACK_BOOSTS` symbol into an alias.

Also includes miscellaneous fixes to `symcompat.py` and to `DebugDisplay` and `DebugPrint0`.