### PR TITLE
Replace GetSleepAnimationId with GetIdleAnimationId

### DIFF
--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -301,7 +301,9 @@ bool TryDecreaseLevel(struct entity* user, struct entity* target, int n_levels);
 bool LevelUp(struct entity* user, struct entity* target, bool message, bool dialogue);
 void GetMonsterMoves(struct move_id_16* out_moves, enum monster_id monster_id, int level);
 void EvolveMonster(struct entity* user, struct entity* target, enum monster_id new_monster_id);
-uint8_t GetSleepAnimationId(struct entity* entity);
+void ChangeMonsterAnimation(struct entity* monster, int8_t animation_id,
+                            enum direction_id direction);
+uint8_t GetIdleAnimationId(struct entity* entity);
 bool DisplayActions(struct entity* param_1);
 void CheckNonLeaderTile(struct entity* entity);
 bool EndNegativeStatusCondition(struct entity* user, struct entity* target, bool animation,

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -3186,8 +3186,6 @@ overlay29:
         r1: ID of the animation to set
         r2: Direction to turn the monster in, or DIR_NONE to keep the current direction
     - name: GetIdleAnimationId
-      aliases:
-        - GetSleepAnimationId
       address:
         EU: 0x23054E0
         NA: 0x2304AB4

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -3186,6 +3186,8 @@ overlay29:
         r1: ID of the animation to set
         r2: Direction to turn the monster in, or DIR_NONE to keep the current direction
     - name: GetIdleAnimationId
+      aliases:
+        - GetSleepAnimationId
       address:
         EU: 0x23054E0
         NA: 0x2304AB4

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -3173,15 +3173,27 @@ overlay29:
         r0: user entity pointer?
         r1: target pointer to the entity to evolve
         r2: Species to evolve into
-    - name: GetSleepAnimationId
+    - name: ChangeMonsterAnimation
+      address:
+        EU: 0x23053D4
+        NA: 0x23049A8
+      description: |-
+        Changes the animation a monster is currently playing. Optionally changes their direction as well.
+        
+        Does nothing if the provided entity is not a monster.
+        
+        r0: Entity pointer
+        r1: ID of the animation to set
+        r2: Direction to turn the monster in, or DIR_NONE to keep the current direction
+    - name: GetIdleAnimationId
       address:
         EU: 0x23054E0
         NA: 0x2304AB4
         JP: 0x2306004
       description: |-
-        Returns the animation id to be applied to a monster that has the sleep, napping, nightmare or bide status.
+        Returns the animation id to be applied to a monster that is currently idling.
         
-        Returns a different animation for sudowoodo and for monsters with infinite sleep turns (0x7F).
+        Returns a different animation for monsters with the sleep, napping, nightmare or bide status, as well as for sudowoodo and for monsters with infinite sleep turns (0x7F).
         
         r0: pointer to entity
         return: animation ID


### PR DESCRIPTION
Better documents `GetSleepAnimationId`, which is actually used to get the animation a monster should play while idling. The function has been renamed to `GetIdleAnimationId`.

Also documents `ChangeMonsterAnimation`.