### PR TITLE
Fix `ExecuteMonsterAction` return value

### DIFF
--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -237,7 +237,7 @@ uint16_t GetMaxHpAtLevel(enum monster_id monster_id, int level);
 uint8_t GetOffensiveStatAtLevel(enum monster_id monster_id, int level, int stat_idx);
 uint8_t GetDefensiveStatAtLevel(enum monster_id monster_id, int level, int stat_idx);
 void GetOutlawSpawnData(struct spawned_target_data* outlaw);
-void ExecuteMonsterAction(struct entity* monster);
+bool ExecuteMonsterAction(struct entity* monster);
 void TryActivateFlashFireOnAllMonsters(void);
 bool HasStatusThatPreventsActing(struct entity* monster);
 enum mobility_type GetMobilityTypeCheckSlip(enum monster_id species, bool walk_on_water);

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -2506,6 +2506,7 @@ overlay29:
         Executes the set action for the specified monster. Used for both AI actions and player-inputted actions. If the action is not ACTION_NOTHING, ACTION_PASS_TURN, ACTION_WALK or ACTION_UNK_4, the monster's already_acted field is set to true. Includes a switch based on the action ID that performs the action, although some of them aren't handled by said swtich.
         
         r0: Pointer to monster entity
+        return: If the result is true, the AI is run again for the current ally, and it performs another action. This can happen up to three times.
     - name: TryActivateFlashFireOnAllMonsters
       address:
         EU: 0x22FFB94


### PR DESCRIPTION
`ExecuteMonsterAction` is supposed to have a return value, which became apparent after trying to hook calls to this function via a wrapper with a `void` return type and watching every Pokémon attack three times in a row. The actual return value seems to be a `bool` because either 0 or 1 are moved into r0 before the function returns.