### PR TITLE
Add all non-RAM JP addresses

### DIFF
--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -34,16 +34,19 @@ arm9:
       address:
         EU: 0x20001A4
         NA: 0x2000566
+        JP: 0x2000154
       description: Software interrupt.
     - name: Svc_WaitByLoop
       address:
         EU: 0x20006B0
         NA: 0x2000088
+        JP: 0x200073A
       description: Software interrupt.
     - name: Svc_CpuSet
       address:
         EU: 0x200079E
         NA: 0x200078E
+        JP: 0x2000226
       description: Software interrupt.
     - name: _start
       address:
@@ -88,6 +91,7 @@ arm9:
       address:
         EU: 0x2000B9C
         NA: 0x2000B9C
+        JP: 0x2000B9C
       description: "Startup routine in the program's crt0 (https://en.wikipedia.org/wiki/Crt0)."
     - name: NitroMain
       address:
@@ -845,6 +849,9 @@ arm9:
           - 0x2005050
           - 0x20050B0
         NA:
+          - 0x2005050
+          - 0x20050B0
+        JP:
           - 0x2005050
           - 0x20050B0
       description: |-
@@ -1722,6 +1729,7 @@ arm9:
           - 0x2042DF4
           - 0x2052768
           - 0x2054D98
+          - 0x2060CD8
       description: |-
         Functionally the same as sprintf, just defined statically in many different places.
         
@@ -2035,6 +2043,7 @@ arm9:
       address:
         EU: 0x200EC74
         NA: 0x200EBCC
+        JP: 0x200EBFC
       description: |-
         Changes the currently active inventory to TEAM_MAIN.
         
@@ -2902,6 +2911,7 @@ arm9:
       address:
         EU: 0x2011628
         NA: 0x2011580
+        JP: 0x2011550
       description: |-
         Applies the hp boost from the Sitrus Berry to the target monster.
         
@@ -2912,6 +2922,7 @@ arm9:
       address:
         EU: 0x2011664
         NA: 0x20115BC
+        JP: 0x201158C
       description: |-
         Applies the hp boost from the Life Seed to the target monster.
         
@@ -3765,6 +3776,7 @@ arm9:
       address:
         EU: 0x2017BF4
         NA: 0x2017B58
+        JP: 0x2017BB0
       description: |-
         Likely a linker-generated veneer for PlayBgmById.
         
@@ -3775,6 +3787,7 @@ arm9:
       address:
         EU: 0x2017C00
         NA: 0x2017B64
+        JP: 0x2017BBC
       description: |-
         Likely a linker-generated veneer for PlayBgmByIdVolume.
         
@@ -4035,6 +4048,9 @@ arm9:
         NA:
           - 0x201C0B0
           - 0x201C0CC
+        JP:
+          - 0x201C108
+          - 0x201C124
       description: |-
         Initialize the animation_control structure, and set a certain value in a bitflag to 1
         
@@ -4745,6 +4761,7 @@ arm9:
       address:
         EU: 0x20237F4
         NA: 0x20235F8
+        JP: 0x2023648
       description: |-
         Likely a linker-generated veneer for StrcmpTag.
         
@@ -4757,6 +4774,7 @@ arm9:
       address:
         EU: 0x2023800
         NA: 0x2023604
+        JP: 0x2023654
       description: |-
         Likely a linker-generated veneer for AtoiTag.
         
@@ -4812,6 +4830,7 @@ arm9:
       address:
         EU: 0x20252A4
         NA: 0x2024FD8
+        JP: 0x2025028
       description: |-
         Returns a string containing some information to be used when displaying the dungeon results screen.
         
@@ -4910,6 +4929,7 @@ arm9:
       address:
         EU: 0x20255E0
         NA: 0x2025314
+        JP: 0x202536C
       description: |-
         A special version of strncpy for handling names. Appears to use character 0x7E as some kind of
         formatting character in NA? Copies at most n characters.
@@ -6495,6 +6515,9 @@ arm9:
         NA:
           - 0x2031AA4
           - 0x20329E4
+        JP:
+          - 0x2031DC4
+          - 0x2032D04
       description: |-
         Calculates the window height (divided by 8, as in struct window_params) of a menu, given its items and input flags.
         
@@ -6589,6 +6612,7 @@ arm9:
       address:
         EU: 0x203AA58
         NA: 0x203A75C
+        JP: 0x203AB68
       description: |-
         Gets the menu item text (member name) for a given team member for a team selection menu.
         
@@ -6649,6 +6673,7 @@ arm9:
       address:
         EU: 0x2048A74
         NA: 0x2048758
+        JP: 0x2048AC4
       description: |-
         Likely a linker-generated veneer for EventFlagBackup.
         
@@ -7554,6 +7579,7 @@ arm9:
       address:
         EU: 0x204FBC4
         NA: 0x204F88C
+        JP: 0x204FBE0
       description: |-
         Gets the level that should be used for outlaws for the given dungeon and floor
         
@@ -7563,6 +7589,7 @@ arm9:
       address:
         EU: 0x204FBE0
         NA: 0x204F8A8
+        JP: 0x204FBFC
       description: |-
         Gets the level that should be used for team leader outlaws for the given dungeon and floor. Identical to GetOutlawLevel.
         
@@ -7572,6 +7599,7 @@ arm9:
       address:
         EU: 0x204FBFC
         NA: 0x204F8C4
+        JP: 0x204FC18
       description: |-
         Gets the level that should be used for minion outlaws for the given dungeon and floor.
         
@@ -8023,6 +8051,7 @@ arm9:
       address:
         EU: 0x2050C9C
         NA: 0x2050964
+        JP: 0x2050CB0
       description: |-
         Determines which type a monster with Conversion2 should turn into after being hit by a certain
         type of move.
@@ -9483,7 +9512,7 @@ arm9:
       address:
         EU: 0x20565E0
         NA: 0x2056264
-        JP: 0x20565C4
+        JP: 0x2056600
       description: |-
         Checks if a team member's member index (team_member::member_idx) is equal to certain values.
         
@@ -9611,6 +9640,7 @@ arm9:
       address:
         EU: 0x2058F98
         NA: 0x2058C1C
+        JP: 0x2058F18
       description: |-
         Note: unverified, ported from Irdkwia's notes
         
@@ -9620,6 +9650,7 @@ arm9:
       address:
         EU: 0x2058FB8
         NA: 0x2058C3C
+        JP: 0x2058F38
       description: |-
         Returns whether or not the tactic involves following the team leader.
         
@@ -10481,6 +10512,7 @@ arm9:
       address:
         EU: 0x20917E0
         NA: 0x2091448
+        JP: 0x2091730
       length:
         NA: 0x1000
       description: |-
@@ -10504,90 +10536,105 @@ arm9:
       address:
         EU: 0x2094EF8
         NA: 0x2094AFC
+        JP: 0x2094DE4
       length:
         NA: 0x4
     - name: STRING_DEBUG_FORMAT_LINE_FILE
       address:
         EU: 0x2094EFC
         NA: 0x2094B00
+        JP: 0x2094DE8
       length:
         NA: 0x1C
     - name: STRING_DEBUG_NO_PROG_POS
       address:
         EU: 0x2094F18
         NA: 0x2094B1C
+        JP: 0x2094E04
       length:
         NA: 0x18
     - name: STRING_DEBUG_SPACED_PRINT
       address:
         EU: 0x2094F30
         NA: 0x2094B34
+        JP: 0x2094E1C
       length:
         NA: 0xC
     - name: STRING_DEBUG_FATAL
       address:
         EU: 0x2094F3C
         NA: 0x2094B40
+        JP: 0x2094E28
       length:
         NA: 0x14
     - name: STRING_DEBUG_NEWLINE
       address:
         EU: 0x2094F50
         NA: 0x2094B54
+        JP: 0x2094E3C
       length:
         NA: 0x4
     - name: STRING_DEBUG_LOG_NULL
       address:
         EU: 0x2094F54
         NA: 0x2094B58
+        JP: 0x2094E40
       length:
         NA: 0x8
     - name: STRING_DEBUG_STRING_NEWLINE
       address:
         EU: 0x2094F5C
         NA: 0x2094B60
+        JP: 0x2094E48
       length:
         NA: 0x4
     - name: STRING_EFFECT_EFFECT_BIN
       address:
         EU: 0x2094F60
         NA: 0x2094B64
+        JP: 0x2094E4C
       length:
         NA: 0x14
     - name: STRING_MONSTER_MONSTER_BIN
       address:
         EU: 0x2094F74
         NA: 0x2094B78
+        JP: 0x2094E60
       length:
         NA: 0x14
     - name: STRING_BALANCE_M_LEVEL_BIN
       address:
         EU: 0x2094F88
         NA: 0x2094B8C
+        JP: 0x2094E74
       length:
         NA: 0x14
     - name: STRING_DUNGEON_DUNGEON_BIN
       address:
         EU: 0x2094F9C
         NA: 0x2094BA0
+        JP: 0x2094E88
       length:
         NA: 0x14
     - name: STRING_MONSTER_M_ATTACK_BIN
       address:
         EU: 0x2094FB0
         NA: 0x2094BB4
+        JP: 0x2094E9C
       length:
         NA: 0x18
     - name: STRING_MONSTER_M_GROUND_BIN
       address:
         EU: 0x2094FC8
         NA: 0x2094BCC
+        JP: 0x2094EB4
       length:
         NA: 0x18
     - name: STRING_FILE_DIRECTORY_INIT
       address:
         EU: 0x2094FE0
         NA: 0x2094BE4
+        JP: 0x2094ECC
       length:
         NA: 0x28
     - name: AVAILABLE_ITEMS_IN_GROUP_TABLE
@@ -10709,6 +10756,7 @@ arm9:
       address:
         EU: 0x2098569
         NA: 0x2098125
+        JP: 0x2098419
       length:
         EU: 0x777
         NA: 0x777
@@ -10790,6 +10838,7 @@ arm9:
       address:
         EU: 0x209B3CC
         NA: 0x209AE90
+        JP: 0x209B7E4
       length:
         NA: 0x10
       description: |-
@@ -10802,6 +10851,7 @@ arm9:
       address:
         EU: 0x209B3DC
         NA: 0x209AEA0
+        JP: 0x209B7F4
       length:
         NA: 0x10
       description: |-
@@ -10814,6 +10864,7 @@ arm9:
       address:
         EU: 0x209B3EC
         NA: 0x209AEB0
+        JP: 0x209B804
       length:
         NA: 0x10
       description: |-
@@ -10826,6 +10877,7 @@ arm9:
       address:
         EU: 0x209B3FC
         NA: 0x209AEC0
+        JP: 0x209B814
       length:
         NA: 0x10
       description: |-
@@ -10838,6 +10890,7 @@ arm9:
       address:
         EU: 0x209B40C
         NA: 0x209AED0
+        JP: 0x209B824
       length:
         NA: 0x10
       description: |-
@@ -10850,6 +10903,7 @@ arm9:
       address:
         EU: 0x209B448
         NA: 0x209AF0C
+        JP: 0x209B860
       length:
         NA: 0x10
       description: |-
@@ -10862,6 +10916,7 @@ arm9:
       address:
         EU: 0x209B458
         NA: 0x209AF1C
+        JP: 0x209B870
       length:
         NA: 0x10
       description: Default window_params for a scroll_box.
@@ -10869,6 +10924,7 @@ arm9:
       address:
         EU: 0x209B468
         NA: 0x209AF2C
+        JP: 0x209B880
       length:
         NA: 0x10
       description: Default window_params for a dialogue_box.
@@ -10876,6 +10932,7 @@ arm9:
       address:
         EU: 0x209B478
         NA: 0x209AF3C
+        JP: 0x209B890
       length:
         NA: 0x10
       description: |-
@@ -10886,6 +10943,7 @@ arm9:
       address:
         EU: 0x209B488
         NA: 0x209AF4C
+        JP: 0x209B8A0
       length:
         NA: 0x10
       description: Default window_params for a text_box.
@@ -10893,6 +10951,7 @@ arm9:
       address:
         EU: 0x209B498
         NA: 0x209AF5C
+        JP: 0x209B8B0
       length:
         NA: 0x10
       description: |-
@@ -10905,6 +10964,7 @@ arm9:
       address:
         EU: 0x209B4B4
         NA: 0x209AF78
+        JP: 0x209B8CC
       length:
         NA: 0x10
       description: Default window_params for a controls_chart.
@@ -10912,6 +10972,7 @@ arm9:
       address:
         EU: 0x209B4D0
         NA: 0x209AF94
+        JP: 0x209B8E8
       length:
         NA: 0x10
       description: Default window_params for an alert_box.
@@ -10919,6 +10980,7 @@ arm9:
       address:
         EU: 0x209B4E0
         NA: 0x209AFA4
+        JP: 0x209B8F8
       length:
         NA: 0x10
       description: |-
@@ -10929,6 +10991,7 @@ arm9:
       address:
         EU: 0x209B4F0
         NA: 0x209AFB4
+        JP: 0x209B908
       length:
         NA: 0x10
       description: |-
@@ -10997,6 +11060,7 @@ arm9:
       address:
         EU: 0x209E658
         NA: 0x209E0D4
+        JP: 0x209F4A8
       length:
         NA: 0x14
       description: |-
@@ -11817,7 +11881,7 @@ arm9:
       address:
         EU: 0x20A416C
         NA: 0x20A3B6C
-        JP: 0x20A4F50
+        JP: 0x20A4F60
       length:
         EU: 0x30
         NA: 0x30
@@ -11827,7 +11891,7 @@ arm9:
       address:
         EU: 0x20A419C
         NA: 0x20A3B9C
-        JP: 0x20A4F80
+        JP: 0x20A4F50
       length:
         EU: 0x10
         NA: 0x10
@@ -12258,6 +12322,7 @@ arm9:
       address:
         EU: 0x20AA840
         NA: 0x20A9FA0
+        JP: 0x20AB3E8
       length:
         EU: 0x10
         NA: 0x10
@@ -12293,6 +12358,7 @@ arm9:
       address:
         EU: 0x20AE954
         NA: 0x20AE0B4
+        JP: 0x20AF4FC
       length:
         EU: 0x10
         NA: 0x10
@@ -12300,6 +12366,7 @@ arm9:
       address:
         EU: 0x20AE964
         NA: 0x20AE0C4
+        JP: 0x20AF50C
       length:
         EU: 0x60
         NA: 0x60
@@ -12320,6 +12387,7 @@ arm9:
       address:
         EU: 0x20AF7A0
         NA: 0x20AEF00
+        JP: 0x20B0340
       length:
         EU: 0x8
         NA: 0x8
@@ -12341,6 +12409,7 @@ arm9:
       address:
         EU: 0x20AFAD0
         NA: 0x20AF230
+        JP: 0x20B0670
       length:
         EU: 0x4
         NA: 0x4
@@ -12418,6 +12487,7 @@ arm9:
       address:
         EU: 0x20AFF50
         NA: 0x20AF698
+        JP: 0x20B0AD8
       length:
         NA: 0x1
     - name: PACK_FILES_OPENED
@@ -12470,6 +12540,7 @@ arm9:
       address:
         EU: 0x20AFF78
         NA: 0x20AF6C0
+        JP: 0x20B0B00
       length:
         EU: 0xC
         NA: 0xC
@@ -12481,6 +12552,7 @@ arm9:
       address:
         EU: 0x20AFFA8
         NA: 0x20AF6DC
+        JP: 0x20B0B1C
       description: "[Runtime] Seems to be some sort of region (a table of tables?) that holds pointers to various important tables related to moves."
     - name: MOVE_DATA_TABLE_PTR
       address:
@@ -12497,6 +12569,7 @@ arm9:
       address:
         EU: 0x20B0524
         NA: 0x20AFC68
+        JP: 0x20B10A8
       length:
         NA: 0x4
       description: |-
@@ -12507,6 +12580,7 @@ arm9:
       address:
         EU: 0x20B0540
         NA: 0x20AFC80
+        JP: 0x20B10C0
       length:
         EU: 0x44
         NA: 0x44
@@ -12518,6 +12592,7 @@ arm9:
       address:
         EU: 0x20B0584
         NA: 0x20AFCC4
+        JP: 0x20B1104
       length:
         EU: 0x20
         NA: 0x20
@@ -12613,6 +12688,7 @@ arm9:
       address:
         EU: 0x20B0890
         NA: 0x20AFF74
+        JP: 0x20B17E8
       length:
         EU: 0x4
         NA: 0x4
@@ -12768,6 +12844,7 @@ arm9:
       address:
         EU: 0x20B14D4
         NA: 0x20B0B90
+        JP: 0x20B2404
       length:
         EU: 0x1FC
         NA: 0x1FC
@@ -12805,6 +12882,7 @@ arm9:
       address:
         EU: 0x20B1B94
         NA: 0x20B1250
+        JP: 0x20B2AC4
       length:
         EU: 0x40
         NA: 0x40
@@ -12812,6 +12890,7 @@ arm9:
       address:
         EU: 0x20B34D8
         NA: 0x20B2B94
+        JP: 0x20B4408
       length:
         EU: 0x1
         NA: 0x1
@@ -12819,6 +12898,7 @@ arm9:
       address:
         EU: 0x20B34DC
         NA: 0x20B2B98
+        JP: 0x20B440C
       length:
         EU: 0x4
         NA: 0x4

--- a/symbols/arm9/libs.yml
+++ b/symbols/arm9/libs.yml
@@ -78,6 +78,7 @@ libs:
       address:
         EU: 0x206CD40
         NA: 0x206C9A8
+        JP: 0x206CC90
     - name: DseMem_Allocate
       address:
         EU: 0x206CD54
@@ -1384,26 +1385,32 @@ libs:
       address:
         EU: 0x2077494
         NA: 0x20770FC
+        JP: 0x20773E4
     - name: GX_ResetBankForObjExtPltt
       address:
         EU: 0x20774B8
         NA: 0x2077120
+        JP: 0x2077408
     - name: GX_ResetBankForTex
       address:
         EU: 0x20774DC
         NA: 0x2077144
+        JP: 0x207742C
     - name: GX_ResetBankForTexPltt
       address:
         EU: 0x20774F0
         NA: 0x2077158
+        JP: 0x2077440
     - name: GX_ResetBankForSubBgExtPltt
       address:
         EU: 0x2077504
         NA: 0x207716C
+        JP: 0x2077454
     - name: GX_ResetBankForSubObjExtPltt
       address:
         EU: 0x207752C
         NA: 0x2077194
+        JP: 0x207747C
     - name: DisableBankForX
       address:
         EU: 0x2077554
@@ -1413,54 +1420,67 @@ libs:
       address:
         EU: 0x2077634
         NA: 0x207729C
+        JP: 0x2077584
     - name: GX_DisableBankForObj
       address:
         EU: 0x2077648
         NA: 0x20772B0
+        JP: 0x2077598
     - name: GX_DisableBankForBgExtPltt
       address:
         EU: 0x207765C
         NA: 0x20772C4
+        JP: 0x20775AC
     - name: GX_DisableBankForObjExtPltt
       address:
         EU: 0x2077680
         NA: 0x20772E8
+        JP: 0x20775D0
     - name: GX_DisableBankForTex
       address:
         EU: 0x20776A4
         NA: 0x207730C
+        JP: 0x20775F4
     - name: GX_DisableBankForTexPltt
       address:
         EU: 0x20776B8
         NA: 0x2077320
+        JP: 0x2077608
     - name: GX_DisableBankForClearImage
       address:
         EU: 0x20776CC
         NA: 0x2077334
+        JP: 0x207761C
     - name: GX_DisableBankForArm7
       address:
         EU: 0x20776E0
         NA: 0x2077348
+        JP: 0x2077630
     - name: GX_DisableBankForLcdc
       address:
         EU: 0x20776F4
         NA: 0x207735C
+        JP: 0x2077644
     - name: GX_DisableBankForSubBg
       address:
         EU: 0x2077708
         NA: 0x2077370
+        JP: 0x2077658
     - name: GX_DisableBankForSubObj
       address:
         EU: 0x207771C
         NA: 0x2077384
+        JP: 0x207766C
     - name: GX_DisableBankForSubBgExtPltt
       address:
         EU: 0x2077730
         NA: 0x2077398
+        JP: 0x2077680
     - name: GX_DisableBankForSubObjExtPltt
       address:
         EU: 0x2077758
         NA: 0x20773C0
+        JP: 0x20776A8
     - name: G2_GetBG0ScrPtr
       address:
         EU: 0x2077780
@@ -1667,46 +1687,57 @@ libs:
       address:
         EU: 0x2078348
         NA: 0x2077FB0
+        JP: 0x2078298
     - name: GX_LoadBg1Scr
       address:
         EU: 0x20783A8
         NA: 0x2078010
+        JP: 0x20782F8
     - name: Gxs_LoadBg1Scr
       address:
         EU: 0x2078408
         NA: 0x2078070
+        JP: 0x2078358
     - name: GX_LoadBg2Scr
       address:
         EU: 0x2078468
         NA: 0x20780D0
+        JP: 0x20783B8
     - name: GX_LoadBg3Scr
       address:
         EU: 0x20784C8
         NA: 0x2078130
+        JP: 0x2078418
     - name: GX_LoadBg0Char
       address:
         EU: 0x2078528
         NA: 0x2078190
+        JP: 0x2078478
     - name: Gxs_LoadBg0Char
       address:
         EU: 0x2078588
         NA: 0x20781F0
+        JP: 0x20784D8
     - name: GX_LoadBg1Char
       address:
         EU: 0x20785E8
         NA: 0x2078250
+        JP: 0x2078538
     - name: Gxs_LoadBg1Char
       address:
         EU: 0x2078648
         NA: 0x20782B0
+        JP: 0x2078598
     - name: GX_LoadBg2Char
       address:
         EU: 0x20786A8
         NA: 0x2078310
+        JP: 0x20785F8
     - name: GX_LoadBg3Char
       address:
         EU: 0x2078708
         NA: 0x2078370
+        JP: 0x2078658
     - name: GX_BeginLoadBgExtPltt
       address:
         EU: 0x2078768

--- a/symbols/overlay01.yml
+++ b/symbols/overlay01.yml
@@ -57,6 +57,7 @@ overlay1:
       address:
         EU: 0x23336D8
         NA: 0x2332EF4
+        JP: 0x23346A4
       description: |-
         Fetches the required data and creates all the strings to display the contents shown in the window
         when choosing continue in the main menu.
@@ -67,6 +68,7 @@ overlay1:
       address:
         EU: 0x233B878
         NA: 0x233B12C
+        JP: 0x233C9AC
       length:
         EU: 0x1E8
         NA: 0x1E8
@@ -75,6 +77,7 @@ overlay1:
       address:
         EU: 0x233BA60
         NA: 0x233B314
+        JP: 0x233CB94
       length:
         EU: 0x1F0
         NA: 0x1F0
@@ -86,6 +89,7 @@ overlay1:
       address:
         EU: 0x233BC64
         NA: 0x233B518
+        JP: 0x233CD98
       length:
         EU: 0x10
         NA: 0x10
@@ -94,6 +98,7 @@ overlay1:
       address:
         EU: 0x233BC74
         NA: 0x233B528
+        JP: 0x233CDA8
       length:
         EU: 0x10
         NA: 0x10
@@ -102,6 +107,7 @@ overlay1:
       address:
         EU: 0x233BC84
         NA: 0x233B538
+        JP: 0x233CDB8
       length:
         EU: 0x10
         NA: 0x10
@@ -110,6 +116,7 @@ overlay1:
       address:
         EU: 0x233BC94
         NA: 0x233B548
+        JP: 0x233CDC8
       length:
         EU: 0x10
         NA: 0x10
@@ -145,6 +152,7 @@ overlay1:
       address:
         EU: 0x233BE68
         NA: 0x233B71C
+        JP: 0x233CF94
       length:
         EU: 0x10
         NA: 0x10
@@ -153,6 +161,7 @@ overlay1:
       address:
         EU: 0x233BE78
         NA: 0x233B72C
+        JP: 0x233CFA4
       length:
         EU: 0x10
         NA: 0x10
@@ -161,6 +170,7 @@ overlay1:
       address:
         EU: 0x233BE88
         NA: 0x233B73C
+        JP: 0x233CFB4
       length:
         EU: 0x10
         NA: 0x10
@@ -169,6 +179,7 @@ overlay1:
       address:
         EU: 0x233BE98
         NA: 0x233B74C
+        JP: 0x233CFC4
       length:
         EU: 0x18
         NA: 0x18
@@ -176,6 +187,7 @@ overlay1:
       address:
         EU: 0x233BF1C
         NA: 0x233B7D0
+        JP: 0x233D048
       length:
         EU: 0x10
         NA: 0x10
@@ -184,6 +196,7 @@ overlay1:
       address:
         EU: 0x233BF3C
         NA: 0x233B7F0
+        JP: 0x233D068
       length:
         EU: 0x10
         NA: 0x10
@@ -201,6 +214,7 @@ overlay1:
       address:
         EU: 0x233BFBC
         NA: 0x233B870
+        JP: 0x233D0E8
       length:
         EU: 0x10
         NA: 0x10

--- a/symbols/overlay09.yml
+++ b/symbols/overlay09.yml
@@ -163,6 +163,7 @@ overlay9:
       address:
         EU: 0x233FF1C
         NA: 0x233F794
+        JP: 0x2340FC0
       length:
         NA: 0x10
       description: |-
@@ -175,6 +176,7 @@ overlay9:
       address:
         EU: 0x233FF2C
         NA: 0x233F7A4
+        JP: 0x2340FD0
       length:
         NA: 0x10
       description: |-
@@ -187,6 +189,7 @@ overlay9:
       address:
         EU: 0x233FF3C
         NA: 0x233F7B4
+        JP: 0x2340FE0
       length:
         NA: 0x10
       description: Default window_params for an input_lock_box.

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -122,6 +122,9 @@ overlay10:
         NA:
           - 0x22BD44C
           - 0x22C183C
+        JP:
+          - 0x22BEBEC
+          - 0x22C2FA8
       description: |-
         Statically defined copy of sprintf(3) in overlay 10. See arm9.yml for more information.
         
@@ -203,7 +206,7 @@ overlay10:
       address:
         EU: 0x22C0844
         NA: 0x22BFF04
-        JP: 0x22C16A4
+        JP: 0x22C16A8
       description: |-
         Note: unverified, ported from Irdkwia's notes
         
@@ -223,6 +226,7 @@ overlay10:
       address:
         EU: 0x22C1328
         NA: 0x22C09E8
+        JP: 0x22C218C
       description: |-
         Handles creating the windows, sprites, etc. for the team stats top screen display.
         
@@ -264,6 +268,7 @@ overlay10:
       address:
         EU: 0x22C2094
         NA: 0x22C1748
+        JP: 0x22C2E9C
       description: |-
         Appears to populate the Lv./HP row in the "Team stats" top screen.
         
@@ -272,6 +277,7 @@ overlay10:
       address:
         EU: 0x22C21BC
         NA: 0x22C1864
+        JP: 0x22C2FD0
       description: |-
         Appears to populate the name/gender row in the "Team stats" top screen.
         
@@ -318,6 +324,7 @@ overlay10:
       address:
         EU: 0x22C4CEC
         NA: 0x22C4394
+        JP: 0x22C5A7C
       length:
         NA: 0x10
       description: |-
@@ -603,6 +610,7 @@ overlay10:
       address:
         EU: 0x22C4E2C
         NA: 0x22C44D4
+        JP: 0x22C5BBC
       length:
         NA: 0x2
       description: Damage dealt by the burn status condition.
@@ -610,6 +618,7 @@ overlay10:
       address:
         EU: 0x22C4E30
         NA: 0x22C44D8
+        JP: 0x22C5BC0
       length:
         NA: 0x2
       description: Damage dealt by the poison status condition.
@@ -827,6 +836,7 @@ overlay10:
       address:
         EU: 0x22C4ED0
         NA: 0x22C4578
+        JP: 0x22C5C60
       length:
         NA: 0x2
       description: The passive bonus health regen given when the weather is rain for the abilities rain dish and dry skin.
@@ -834,6 +844,7 @@ overlay10:
       address:
         EU: 0x22C4EE0
         NA: 0x22C4588
+        JP: 0x22C5C70
       length:
         NA: 0x2
       description: The amount of health drained by leech seed status.
@@ -974,6 +985,7 @@ overlay10:
       address:
         EU: 0x22C4F88
         NA: 0x22C4630
+        JP: 0x22C5D18
       length:
         EU: 0x2
       description: The passive bonus health regen given when the weather is hail for the ability ice body.
@@ -1018,6 +1030,7 @@ overlay10:
       address:
         EU: 0x22C4FAC
         NA: 0x22C4654
+        JP: 0x22C5D3C
       length:
         NA: 0x2
       description: "The number of turns the moves rain dance, hail, sandstorm, sunny day and defog change the weather for. (3000)"
@@ -1166,6 +1179,7 @@ overlay10:
       address:
         EU: 0x22C5004
         NA: 0x22C46AC
+        JP: 0x22C5D94
       length:
         NA: 0x2
       description: The number of turns between leech seed health drain.
@@ -1173,6 +1187,7 @@ overlay10:
       address:
         EU: 0x22C5008
         NA: 0x22C46B0
+        JP: 0x22C5D98
       length:
         EU: 0x2
         NA: 0x2
@@ -1252,6 +1267,7 @@ overlay10:
       address:
         EU: 0x22C5028
         NA: 0x22C46D0
+        JP: 0x22C5DB8
       length:
         NA: 0x2
       description: The passive bonus regen given by the wish status condition.
@@ -1336,7 +1352,7 @@ overlay10:
       address:
         EU: 0x22C5068
         NA: 0x22C4710
-        JP: 0x22C5DE8
+        JP: 0x22C5DF8
       length:
         NA: 0x4
         JP: 0x4
@@ -1424,6 +1440,7 @@ overlay10:
       address:
         EU: 0x22C50B0
         NA: 0x22C4758
+        JP: 0x22C5E40
       length:
         NA: 0x4
       description: "The damage multiplier corresponding to MATCHUP_IMMUNE, as a fixed-point number with 8 fraction bits (0.5)."
@@ -1837,6 +1854,7 @@ overlay10:
       address:
         EU: 0x22C54CC
         NA: 0x22C4B74
+        JP: 0x22C625C
       length:
         EU: 0x48
         NA: 0x48

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -427,6 +427,7 @@ overlay11:
       address:
         EU: 0x22F78A8
         NA: 0x22F6F08
+        JP: 0x22F858C
       description: |-
         Likely a linker-generated veneer for InitAnimDataFromOtherAnimData.
         
@@ -442,6 +443,9 @@ overlay11:
         NA:
           - 0x22F6F14
           - 0x22F7064
+        JP:
+          - 0x22F8598
+          - 0x22F86E8
       description: |-
         Does more stuff related to animations...probably?
         
@@ -696,6 +700,7 @@ overlay11:
       address:
         EU: 0x23174B8
         NA: 0x2316AD8
+        JP: 0x231803C
       length:
         NA: 0x20
       description: Used by ScriptCommandParsing somehow
@@ -703,6 +708,7 @@ overlay11:
       address:
         EU: 0x23174D8
         NA: 0x2316AF8
+        JP: 0x231805C
       length:
         NA: 0x1B18
       description: "Opcode name strings pointed to by entries in SCRIPT_OP_CODES (script_opcode::name)"
@@ -725,6 +731,7 @@ overlay11:
       address:
         EU: 0x2319BE8
         NA: 0x2319208
+        JP: 0x231A76C
       length:
         NA: 0x8E4
       description: Strings used with various debug printing functions throughout the overlay
@@ -732,6 +739,7 @@ overlay11:
       address:
         EU: 0x231A4CC
         NA: 0x2319AEC
+        JP: 0x231B050
       length:
         NA: 0x2D3C
       description: "Common routine name strings pointed to by entries in C_ROUTINES (common_routine::name)"
@@ -753,6 +761,7 @@ overlay11:
       address:
         EU: 0x231E7F0
         NA: 0x231DE10
+        JP: 0x231F374
       length:
         NA: 0x30
       description: |-
@@ -763,6 +772,7 @@ overlay11:
       address:
         EU: 0x231E820
         NA: 0x231DE40
+        JP: 0x231F3A4
       length:
         EU: 0x10BC
         NA: 0x1014
@@ -841,6 +851,7 @@ overlay11:
       address:
         EU: 0x23223FC
         NA: 0x23218CC
+        JP: 0x2322E30
       length:
         EU: 0xA8
         NA: 0xA8
@@ -852,6 +863,7 @@ overlay11:
       address:
         EU: 0x2322F8C
         NA: 0x232245C
+        JP: 0x23239C0
       length:
         NA: 0x10
       description: Default window_params for a team_info_box.
@@ -859,6 +871,7 @@ overlay11:
       address:
         EU: 0x2323B9C
         NA: 0x232306C
+        JP: 0x23245E8
       length:
         EU: 0x150
         NA: 0x150
@@ -905,6 +918,7 @@ overlay11:
       address:
         EU: 0x2325924
         NA: 0x2324DE4
+        JP: 0x2326344
       length:
         EU: 0x4
         NA: 0x4

--- a/symbols/overlay13.yml
+++ b/symbols/overlay13.yml
@@ -260,7 +260,7 @@ overlay13:
       address:
         EU: 0x238D9E0
         NA: 0x238CEA0
-        JP: 0x238E408
+        JP: 0x238E400
       length:
         EU: 0x4
         NA: 0x4
@@ -270,7 +270,7 @@ overlay13:
       address:
         EU: 0x238D9E4
         NA: 0x238CEA4
-        JP: 0x238E40C
+        JP: 0x238E404
       length:
         EU: 0x4
         NA: 0x4
@@ -290,7 +290,7 @@ overlay13:
       address:
         EU: 0x238D9EC
         NA: 0x238CEAC
-        JP: 0x238E414
+        JP: 0x238E40C
       length:
         EU: 0x10
         NA: 0x10
@@ -300,7 +300,7 @@ overlay13:
       address:
         EU: 0x238D9FC
         NA: 0x238CEBC
-        JP: 0x238E424
+        JP: 0x238E41C
       length:
         EU: 0x10
         NA: 0x10
@@ -310,7 +310,7 @@ overlay13:
       address:
         EU: 0x238DA0C
         NA: 0x238CECC
-        JP: 0x238E434
+        JP: 0x238E42C
       length:
         EU: 0x48
         NA: 0x48
@@ -330,7 +330,7 @@ overlay13:
       address:
         EU: 0x238DA64
         NA: 0x238CF24
-        JP: 0x238E48C
+        JP: 0x238E484
       length:
         EU: 0x84
         NA: 0x84

--- a/symbols/overlay14.yml
+++ b/symbols/overlay14.yml
@@ -97,6 +97,7 @@ overlay14:
       address:
         EU: 0x238CF14
         NA: 0x238C3D4
+        JP: 0x238D93C
       description: |-
         State 0x5: Exit (wraps SentrySetExitingState).
         
@@ -500,6 +501,7 @@ overlay14:
       address:
         EU: 0x238E720
         NA: 0x238DB80
+        JP: 0x238F0E0
       length:
         NA: 0x4
       description: Pointer to the SENTRY_DUTY_STRUCT.
@@ -507,6 +509,7 @@ overlay14:
       address:
         EU: 0x238E734
         NA: 0x238DB94
+        JP: 0x238F0F4
       length:
         NA: 0x8C
       description: |-

--- a/symbols/overlay15.yml
+++ b/symbols/overlay15.yml
@@ -33,6 +33,7 @@ overlay15:
       address:
         EU: 0x238BBF8
         NA: 0x238B08C
+        JP: 0x238C604
       length:
         EU: 0x10
         NA: 0x10
@@ -41,6 +42,7 @@ overlay15:
       address:
         EU: 0x238BC08
         NA: 0x238B09C
+        JP: 0x238C614
       length:
         EU: 0x10
         NA: 0x10
@@ -49,6 +51,7 @@ overlay15:
       address:
         EU: 0x238BC18
         NA: 0x238B0AC
+        JP: 0x238C624
       length:
         EU: 0x10
         NA: 0x10
@@ -69,6 +72,7 @@ overlay15:
       address:
         EU: 0x238BCE0
         NA: 0x238B180
+        JP: 0x238C6E0
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay16.yml
+++ b/symbols/overlay16.yml
@@ -72,6 +72,7 @@ overlay16:
       address:
         EU: 0x238D908
         NA: 0x238CDC4
+        JP: 0x238E344
       length:
         EU: 0x10
         NA: 0x10
@@ -80,6 +81,7 @@ overlay16:
       address:
         EU: 0x238D918
         NA: 0x238CDD4
+        JP: 0x238E354
       length:
         EU: 0x10
         NA: 0x10
@@ -88,6 +90,7 @@ overlay16:
       address:
         EU: 0x238D928
         NA: 0x238CDE4
+        JP: 0x238E364
       length:
         EU: 0x10
         NA: 0x10
@@ -108,6 +111,7 @@ overlay16:
       address:
         EU: 0x238D980
         NA: 0x238CE40
+        JP: 0x238E3C0
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay17.yml
+++ b/symbols/overlay17.yml
@@ -18,6 +18,7 @@ overlay17:
       address:
         EU: 0x238C674
         NA: 0x238BB34
+        JP: 0x238D090
       length:
         EU: 0x10
         NA: 0x10
@@ -26,6 +27,7 @@ overlay17:
       address:
         EU: 0x238C684
         NA: 0x238BB44
+        JP: 0x238D0A0
       length:
         EU: 0x10
         NA: 0x10
@@ -34,6 +36,7 @@ overlay17:
       address:
         EU: 0x238C694
         NA: 0x238BB54
+        JP: 0x238D0B0
       length:
         EU: 0x10
         NA: 0x10
@@ -42,6 +45,7 @@ overlay17:
       address:
         EU: 0x238C6A4
         NA: 0x238BB64
+        JP: 0x238D0C0
       length:
         EU: 0x10
         NA: 0x10
@@ -50,6 +54,7 @@ overlay17:
       address:
         EU: 0x238C6B4
         NA: 0x238BB74
+        JP: 0x238D0D0
       length:
         EU: 0x10
         NA: 0x10
@@ -148,6 +153,7 @@ overlay17:
       address:
         EU: 0x238C884
         NA: 0x238BD44
+        JP: 0x238D2A0
       length:
         NA: 0xA8
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -161,6 +167,7 @@ overlay17:
       address:
         EU: 0x238C940
         NA: 0x238BE00
+        JP: 0x238D360
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay18.yml
+++ b/symbols/overlay18.yml
@@ -18,6 +18,7 @@ overlay18:
       address:
         EU: 0x238DDB0
         NA: 0x238D270
+        JP: 0x238E7DC
       length:
         EU: 0x10
         NA: 0x10
@@ -26,6 +27,7 @@ overlay18:
       address:
         EU: 0x238DDC0
         NA: 0x238D280
+        JP: 0x238E7EC
       length:
         EU: 0x10
         NA: 0x10
@@ -34,6 +36,7 @@ overlay18:
       address:
         EU: 0x238DDD0
         NA: 0x238D290
+        JP: 0x238E7FC
       length:
         EU: 0x10
         NA: 0x10
@@ -42,6 +45,7 @@ overlay18:
       address:
         EU: 0x238DDE0
         NA: 0x238D2A0
+        JP: 0x238E80C
       length:
         EU: 0x10
         NA: 0x10
@@ -50,6 +54,7 @@ overlay18:
       address:
         EU: 0x238DDF0
         NA: 0x238D2B0
+        JP: 0x238E81C
       length:
         EU: 0x10
         NA: 0x10
@@ -58,6 +63,7 @@ overlay18:
       address:
         EU: 0x238DE00
         NA: 0x238D2C0
+        JP: 0x238E82C
       length:
         EU: 0x10
         NA: 0x10
@@ -66,6 +72,7 @@ overlay18:
       address:
         EU: 0x238DE10
         NA: 0x238D2D0
+        JP: 0x238E83C
       length:
         EU: 0x10
         NA: 0x10
@@ -74,6 +81,7 @@ overlay18:
       address:
         EU: 0x238DE20
         NA: 0x238D2E0
+        JP: 0x238E84C
       length:
         EU: 0x10
         NA: 0x10
@@ -82,6 +90,7 @@ overlay18:
       address:
         EU: 0x238DE30
         NA: 0x238D2F0
+        JP: 0x238E85C
       length:
         EU: 0x10
         NA: 0x10
@@ -90,6 +99,7 @@ overlay18:
       address:
         EU: 0x238DE40
         NA: 0x238D300
+        JP: 0x238E86C
       length:
         EU: 0x10
         NA: 0x10
@@ -98,6 +108,7 @@ overlay18:
       address:
         EU: 0x238DE50
         NA: 0x238D310
+        JP: 0x238E87C
       length:
         EU: 0x10
         NA: 0x10
@@ -187,6 +198,7 @@ overlay18:
       address:
         EU: 0x238E008
         NA: 0x238D4C8
+        JP: 0x238EA34
       length:
         NA: 0x130
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -200,6 +212,7 @@ overlay18:
       address:
         EU: 0x238E160
         NA: 0x238D620
+        JP: 0x238EBA0
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay19.yml
+++ b/symbols/overlay19.yml
@@ -55,6 +55,7 @@ overlay19:
       address:
         EU: 0x238E614
         NA: 0x238DAE0
+        JP: 0x238F038
       length:
         NA: 0x8
       description: |-
@@ -65,6 +66,7 @@ overlay19:
       address:
         EU: 0x238E61C
         NA: 0x238DAE8
+        JP: 0x238F040
       length:
         NA: 0xC
       description: |-
@@ -87,6 +89,7 @@ overlay19:
       address:
         EU: 0x238E700
         NA: 0x238DBCC
+        JP: 0x238F124
       length:
         NA: 0x5AC
       description: |-
@@ -97,6 +100,7 @@ overlay19:
       address:
         EU: 0x238ECAC
         NA: 0x238E178
+        JP: 0x238F6D0
       length:
         NA: 0x2C
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -104,6 +108,7 @@ overlay19:
       address:
         EU: 0x238ECD8
         NA: 0x238E1A4
+        JP: 0x238F6FC
       length:
         NA: 0x28
       description: |-
@@ -114,6 +119,7 @@ overlay19:
       address:
         EU: 0x238ED00
         NA: 0x238E1CC
+        JP: 0x238F724
       length:
         NA: 0xC
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -121,6 +127,7 @@ overlay19:
       address:
         EU: 0x238ED0C
         NA: 0x238E1D8
+        JP: 0x238F730
       length:
         EU: 0x10
         NA: 0x10
@@ -129,6 +136,7 @@ overlay19:
       address:
         EU: 0x238ED1C
         NA: 0x238E1E8
+        JP: 0x238F740
       length:
         EU: 0x10
         NA: 0x10
@@ -137,6 +145,7 @@ overlay19:
       address:
         EU: 0x238ED2C
         NA: 0x238E1F8
+        JP: 0x238F750
       length:
         EU: 0x10
         NA: 0x10
@@ -163,6 +172,7 @@ overlay19:
       address:
         EU: 0x238ED6C
         NA: 0x238E238
+        JP: 0x238F790
       length:
         NA: 0x18
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -203,6 +213,7 @@ overlay19:
       address:
         EU: 0x238EE80
         NA: 0x238E360
+        JP: 0x238F8A0
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay20.yml
+++ b/symbols/overlay20.yml
@@ -18,6 +18,7 @@ overlay20:
       address:
         EU: 0x238DABC
         NA: 0x238CF7C
+        JP: 0x238E4D8
       length:
         NA: 0x8
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -70,6 +71,7 @@ overlay20:
       address:
         EU: 0x238DB54
         NA: 0x238D014
+        JP: 0x238E570
       length:
         NA: 0x14
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -77,6 +79,7 @@ overlay20:
       address:
         EU: 0x238DB68
         NA: 0x238D028
+        JP: 0x238E584
       length:
         EU: 0x10
         NA: 0x10
@@ -85,6 +88,7 @@ overlay20:
       address:
         EU: 0x238DB78
         NA: 0x238D038
+        JP: 0x238E594
       length:
         EU: 0x10
         NA: 0x10
@@ -93,6 +97,7 @@ overlay20:
       address:
         EU: 0x238DB88
         NA: 0x238D048
+        JP: 0x238E5A4
       length:
         EU: 0x10
         NA: 0x10
@@ -101,6 +106,7 @@ overlay20:
       address:
         EU: 0x238DB98
         NA: 0x238D058
+        JP: 0x238E5B4
       length:
         EU: 0x10
         NA: 0x10
@@ -109,6 +115,7 @@ overlay20:
       address:
         EU: 0x238DBA8
         NA: 0x238D068
+        JP: 0x238E5C4
       length:
         EU: 0x10
         NA: 0x10
@@ -117,6 +124,7 @@ overlay20:
       address:
         EU: 0x238DBB8
         NA: 0x238D078
+        JP: 0x238E5D4
       length:
         EU: 0x10
         NA: 0x10

--- a/symbols/overlay21.yml
+++ b/symbols/overlay21.yml
@@ -18,6 +18,7 @@ overlay21:
       address:
         EU: 0x238D568
         NA: 0x238CA28
+        JP: 0x238DF98
       length:
         EU: 0x10
         NA: 0x10
@@ -104,6 +105,7 @@ overlay21:
       address:
         EU: 0x238D6A8
         NA: 0x238CB68
+        JP: 0x238E0D8
       length:
         EU: 0x10
         NA: 0x10
@@ -112,6 +114,7 @@ overlay21:
       address:
         EU: 0x238D6B8
         NA: 0x238CB78
+        JP: 0x238E0E8
       length:
         EU: 0x10
         NA: 0x10
@@ -120,6 +123,7 @@ overlay21:
       address:
         EU: 0x238D6C8
         NA: 0x238CB88
+        JP: 0x238E0F8
       length:
         EU: 0x10
         NA: 0x10
@@ -128,6 +132,7 @@ overlay21:
       address:
         EU: 0x238D6D8
         NA: 0x238CB98
+        JP: 0x238E108
       length:
         EU: 0x10
         NA: 0x10
@@ -136,6 +141,7 @@ overlay21:
       address:
         EU: 0x238D6E8
         NA: 0x238CBA8
+        JP: 0x238E118
       length:
         EU: 0x10
         NA: 0x10
@@ -144,6 +150,7 @@ overlay21:
       address:
         EU: 0x238DA5C
         NA: 0x238CF1C
+        JP: 0x238E48C
       length:
         NA: 0x8
       description: 合成：
@@ -157,6 +164,7 @@ overlay21:
       address:
         EU: 0x238DA80
         NA: 0x238CF40
+        JP: 0x238E4C0
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay22.yml
+++ b/symbols/overlay22.yml
@@ -18,6 +18,7 @@ overlay22:
       address:
         EU: 0x238F35C
         NA: 0x238E81C
+        JP: 0x238FD7C
       length:
         EU: 0x10
         NA: 0x10
@@ -26,6 +27,7 @@ overlay22:
       address:
         EU: 0x238F37C
         NA: 0x238E83C
+        JP: 0x238FD9C
       length:
         EU: 0x10
         NA: 0x10
@@ -34,6 +36,7 @@ overlay22:
       address:
         EU: 0x238F39C
         NA: 0x238E85C
+        JP: 0x238FDBC
       length:
         NA: 0xC
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -77,6 +80,7 @@ overlay22:
       address:
         EU: 0x238F430
         NA: 0x238E8F0
+        JP: 0x238FE50
       length:
         NA: 0x60
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -102,6 +106,7 @@ overlay22:
       address:
         EU: 0x238F4C0
         NA: 0x238E980
+        JP: 0x238FEE0
       length:
         EU: 0x10
         NA: 0x10
@@ -110,6 +115,7 @@ overlay22:
       address:
         EU: 0x238F4D0
         NA: 0x238E990
+        JP: 0x238FEF0
       length:
         EU: 0x10
         NA: 0x10
@@ -118,6 +124,7 @@ overlay22:
       address:
         EU: 0x238F4E0
         NA: 0x238E9A0
+        JP: 0x238FF00
       length:
         EU: 0x10
         NA: 0x10
@@ -126,6 +133,7 @@ overlay22:
       address:
         EU: 0x238F4F0
         NA: 0x238E9B0
+        JP: 0x238FF10
       length:
         EU: 0x10
         NA: 0x10
@@ -134,6 +142,7 @@ overlay22:
       address:
         EU: 0x238F500
         NA: 0x238E9C0
+        JP: 0x238FF20
       length:
         EU: 0x10
         NA: 0x10
@@ -148,6 +157,7 @@ overlay22:
       address:
         EU: 0x238F7A0
         NA: 0x238EC60
+        JP: 0x23901C0
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -161,6 +171,7 @@ overlay22:
       address:
         EU: 0x238F7A8
         NA: 0x238EC68
+        JP: 0x23901C8
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -174,6 +185,7 @@ overlay22:
       address:
         EU: 0x238F7B0
         NA: 0x238EC70
+        JP: 0x23901D0
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay23.yml
+++ b/symbols/overlay23.yml
@@ -18,6 +18,7 @@ overlay23:
       address:
         EU: 0x238DE28
         NA: 0x238D2E8
+        JP: 0x238E8A0
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -25,6 +26,7 @@ overlay23:
       address:
         EU: 0x238DE2C
         NA: 0x238D2EC
+        JP: 0x238E8A4
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -32,6 +34,7 @@ overlay23:
       address:
         EU: 0x238DE30
         NA: 0x238D2F0
+        JP: 0x238E8A8
       length:
         NA: 0xC
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -108,6 +111,7 @@ overlay23:
       address:
         EU: 0x238DF38
         NA: 0x238D3F8
+        JP: 0x238E9B0
       length:
         EU: 0x10
         NA: 0x10
@@ -116,6 +120,7 @@ overlay23:
       address:
         EU: 0x238DF48
         NA: 0x238D408
+        JP: 0x238E9C0
       length:
         EU: 0x10
         NA: 0x10
@@ -124,6 +129,7 @@ overlay23:
       address:
         EU: 0x238DF58
         NA: 0x238D418
+        JP: 0x238E9D0
       length:
         EU: 0x10
         NA: 0x10
@@ -132,6 +138,7 @@ overlay23:
       address:
         EU: 0x238DF68
         NA: 0x238D428
+        JP: 0x238E9E0
       length:
         EU: 0x10
         NA: 0x10
@@ -140,6 +147,7 @@ overlay23:
       address:
         EU: 0x238DF78
         NA: 0x238D438
+        JP: 0x238E9F0
       length:
         EU: 0x10
         NA: 0x10
@@ -154,6 +162,7 @@ overlay23:
       address:
         EU: 0x238E3E0
         NA: 0x238D8A0
+        JP: 0x238EE60
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay24.yml
+++ b/symbols/overlay24.yml
@@ -18,6 +18,7 @@ overlay24:
       address:
         EU: 0x238D048
         NA: 0x238C508
+        JP: 0x238DA70
       length:
         NA: 0xC
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -25,6 +26,7 @@ overlay24:
       address:
         EU: 0x238D054
         NA: 0x238C514
+        JP: 0x238DA7C
       length:
         NA: 0xC
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -74,6 +76,7 @@ overlay24:
       address:
         EU: 0x238D100
         NA: 0x238C5C0
+        JP: 0x238DB28
       length:
         EU: 0x10
         NA: 0x10
@@ -94,6 +97,7 @@ overlay24:
       address:
         EU: 0x238D140
         NA: 0x238C600
+        JP: 0x238DB60
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay25.yml
+++ b/symbols/overlay25.yml
@@ -18,6 +18,7 @@ overlay25:
       address:
         EU: 0x238BFD8
         NA: 0x238B498
+        JP: 0x238C9F8
       length:
         NA: 0xC
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -25,6 +26,7 @@ overlay25:
       address:
         EU: 0x238BFE4
         NA: 0x238B4A4
+        JP: 0x238CA04
       length:
         EU: 0x10
         NA: 0x10
@@ -84,6 +86,7 @@ overlay25:
       address:
         EU: 0x238C0A4
         NA: 0x238B564
+        JP: 0x238CAC4
       length:
         EU: 0x10
         NA: 0x10
@@ -92,6 +95,7 @@ overlay25:
       address:
         EU: 0x238C0B4
         NA: 0x238B574
+        JP: 0x238CAD4
       length:
         EU: 0x10
         NA: 0x10
@@ -100,6 +104,7 @@ overlay25:
       address:
         EU: 0x238C0C4
         NA: 0x238B584
+        JP: 0x238CAE4
       length:
         EU: 0x10
         NA: 0x10
@@ -108,6 +113,7 @@ overlay25:
       address:
         EU: 0x238C0D4
         NA: 0x238B594
+        JP: 0x238CAF4
       length:
         EU: 0x10
         NA: 0x10
@@ -122,6 +128,7 @@ overlay25:
       address:
         EU: 0x238C120
         NA: 0x238B5E0
+        JP: 0x238CB40
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay27.yml
+++ b/symbols/overlay27.yml
@@ -18,6 +18,7 @@ overlay27:
       address:
         EU: 0x238D488
         NA: 0x238C948
+        JP: 0x238DED8
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -25,6 +26,7 @@ overlay27:
       address:
         EU: 0x238D48C
         NA: 0x238C94C
+        JP: 0x238DEDC
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -32,6 +34,7 @@ overlay27:
       address:
         EU: 0x238D490
         NA: 0x238C950
+        JP: 0x238DEE0
       length:
         NA: 0xC
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -105,6 +108,7 @@ overlay27:
       address:
         EU: 0x238D58C
         NA: 0x238CA4C
+        JP: 0x238DFDC
       length:
         EU: 0x10
         NA: 0x10
@@ -113,6 +117,7 @@ overlay27:
       address:
         EU: 0x238D59C
         NA: 0x238CA5C
+        JP: 0x238DFEC
       length:
         EU: 0x10
         NA: 0x10
@@ -121,6 +126,7 @@ overlay27:
       address:
         EU: 0x238D5AC
         NA: 0x238CA6C
+        JP: 0x238DFFC
       length:
         EU: 0x10
         NA: 0x10
@@ -141,6 +147,7 @@ overlay27:
       address:
         EU: 0x238D9C0
         NA: 0x238CE80
+        JP: 0x238E420
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -148,6 +155,7 @@ overlay27:
       address:
         EU: 0x238D9C4
         NA: 0x238CE84
+        JP: 0x238E424
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -45,6 +45,7 @@ overlay29:
       address:
         EU: 0x22DF3C0
         NA: 0x22DEA80
+        JP: 0x22E0120
       description: |-
         Returns the master dungeon pointer (a global, see DUNGEON_PTR_MASTER).
         
@@ -62,6 +63,7 @@ overlay29:
       address:
         EU: 0x22DF3F0
         NA: 0x22DEAB0
+        JP: 0x22E0150
       description: |-
         Frees the dungeons struct pointer to by the master dungeon pointer, and nullifies the pointer.
         
@@ -182,10 +184,55 @@ overlay29:
           - 0x234DDD0
           - 0x234EC14
         JP:
+          - 0x22E19EC
+          - 0x22E30AC
+          - 0x22E4958
+          - 0x22E4E28
+          - 0x22EAC5C
+          - 0x22EDC70
+          - 0x22EE424
+          - 0x22EF9A4
+          - 0x22F0DA4
+          - 0x22F1B94
+          - 0x22F6884
+          - 0x22F788C
+          - 0x22F8930
+          - 0x22FDD90
+          - 0x2300188
+          - 0x2301514
+          - 0x2303F88
+          - 0x2305D08
+          - 0x2306ADC
+          - 0x2307154
+          - 0x230942C
+          - 0x23097B0
+          - 0x230A574
+          - 0x230FE2C
+          - 0x2310544
           - 0x2312538
           - 0x2312DCC
           - 0x23165F0
+          - 0x231A204
+          - 0x231A31C
+          - 0x231B45C
+          - 0x231C660
+          - 0x231E094
+          - 0x2320284
+          - 0x2320A1C
+          - 0x23210A8
+          - 0x2321628
+          - 0x2321C10
+          - 0x23228E4
+          - 0x2326AAC
+          - 0x232FC3C
+          - 0x2335398
           - 0x23364C4
+          - 0x233906C
+          - 0x2345EBC
+          - 0x2346A5C
+          - 0x234AB6C
+          - 0x234F05C
+          - 0x234FE98
       description: |-
         Checks if an entity pointer points to a valid entity (not entity type 0, which represents no entity).
         
@@ -247,6 +294,7 @@ overlay29:
       address:
         EU: 0x22E120C
         NA: 0x22E08CC
+        JP: 0x22E1F5C
       description: |-
         Checks if the current fixed room is the "substitute room" (ID 0x6E).
         
@@ -266,6 +314,7 @@ overlay29:
       address:
         EU: 0x22E129C
         NA: 0x22E095C
+        JP: 0x22E1FEC
       description: |-
         Likely a linker-generated veneer for GetScenarioBalance.
         
@@ -363,6 +412,7 @@ overlay29:
       address:
         EU: 0x22E2C54
         NA: 0x22E2314
+        JP: 0x22E39A4
       description: |-
         Spawns a blank item entity on the floor. Fails if there are more than 64 items already on the floor.
         
@@ -398,6 +448,7 @@ overlay29:
       address:
         EU: 0x22E306C
         NA: 0x22E272C
+        JP: 0x22E3DC0
       description: |-
         Calls ShouldDisplayEntity with r1 = 0
         
@@ -528,8 +579,19 @@ overlay29:
           - 0x231513C
           - 0x2347B50
         JP:
+          - 0x22E497C
+          - 0x22EF974
+          - 0x22F6F90
           - 0x2300CA8
+          - 0x2303C1C
+          - 0x2309450
+          - 0x230BF58
+          - 0x230FAB4
+          - 0x2310D4C
+          - 0x231255C
+          - 0x2313104
           - 0x2316614
+          - 0x2348F00
       description: |-
         Checks if a monster is holding a certain item that isn't disabled by Klutz.
         
@@ -540,6 +602,7 @@ overlay29:
       address:
         EU: 0x22E3CEC
         NA: 0x22E333C
+        JP: 0x22E49AC
       description: |-
         Returns dungeon::display_data::visibility_range. If the visibility range is 0, returns 2 instead.
         
@@ -661,6 +724,13 @@ overlay29:
           - 0x22E6214
           - 0x22E64C4
           - 0x22E6510
+        JP:
+          - 0x22E77A0
+          - 0x22E77EC
+          - 0x22E7838
+          - 0x22E7884
+          - 0x22E7B34
+          - 0x22E7B80
       description: |-
         Just a guess. Calls PlayEffectAnimation with data from animation ID 0x1A9.
         
@@ -910,6 +980,7 @@ overlay29:
       address:
         EU: 0x22EA3A0
         NA: 0x22E99F0
+        JP: 0x22EB058
       description: |-
         Searches for the closest unoccupied tile within 2 steps of the given origin.
         
@@ -923,6 +994,7 @@ overlay29:
       address:
         EU: 0x22EA3BC
         NA: 0x22E9A0C
+        JP: 0x22EB074
       description: |-
         Searches for the farthest unoccupied tile within 2 steps of the given origin.
         
@@ -1123,6 +1195,7 @@ overlay29:
       address:
         EU: 0x22EB614
         NA: 0x22EAC64
+        JP: 0x22EC2CC
       description: |-
         Sets the dungeon PRNG to use the primary LCG for subsequent random number generation.
         
@@ -1434,6 +1507,7 @@ overlay29:
       address:
         EU: 0x22EE950
         NA: 0x22EDFA0
+        JP: 0x22EF604
       description: |-
         Called whenever a monster steps on a trap.
         
@@ -1478,6 +1552,7 @@ overlay29:
       address:
         EU: 0x22EF1D4
         NA: 0x22EE820
+        JP: 0x22EFE80
       description: |-
         If the defender is the leader, end the current floor unless it has a rescue point.
         Otherwise, make the entity faint and ignore reviver seeds. If not called by a random
@@ -1534,6 +1609,7 @@ overlay29:
       address:
         EU: 0x22EF804
         NA: 0x22EEE50
+        JP: 0x22F04A4
       description: |-
         Tries to apply the damage from the stealth rock trap but does nothing if the defender is a rock type.
         
@@ -1552,6 +1628,7 @@ overlay29:
       address:
         EU: 0x22EF8F4
         NA: 0x22EEF40
+        JP: 0x22F0540
       description: |-
         Selects a random trap that isn't a wonder tile and isn't a random trap and calls
         ApplyTrapEffect on all monsters that is different from the trap's team.
@@ -1565,6 +1642,7 @@ overlay29:
       address:
         EU: 0x22EFA28
         NA: 0x22EF074
+        JP: 0x22F066C
       description: |-
         Spawns several monsters around the position and gives all monsters on the floor the
         grudge status condition.
@@ -1801,6 +1879,7 @@ overlay29:
       address:
         EU: 0x22F7D40
         NA: 0x22F7388
+        JP: 0x22F8954
       description: |-
         Gets the sprite index of the specified monster on this floor
         
@@ -1810,6 +1889,7 @@ overlay29:
       address:
         EU: 0x22F7D60
         NA: 0x22F73A8
+        JP: 0x22F8970
       description: |-
         Likely a linker-generated veneer for arm9::JoinedAtRangeCheck2.
         
@@ -2014,7 +2094,13 @@ overlay29:
           - 0x2311B94
           - 0x2322D64
           - 0x2332A0C
-        JP: 0x2302F74
+        JP:
+          - 0x22FAC8C
+          - 0x2302F74
+          - 0x230BEC4
+          - 0x23130A4
+          - 0x232420C
+          - 0x2333E00
       description: |-
         Checks if a defender has an active ability that isn't disabled by an attacker's Mold Breaker.
         
@@ -2047,6 +2133,16 @@ overlay29:
           - 0x231B318
           - 0x2322DB8
           - 0x234D460
+        JP:
+          - 0x22FACD8
+          - 0x2302FC0
+          - 0x230BF10
+          - 0x2310EBC
+          - 0x2319F80
+          - 0x231BEA4
+          - 0x231C7E4
+          - 0x2324258
+          - 0x234E6EC
       description: |-
         Checks if an entity is a monster (entity type 1).
         
@@ -2090,6 +2186,7 @@ overlay29:
       address:
         EU: 0x22FA480
         NA: 0x22F9A74
+        JP: 0x22FB02C
       description: |-
         Restores PP for all moves, clears flags move::f_consume_2_pp, move::flags2_unk5 and move::flags2_unk7, and sets flag move::f_consume_pp.
         Called when a monster is revived.
@@ -2099,6 +2196,7 @@ overlay29:
       address:
         EU: 0x22FA64C
         NA: 0x22F9C40
+        JP: 0x22FB1F8
       description: |-
         Likely a linker-generated veneer for CheckTeamMemberIdx.
         
@@ -2110,6 +2208,7 @@ overlay29:
       address:
         EU: 0x22FA674
         NA: 0x22F9C68
+        JP: 0x22FB220
       description: |-
         Likely a linker-generated veneer for IsMonsterIdInNormalRange.
         
@@ -2194,7 +2293,17 @@ overlay29:
           - 0x2347B80
           - 0x23482B0
         JP:
+          - 0x22FC224
+          - 0x2301358
+          - 0x230BF34
+          - 0x2310DE8
+          - 0x231258C
           - 0x2315CC0
+          - 0x231AC78
+          - 0x231BD4C
+          - 0x2324DB8
+          - 0x2333DDC
+          - 0x2348F30
           - 0x2349638
       description: |-
         Checks if a monster is a team member under the effects of a certain exclusive item effect.
@@ -2236,6 +2345,7 @@ overlay29:
       address:
         EU: 0x22FBAB4
         NA: 0x22FB0A8
+        JP: 0x22FC630
       description: |-
         Returns how many of a monster's move are out of PP.
         
@@ -2581,7 +2691,7 @@ overlay29:
       address:
         EU: 0x23006C8
         NA: 0x22FFC9C
-        JP: 0x2300B54
+        JP: 0x23010AC
       description: |-
         Checks if a given monster cannot stand on a given tile.
         
@@ -2611,6 +2721,7 @@ overlay29:
       address:
         EU: 0x2300978
         NA: 0x22FFF4C
+        JP: 0x230137C
       description: |-
         Calls CalcSpeedStage with a speed counter weight of 1.
         
@@ -2789,6 +2900,7 @@ overlay29:
       address:
         EU: 0x23018A4
         NA: 0x2300E78
+        JP: 0x230225C
       description: |-
         Checks if the given monster can move in the specified direction
         
@@ -3065,6 +3177,7 @@ overlay29:
       address:
         EU: 0x2302DEC
         NA: 0x23023C0
+        JP: 0x2303910
       description: |-
         Updates monster::state_flags and monster::prev_state_flags with new values.
         
@@ -3480,6 +3593,7 @@ overlay29:
       address:
         EU: 0x2308D6C
         NA: 0x2308340
+        JP: 0x2309874
       description: |-
         Runs the AI for a single monster to determine whether the monster can act and which action it should perform if so
         
@@ -3605,6 +3719,7 @@ overlay29:
       address:
         EU: 0x230B778
         NA: 0x230AD04
+        JP: 0x230C27C
       description: |-
         Calculates type-based effects on damage.
         
@@ -3792,6 +3907,7 @@ overlay29:
       address:
         EU: 0x230EAD8
         NA: 0x230E064
+        JP: 0x230F5A4
       description: |-
         Asks the player if they would like to recruit the enemy that was just defeated and handles the recruitment if they accept.
         
@@ -3834,6 +3950,7 @@ overlay29:
       address:
         EU: 0x23101EC
         NA: 0x230F778
+        JP: 0x2310CB4
       description: |-
         Gets the exclusive item boost for attack/special attack for a monster
         
@@ -3844,6 +3961,7 @@ overlay29:
       address:
         EU: 0x23101FC
         NA: 0x230F788
+        JP: 0x2310CC4
       description: |-
         Gets the exclusive item boost for defense/special defense for a monster
         
@@ -5302,6 +5420,7 @@ overlay29:
       address:
         EU: 0x231BAC0
         NA: 0x231B060
+        JP: 0x231C530
       description: |-
         Displays the message and applies the speed boost for the ability Motor Drive.
         
@@ -5444,6 +5563,7 @@ overlay29:
       address:
         EU: 0x231D884
         NA: 0x231CE1C
+        JP: 0x231E2E8
       description: |-
         Boosts the target's offensive stats stages to the max.
         
@@ -5657,6 +5777,7 @@ overlay29:
       address:
         EU: 0x2320EB0
         NA: 0x2320448
+        JP: 0x23218F4
       description: |-
         Creates an explosion if possible.
         
@@ -5672,6 +5793,7 @@ overlay29:
       address:
         EU: 0x23211F0
         NA: 0x2320788
+        JP: 0x2321C34
       description: |-
         Creates the explosion for the ability aftermath if possible.
         
@@ -5794,6 +5916,7 @@ overlay29:
       address:
         EU: 0x23252BC
         NA: 0x2324854
+        JP: 0x2325CE4
       description: |-
         Checks if a move should miss a monster due to the monster being in the middle of Fly, Bounce, Dive, Dig, Shadow Force, or some other two-turn move that grants pseudo-invincibility.
         
@@ -6169,6 +6292,7 @@ overlay29:
       address:
         EU: 0x2336DD4
         NA: 0x2336204
+        JP: 0x23375D4
       description: |-
         Calls IsBackgroundTileset with the current tileset ID
         
@@ -6197,6 +6321,7 @@ overlay29:
       address:
         EU: 0x2336F90
         NA: 0x23363C0
+        JP: 0x2337790
       description: |-
         Gets the spawn position for the stairs and stores it at the passed pointers.
         
@@ -6227,6 +6352,7 @@ overlay29:
       address:
         EU: 0x2337020
         NA: 0x2336450
+        JP: 0x2337820
       description: |-
         Returns the texture_id of the default tile?
         
@@ -6325,6 +6451,7 @@ overlay29:
       address:
         EU: 0x2338A64
         NA: 0x2337E94
+        JP: 0x2339258
       description: |-
         Returns flag tileset_property::is_water_tileset for the current tileset
         
@@ -6362,6 +6489,7 @@ overlay29:
       address:
         EU: 0x2338F60
         NA: 0x2338390
+        JP: 0x2339754
       description: |-
         Checks if gravity is active on the floor.
         
@@ -6379,6 +6507,7 @@ overlay29:
       address:
         EU: 0x2339090
         NA: 0x23384C0
+        JP: 0x2339884
       description: |-
         Gets the boost_kecleon_shop_spawn_chance field on the dungeon struct.
         
@@ -6387,6 +6516,7 @@ overlay29:
       address:
         EU: 0x23390A8
         NA: 0x23384D8
+        JP: 0x233989C
       description: |-
         Sets the boost_kecleon_shop_spawn_chance field on the dungeon struct to the given value.
         
@@ -6404,6 +6534,7 @@ overlay29:
       address:
         EU: 0x2339118
         NA: 0x2338548
+        JP: 0x233990C
       description: |-
         Sets the dough_seed_extra_money_flag field on the dungeon struct to the given value.
         
@@ -6422,6 +6553,7 @@ overlay29:
       address:
         EU: 0x2339194
         NA: 0x23385C4
+        JP: 0x2339988
       description: |-
         Checks if the current floor is the Secret Bazaar.
         
@@ -6430,6 +6562,7 @@ overlay29:
       address:
         EU: 0x23391BC
         NA: 0x23385EC
+        JP: 0x23399B0
       description: |-
         Gets the boost_hidden_stairs_spawn_chance field on the dungeon struct.
         
@@ -6438,6 +6571,7 @@ overlay29:
       address:
         EU: 0x23391D4
         NA: 0x2338604
+        JP: 0x23399C8
       description: |-
         Sets the boost_hidden_stairs_spawn_chance field on the dungeon struct to the given value.
         
@@ -6455,6 +6589,7 @@ overlay29:
       address:
         EU: 0x233922C
         NA: 0x233865C
+        JP: 0x2339A20
       description: |-
         Checks if the current floor is the Secret Room fixed floor (from hidden stairs).
         
@@ -6503,11 +6638,13 @@ overlay29:
       address:
         EU: 0x2339450
         NA: 0x2338880
+        JP: 0x2339C44
       description: "return: dungeon_generation_info::field_0xc"
     - name: GetMinimapData
       address:
         EU: 0x2339CE8
         NA: 0x2339118
+        JP: 0x233A4DC
       description: |-
         Returns a pointer to the minimap_display_data struct in the dungeon struct.
         
@@ -6579,6 +6716,7 @@ overlay29:
       address:
         EU: 0x233B208
         NA: 0x233A624
+        JP: 0x233B9E8
       description: |-
         Likely a linker-generated veneer for LoadFixedRoomData.
         
@@ -6771,6 +6909,7 @@ overlay29:
       address:
         EU: 0x233CF10
         NA: 0x233C32C
+        JP: 0x233D6F0
       description: |-
         Handles fixed room generation if the floor contains a fixed room.
         
@@ -7299,6 +7438,7 @@ overlay29:
       address:
         EU: 0x2343980
         NA: 0x2342D9C
+        JP: 0x234415C
       description: |-
         Gets the hidden stairs type for a given floor.
         
@@ -7533,6 +7673,7 @@ overlay29:
       address:
         EU: 0x234511C
         NA: 0x2344538
+        JP: 0x23458FC
       description: |-
         Likely a linker-generated veneer for IsSecretBazaar.
         
@@ -8910,6 +9051,7 @@ overlay29:
       address:
         EU: 0x2351DC8
         NA: 0x23511BC
+        JP: 0x235243C
       length:
         EU: 0x10
         NA: 0x10
@@ -8918,6 +9060,7 @@ overlay29:
       address:
         EU: 0x2351DD8
         NA: 0x23511CC
+        JP: 0x235244C
       length:
         EU: 0x10
         NA: 0x10
@@ -8926,6 +9069,7 @@ overlay29:
       address:
         EU: 0x2351DF8
         NA: 0x23511EC
+        JP: 0x235246C
       length:
         EU: 0x18
         NA: 0x18
@@ -8934,6 +9078,7 @@ overlay29:
       address:
         EU: 0x2351E08
         NA: 0x23511FC
+        JP: 0x235247C
       length:
         EU: 0x18
         NA: 0x18
@@ -8942,6 +9087,7 @@ overlay29:
       address:
         EU: 0x2351E20
         NA: 0x2351214
+        JP: 0x2352494
       length:
         EU: 0x18
         NA: 0x18
@@ -8950,6 +9096,7 @@ overlay29:
       address:
         EU: 0x2351E78
         NA: 0x235126C
+        JP: 0x23524EC
       length:
         EU: 0x28
         NA: 0x28
@@ -8958,6 +9105,7 @@ overlay29:
       address:
         EU: 0x2351EA0
         NA: 0x2351294
+        JP: 0x2352514
       length:
         EU: 0x28
         NA: 0x28
@@ -8966,6 +9114,7 @@ overlay29:
       address:
         EU: 0x2351EC8
         NA: 0x23512BC
+        JP: 0x235253C
       length:
         EU: 0x28
         NA: 0x28
@@ -8974,6 +9123,7 @@ overlay29:
       address:
         EU: 0x2351EF0
         NA: 0x23512E4
+        JP: 0x2352564
       length:
         EU: 0x28
         NA: 0x28
@@ -8982,6 +9132,7 @@ overlay29:
       address:
         EU: 0x2351F18
         NA: 0x235130C
+        JP: 0x235258C
       length:
         EU: 0x40
         NA: 0x40
@@ -8990,6 +9141,7 @@ overlay29:
       address:
         EU: 0x2351F48
         NA: 0x235133C
+        JP: 0x23525BC
       length:
         EU: 0x38
         NA: 0x38
@@ -8998,6 +9150,7 @@ overlay29:
       address:
         EU: 0x2351F80
         NA: 0x2351374
+        JP: 0x23525F4
       length:
         EU: 0x40
         NA: 0x40
@@ -9006,6 +9159,7 @@ overlay29:
       address:
         EU: 0x2351FC0
         NA: 0x23513B4
+        JP: 0x2352634
       length:
         EU: 0x40
         NA: 0x40
@@ -9014,6 +9168,7 @@ overlay29:
       address:
         EU: 0x2352000
         NA: 0x23513F4
+        JP: 0x2352674
       length:
         EU: 0x70
         NA: 0x70
@@ -9022,6 +9177,7 @@ overlay29:
       address:
         EU: 0x2352100
         NA: 0x23514F4
+        JP: 0x2352774
       length:
         EU: 0x90
         NA: 0x90
@@ -9030,6 +9186,7 @@ overlay29:
       address:
         EU: 0x2352328
         NA: 0x235171C
+        JP: 0x235299C
       length:
         EU: 0x20
         NA: 0x20
@@ -9041,6 +9198,7 @@ overlay29:
       address:
         EU: 0x23523E8
         NA: 0x23517DC
+        JP: 0x2352A5C
       length:
         NA: 0x68
       description: |-
@@ -9053,6 +9211,7 @@ overlay29:
       address:
         EU: 0x2352450
         NA: 0x2351844
+        JP: 0x2352AC4
       length:
         NA: 0x68
       description: |-
@@ -9065,6 +9224,7 @@ overlay29:
       address:
         EU: 0x23524B8
         NA: 0x23518AC
+        JP: 0x2352B2C
       length:
         NA: 0xC8
       description: |-
@@ -9077,6 +9237,7 @@ overlay29:
       address:
         EU: 0x2352C1C
         NA: 0x2352010
+        JP: 0x2353290
       length:
         EU: 0x20
         NA: 0x20
@@ -9088,6 +9249,7 @@ overlay29:
       address:
         EU: 0x2352E90
         NA: 0x2352284
+        JP: 0x2353504
       length:
         EU: 0xFA
         NA: 0xFA
@@ -9119,6 +9281,7 @@ overlay29:
       address:
         EU: 0x2353448
         NA: 0x235283C
+        JP: 0x2353ABC
       length:
         NA: 0x8
       description: "A generic damage multiplier of 0.5 used in various places, as a 64-bit fixed-point number with 16 fraction bits."
@@ -9126,6 +9289,7 @@ overlay29:
       address:
         EU: 0x2353450
         NA: 0x2352844
+        JP: 0x2353AC4
       length:
         NA: 0x8
       description: "A generic damage multiplier of 1.5 used in various places, as a 64-bit fixed-point number with 16 fraction bits."
@@ -9133,6 +9297,7 @@ overlay29:
       address:
         EU: 0x2353458
         NA: 0x235284C
+        JP: 0x2353ACC
       length:
         NA: 0x8
       description: "A generic damage multiplier of 2 used in various places, as a 64-bit fixed-point number with 16 fraction bits."
@@ -9140,6 +9305,7 @@ overlay29:
       address:
         EU: 0x2353468
         NA: 0x235285C
+        JP: 0x2353ADC
       length:
         NA: 0x8
       description: "The extra damage multiplier for non-Normal-type moves when the weather is Cloudy, as a 64-bit fixed-point number with 16 fraction bits (0.75)."
@@ -9147,6 +9313,7 @@ overlay29:
       address:
         EU: 0x2353470
         NA: 0x2352864
+        JP: 0x2353AE4
       length:
         NA: 0x8
       description: "The extra damage multiplier for super-effective moves when Solid Rock or Filter is active, as a 64-bit fixed-point number with 16 fraction bits (0.75)."
@@ -9154,6 +9321,7 @@ overlay29:
       address:
         EU: 0x2353478
         NA: 0x235286C
+        JP: 0x2353AEC
       length:
         NA: 0x8
       description: "The maximum value of the base damage formula (after DAMAGE_FORMULA_NON_TEAM_MEMBER_MODIFIER application, if relevant), as a 64-bit binary fixed-point number with 16 fraction bits (999)."
@@ -9167,6 +9335,7 @@ overlay29:
       address:
         EU: 0x2353488
         NA: 0x235287C
+        JP: 0x2353AFC
       length:
         NA: 0x8
       description: "The minimum value of the base damage formula (after DAMAGE_FORMULA_NON_TEAM_MEMBER_MODIFIER application, if relevant), as a 64-bit binary fixed-point number with 16 fraction bits (1)."
@@ -9174,6 +9343,7 @@ overlay29:
       address:
         EU: 0x23534B0
         NA: 0x23528A4
+        JP: 0x2353B24
       length:
         NA: 0xE0
       description: |-
@@ -9184,6 +9354,7 @@ overlay29:
       address:
         EU: 0x23536B8
         NA: 0x2352AAC
+        JP: 0x2353D2C
       length:
         EU: 0x2C
         NA: 0x2C
@@ -9192,6 +9363,7 @@ overlay29:
       address:
         EU: 0x23536F4
         NA: 0x2352AE8
+        JP: 0x2353D68
       length:
         EU: 0x4
         NA: 0x4
@@ -9200,6 +9372,7 @@ overlay29:
       address:
         EU: 0x23536F8
         NA: 0x2352AEC
+        JP: 0x2353D6C
       length:
         EU: 0x4
         NA: 0x4
@@ -9208,6 +9381,7 @@ overlay29:
       address:
         EU: 0x23536FC
         NA: 0x2352AF0
+        JP: 0x2353D70
       length:
         NA: 0x28
       description: |-
@@ -9218,6 +9392,7 @@ overlay29:
       address:
         EU: 0x2353BDC
         NA: 0x2352FD0
+        JP: 0x2354250
       length:
         NA: 0x24
       description: |-
@@ -9230,6 +9405,7 @@ overlay29:
       address:
         EU: 0x2353C24
         NA: 0x2353010
+        JP: 0x2354290
       length:
         EU: 0x20
         NA: 0x20
@@ -9245,6 +9421,7 @@ overlay29:
       address:
         EU: 0x2353EE0
         NA: 0x23532D0
+        JP: 0x2354550
       length:
         EU: 0x8
         NA: 0x8
@@ -9253,6 +9430,7 @@ overlay29:
       address:
         EU: 0x2353F3C
         NA: 0x2353324
+        JP: 0x23545A4
       length:
         EU: 0xA
         NA: 0xA
@@ -9261,6 +9439,7 @@ overlay29:
       address:
         EU: 0x2353F48
         NA: 0x2353330
+        JP: 0x23545B0
       length:
         NA: 0x36
       description: List that matches the damage_message ID to their corresponding string ID. The null entry at 0xE in the middle is for hunger. The last entry is null.
@@ -9296,6 +9475,7 @@ overlay29:
       address:
         EU: 0x2354154
         NA: 0x2353554
+        JP: 0x23547D4
       length:
         EU: 0x4
       description: |-
@@ -9306,6 +9486,7 @@ overlay29:
       address:
         EU: 0x235415C
         NA: 0x235355C
+        JP: 0x23547DC
       length:
         EU: 0x4
         NA: 0x4
@@ -9317,6 +9498,7 @@ overlay29:
       address:
         EU: 0x2354170
         NA: 0x2353570
+        JP: 0x23547F0
       length:
         EU: 0x14
         NA: 0x14
@@ -9330,6 +9512,7 @@ overlay29:
       address:
         EU: 0x2354184
         NA: 0x2353584
+        JP: 0x2354804
       length:
         EU: 0x14
         NA: 0x14
@@ -9341,6 +9524,7 @@ overlay29:
       address:
         EU: 0x23541AC
         NA: 0x23535AC
+        JP: 0x235482C
       length:
         EU: 0x2
       description: |-
@@ -9360,6 +9544,7 @@ overlay29:
       address:
         EU: 0x23541B0
         NA: 0x23535B0
+        JP: 0x2354830
       length:
         EU: 0x8
         NA: 0x8
@@ -9368,6 +9553,7 @@ overlay29:
       address:
         EU: 0x23541B8
         NA: 0x23535B8
+        JP: 0x2354838
       length:
         EU: 0x8
         NA: 0x8
@@ -9376,6 +9562,7 @@ overlay29:
       address:
         EU: 0x23541C0
         NA: 0x23535C0
+        JP: 0x2354840
       length:
         EU: 0x8
         NA: 0x8
@@ -9384,6 +9571,7 @@ overlay29:
       address:
         EU: 0x2354310
         NA: 0x2353710
+        JP: 0x2354990
       length:
         EU: 0x8
         NA: 0x8
@@ -9392,6 +9580,7 @@ overlay29:
       address:
         EU: 0x235433C
         NA: 0x2353724
+        JP: 0x235499C
       length:
         EU: 0x14
         NA: 0x14
@@ -9405,6 +9594,7 @@ overlay29:
       address:
         EU: 0x23543A4
         NA: 0x235378C
+        JP: 0x2354A04
       length:
         EU: 0x1
         NA: 0x1
@@ -9418,6 +9608,7 @@ overlay29:
       address:
         EU: 0x23543AC
         NA: 0x2353794
+        JP: 0x2354A0C
       length:
         EU: 0x4
         NA: 0x4
@@ -9426,6 +9617,7 @@ overlay29:
       address:
         EU: 0x23543F8
         NA: 0x23537E0
+        JP: 0x2354A58
       length:
         EU: 0x4
       description: "[Runtime] Pointer to the dungeon fades struct that maintains the status of screen fades in dungeon mode."

--- a/symbols/overlay29/move_effects.yml
+++ b/symbols/overlay29/move_effects.yml
@@ -28,6 +28,11 @@ move_effects:
           - 0x232A500
           - 0x232B8B0
           - 0x232DD88
+        JP:
+          - 0x232724C
+          - 0x232B970
+          - 0x232CCFC
+          - 0x232F190
       description: |-
         Move effect: Deal damage.
         Relevant moves: Many!
@@ -43,6 +48,7 @@ move_effects:
       address:
         EU: 0x232684C
         NA: 0x2325DE4
+        JP: 0x2327270
       description: |-
         Move effect: Iron Tail
         
@@ -82,6 +88,7 @@ move_effects:
       address:
         EU: 0x2326968
         NA: 0x2325F00
+        JP: 0x232738C
       description: |-
         Move effect: Put target enemies to sleep
         Relevant moves: Lovely Kiss, Sing, Spore, Grasswhistle, Hypnosis, Sleep Powder, Dark Void
@@ -108,6 +115,7 @@ move_effects:
       address:
         EU: 0x23269DC
         NA: 0x2325F74
+        JP: 0x2327400
       description: |-
         Move effect: Morning Sun
         
@@ -146,6 +154,7 @@ move_effects:
       address:
         EU: 0x2326AF0
         NA: 0x2326088
+        JP: 0x2327514
       description: |-
         Move effect: Sweet Scent
         
@@ -171,6 +180,7 @@ move_effects:
       address:
         EU: 0x2326B38
         NA: 0x23260D0
+        JP: 0x232755C
       description: |-
         Move effect: Rain Dance
         
@@ -183,6 +193,7 @@ move_effects:
       address:
         EU: 0x2326B94
         NA: 0x232612C
+        JP: 0x23275B8
       description: |-
         Move effect: Hail
         
@@ -209,6 +220,7 @@ move_effects:
       address:
         EU: 0x2326C08
         NA: 0x23261A0
+        JP: 0x232762C
       description: |-
         Move effect: Bubble
         
@@ -338,6 +350,7 @@ move_effects:
       address:
         EU: 0x23270D8
         NA: 0x2326670
+        JP: 0x2327AFC
       description: |-
         Move effect: Deal damage with a 30% chance (ROCK_SLIDE_CRINGE_CHANCE) of inflicting the cringe status on the defender.
         Relevant moves: Rock Slide, Astonish, Iron Head, Dark Pulse, Air Slash, Zen Headbutt, Dragon Rush
@@ -377,6 +390,7 @@ move_effects:
       address:
         EU: 0x2327240
         NA: 0x23267D8
+        JP: 0x2327C64
       description: |-
         Move effect: Fake Tears
         
@@ -481,6 +495,7 @@ move_effects:
       address:
         EU: 0x23274DC
         NA: 0x2326A74
+        JP: 0x2327EFC
       description: |-
         Move effect: Octazooka
         
@@ -532,6 +547,7 @@ move_effects:
       address:
         EU: 0x232770C
         NA: 0x2326CA4
+        JP: 0x232812C
       description: |-
         Move effect: Grudge
         
@@ -558,6 +574,7 @@ move_effects:
       address:
         EU: 0x2327730
         NA: 0x2326CC8
+        JP: 0x2328150
       description: |-
         Move effect: Deal damage with a 10% chance (FLAME_WHEEL_BURN_CHANCE) of burning the defender.
         Relevant moves: Flame Wheel, Lava Plume
@@ -571,6 +588,7 @@ move_effects:
       address:
         EU: 0x23277B8
         NA: 0x2326D50
+        JP: 0x23281D8
       description: |-
         Move effect: Deal damage with a 10% chance (FLAMETHROWER_BURN_CHANCE) of burning the defender.
         Relevant moves: Flamethrower, Fire Blast, Heat Wave, Ember, Fire Punch
@@ -598,6 +616,7 @@ move_effects:
       address:
         EU: 0x232786C
         NA: 0x2326E04
+        JP: 0x232828C
       description: |-
         Move effect: Double Team
         
@@ -623,6 +642,7 @@ move_effects:
       address:
         EU: 0x23278C8
         NA: 0x2326E60
+        JP: 0x23282E8
       description: |-
         Move effect: Boost the user's defense by one stage
         Relevant moves: Harden, Withdraw
@@ -642,6 +662,10 @@ move_effects:
           - 0x2326E80
           - 0x2328230
           - 0x232B434
+        JP:
+          - 0x2328308
+          - 0x23296B8
+          - 0x232C894
       description: |-
         Move effect: Paralyze the defender if possible
         Relevant moves: Disable, Stun Spore, Glare
@@ -655,6 +679,7 @@ move_effects:
       address:
         EU: 0x2327900
         NA: 0x2326E98
+        JP: 0x2328320
       description: |-
         Move effect: Boost the user's attack by one stage
         Relevant moves: Sharpen, Howl, Meditate
@@ -709,6 +734,7 @@ move_effects:
       address:
         EU: 0x2327A9C
         NA: 0x2327034
+        JP: 0x23284BC
       description: |-
         Move effect: Deal damage with a 20% chance (CRUNCH_LOWER_DEFENSE_CHANCE) of lowering the defender's defense.
         Relevant moves: Crunch, Shadow Ball via Nature Power
@@ -722,6 +748,7 @@ move_effects:
       address:
         EU: 0x2327B1C
         NA: 0x23270B4
+        JP: 0x232853C
       description: |-
         Move effect: Deal damage with a 20% chance (BITE_CRINGE_CHANCE) of inflicting the cringe status on the defender.
         Relevant moves: Bite, Needle Arm, Stomp, Rolling Kick
@@ -735,6 +762,7 @@ move_effects:
       address:
         EU: 0x2327B88
         NA: 0x2327120
+        JP: 0x23285A8
       description: |-
         Move effect: Deal damage with a 20% chance (THUNDER_PARALYZE_CHANCE) of paralyzing the defender.
         Relevant moves: Thunder, ThunderPunch, Force Palm, Discharge
@@ -774,6 +802,7 @@ move_effects:
       address:
         EU: 0x2327CF4
         NA: 0x232728C
+        JP: 0x2328714
       description: |-
         Move effect: Deal damage with a 20% chance (CONSTRICT_LOWER_SPEED_CHANCE) of lowering the defender's speed.
         Relevant moves: Constrict, Bubblebeam
@@ -814,6 +843,7 @@ move_effects:
       address:
         EU: 0x2327E34
         NA: 0x23273CC
+        JP: 0x2328854
       description: |-
         Move effect: Focus Punch
         
@@ -840,6 +870,7 @@ move_effects:
       address:
         EU: 0x2328000
         NA: 0x2327598
+        JP: 0x2328A20
       description: |-
         Move effect: Deal damage with a higher multiplier the lower the attacker's HP is.
         Relevant moves: Reversal, Flail
@@ -961,6 +992,7 @@ move_effects:
       address:
         EU: 0x2328350
         NA: 0x23278E8
+        JP: 0x2328D70
       description: |-
         Move effect: Synthesis
         
@@ -1014,6 +1046,7 @@ move_effects:
       address:
         EU: 0x232844C
         NA: 0x23279E4
+        JP: 0x2328E6C
       description: |-
         Move effect: Cosmic Power
         
@@ -1093,6 +1126,7 @@ move_effects:
       address:
         EU: 0x2328674
         NA: 0x2327C08
+        JP: 0x2329090
       description: |-
         Move effect: Deal damage with a 10% chance (PSYBEAM_CONFUSE_CHANCE) of confusing the defender.
         Relevant moves: Psybeam, Signal Beam, Confusion, Chatter, Rock Climb
@@ -1164,6 +1198,7 @@ move_effects:
       address:
         EU: 0x232884C
         NA: 0x2327DE0
+        JP: 0x2329268
       description: |-
         Move effect: Water Spout
         
@@ -1211,6 +1246,11 @@ move_effects:
           - 0x232A3D8
           - 0x232C500
           - 0x232E250
+        JP:
+          - 0x2329494
+          - 0x232B848
+          - 0x232D944
+          - 0x232F650
       description: "See overlay29.yml::EntityIsValid"
     - name: DoMoveRecoverHp
       address:
@@ -1243,6 +1283,7 @@ move_effects:
       address:
         EU: 0x2328B40
         NA: 0x23280D4
+        JP: 0x232955C
       description: |-
         Gets the nature power variant for the current dungeon, based on the tileset ID.
         
@@ -1264,6 +1305,7 @@ move_effects:
       address:
         EU: 0x2328BD8
         NA: 0x232816C
+        JP: 0x23295F4
       description: |-
         Move effect: Deal damage with a 10% chance (LICK_PARALZYE_CHANCE) of paralyzing the defender.
         Relevant moves: Lick, Spark, Body Slam, DragonBreath
@@ -1290,6 +1332,7 @@ move_effects:
       address:
         EU: 0x2328CB4
         NA: 0x2328248
+        JP: 0x23296D0
       description: |-
         Move effect: Shadow Ball
         
@@ -1315,6 +1358,7 @@ move_effects:
       address:
         EU: 0x2328D94
         NA: 0x2328328
+        JP: 0x23297B0
       description: |-
         Move effect: Thunderbolt
         
@@ -1353,6 +1397,7 @@ move_effects:
       address:
         EU: 0x2328F28
         NA: 0x23284BC
+        JP: 0x2329944
       description: |-
         Move effect: Deal damage with a 10% chance (EXTRASENSORY_CRINGE_CHANCE) to inflict the cringe status on the defender.
         Relevant moves: Extrasensory, Hyper Fang, Bone Club
@@ -1379,6 +1424,7 @@ move_effects:
       address:
         EU: 0x2328FA4
         NA: 0x2328538
+        JP: 0x23299C0
       description: |-
         Move effect: Absorb
         
@@ -1401,6 +1447,11 @@ move_effects:
           - 0x2329F14
           - 0x232BDD0
           - 0x232DE20
+        JP:
+          - 0x2329AB8
+          - 0x232B388
+          - 0x232D220
+          - 0x232F224
       description: "See overlay29.yml::DefenderAbilityIsActive"
     - name: DoMoveSkillSwap
       address:
@@ -1432,6 +1483,7 @@ move_effects:
       address:
         EU: 0x2329330
         NA: 0x23288C4
+        JP: 0x2329D44
       description: |-
         Move effect: Headbutt
         
@@ -1457,6 +1509,7 @@ move_effects:
       address:
         EU: 0x2329464
         NA: 0x23289F8
+        JP: 0x2329E78
       description: |-
         Move effect: Sandstorm
         
@@ -1469,6 +1522,7 @@ move_effects:
       address:
         EU: 0x23294C0
         NA: 0x2328A54
+        JP: 0x2329ED4
       description: |-
         Move effect: Lower the defender's accuracy by one stage
         Relevant moves: Sand-Attack, Kinesis, Flash
@@ -1482,6 +1536,7 @@ move_effects:
       address:
         EU: 0x23294E0
         NA: 0x2328A74
+        JP: 0x2329EF4
       description: |-
         Move effect: Deal damage with a 40% chance (SMOG_POISON_CHANCE) of poisoning the defender.
         Relevant moves: Smog, Cross Poison, Gunk Shot, Poison Jab
@@ -1495,6 +1550,7 @@ move_effects:
       address:
         EU: 0x232954C
         NA: 0x2328AE0
+        JP: 0x2329F60
       description: |-
         Move effect: Growth
         
@@ -1507,6 +1563,7 @@ move_effects:
       address:
         EU: 0x232956C
         NA: 0x2328B00
+        JP: 0x2329F80
       description: |-
         Move effect: Sacred Fire
         
@@ -1546,6 +1603,7 @@ move_effects:
       address:
         EU: 0x23297B0
         NA: 0x2328D44
+        JP: 0x232A1C4
       description: |-
         Move effect: SonicBoom
         
@@ -1597,6 +1655,7 @@ move_effects:
       address:
         EU: 0x2329A00
         NA: 0x2328F94
+        JP: 0x232A414
       description: |-
         Move effect: Waterfall
         
@@ -1609,6 +1668,7 @@ move_effects:
       address:
         EU: 0x2329A6C
         NA: 0x2329000
+        JP: 0x232A480
       description: |-
         Move effect: Deal damage with a 40% chance (MUDDY_WATER_LOWER_ACCURACY_CHANCE) of lowering the defender's accuracy.
         Relevant moves: Muddy Water, Mud Bomb, Mirror Shot
@@ -1675,6 +1735,7 @@ move_effects:
       address:
         EU: 0x2329CA8
         NA: 0x232923C
+        JP: 0x232A6BC
       description: |-
         Move effect: Minimize
         
@@ -1727,6 +1788,7 @@ move_effects:
       address:
         EU: 0x2329E64
         NA: 0x23293F8
+        JP: 0x232A878
       description: |-
         Move effect: Moonlight
         
@@ -1754,6 +1816,7 @@ move_effects:
       address:
         EU: 0x2329FA0
         NA: 0x2329534
+        JP: 0x232A9B4
       description: |-
         Move effect: Swords Dance
         
@@ -1805,6 +1868,7 @@ move_effects:
       address:
         EU: 0x232A144
         NA: 0x23296D8
+        JP: 0x232AB58
       description: |-
         Move effect: Boost the defender's defense stat by two stages
         Relevant moves: Iron Defense, Acid Armor, Barrier
@@ -1832,6 +1896,7 @@ move_effects:
       address:
         EU: 0x232A17C
         NA: 0x2329710
+        JP: 0x232AB90
       description: |-
         Move effect: Thundershock
         
@@ -1912,6 +1977,7 @@ move_effects:
       address:
         EU: 0x232A304
         NA: 0x2329898
+        JP: 0x232AD14
       description: |-
         Move effect: Poison Fang
         
@@ -1924,6 +1990,7 @@ move_effects:
       address:
         EU: 0x232A370
         NA: 0x2329904
+        JP: 0x232AD80
       description: |-
         Move effect: Deal damage with an 18% chance (POISON_STING_POISON_CHANCE) to poison the defender.
         Relevant moves: Poison Sting, Sludge, Sludge Bomb
@@ -2043,6 +2110,7 @@ move_effects:
       address:
         EU: 0x232AAB8
         NA: 0x232A04C
+        JP: 0x232B4BC
       description: |-
         Move effect: Deal damage and steal the defender's item if possible.
         Relevant moves: Thief, Covet
@@ -2056,6 +2124,7 @@ move_effects:
       address:
         EU: 0x232AAC4
         NA: 0x232A058
+        JP: 0x232B4C8
       description: |-
         Move effect: Amnesia
         
@@ -2081,6 +2150,7 @@ move_effects:
       address:
         EU: 0x232AB84
         NA: 0x232A118
+        JP: 0x232B588
       description: |-
         Move effect: Growl
         
@@ -2119,6 +2189,7 @@ move_effects:
       address:
         EU: 0x232AC8C
         NA: 0x232A220
+        JP: 0x232B690
       description: |-
         Move effect: Sunny Day
         
@@ -2131,6 +2202,7 @@ move_effects:
       address:
         EU: 0x232ACE8
         NA: 0x232A27C
+        JP: 0x232B6EC
       description: |-
         Move effect: Lower the defender's defense by one stage
         Relevant moves: Tail Whip, Leer
@@ -2157,6 +2229,7 @@ move_effects:
       address:
         EU: 0x232AD28
         NA: 0x232A2BC
+        JP: 0x232B72C
       description: |-
         Move effect: Fake Out
         
@@ -2169,6 +2242,7 @@ move_effects:
       address:
         EU: 0x232AD94
         NA: 0x232A328
+        JP: 0x232B798
       description: |-
         Move effect: Sleep Talk
         
@@ -2194,6 +2268,7 @@ move_effects:
       address:
         EU: 0x232AE68
         NA: 0x232A3FC
+        JP: 0x232B86C
       description: |-
         Move effect: Assist
         
@@ -2232,6 +2307,7 @@ move_effects:
       address:
         EU: 0x232AEFC
         NA: 0x232A490
+        JP: 0x232B900
       description: |-
         Move effect: Swallow
         
@@ -2270,6 +2346,7 @@ move_effects:
       address:
         EU: 0x232B018
         NA: 0x232A5AC
+        JP: 0x232BA1C
       description: |-
         Move effect: Steel Wing
         
@@ -2282,6 +2359,7 @@ move_effects:
       address:
         EU: 0x232B0AC
         NA: 0x232A640
+        JP: 0x232BAAC
       description: |-
         Move effect: Spit Up
         
@@ -2386,6 +2464,7 @@ move_effects:
       address:
         EU: 0x232B95C
         NA: 0x232AEF0
+        JP: 0x232C350
       description: |-
         Move effect: Deal damage with a 30% chance (DIZZY_PUNCH_CONFUSE_CHANCE) to confuse the defender.
         Relevant moves: Dizzy Punch, Water Pulse
@@ -2399,6 +2478,7 @@ move_effects:
       address:
         EU: 0x232B9C8
         NA: 0x232AF5C
+        JP: 0x232C3BC
       description: |-
         Move effect: Bulk Up
         
@@ -2425,6 +2505,7 @@ move_effects:
       address:
         EU: 0x232BA5C
         NA: 0x232AFF0
+        JP: 0x232C450
       description: |-
         Move effect: FeatherDance
         
@@ -2463,6 +2544,7 @@ move_effects:
       address:
         EU: 0x232BBD0
         NA: 0x232B164
+        JP: 0x232C5C4
       description: |-
         Move effect: Crush Claw
         
@@ -2475,6 +2557,7 @@ move_effects:
       address:
         EU: 0x232BC50
         NA: 0x232B1E4
+        JP: 0x232C644
       description: |-
         Move effect: Blaze Kick
         
@@ -2526,6 +2609,7 @@ move_effects:
       address:
         EU: 0x232BF00
         NA: 0x232B494
+        JP: 0x232C8F4
       description: |-
         Move effect: Poison Tail
         
@@ -2565,6 +2649,7 @@ move_effects:
       address:
         EU: 0x232C034
         NA: 0x232B5C8
+        JP: 0x232CA24
       description: |-
         Move effect: Tail Glow
         
@@ -2591,6 +2676,7 @@ move_effects:
       address:
         EU: 0x232C110
         NA: 0x232B6A4
+        JP: 0x232CB00
       description: |-
         Move effect: Perish Song
         
@@ -2616,6 +2702,7 @@ move_effects:
       address:
         EU: 0x232C134
         NA: 0x232B6C8
+        JP: 0x232CB24
       description: |-
         Move effect: Spikes
         
@@ -2668,6 +2755,7 @@ move_effects:
       address:
         EU: 0x232C24C
         NA: 0x232B7E0
+        JP: 0x232CC2C
       description: |-
         Move effect: Defense Curl
         
@@ -2694,6 +2782,7 @@ move_effects:
       address:
         EU: 0x232C28C
         NA: 0x232B820
+        JP: 0x232CC6C
       description: |-
         Move effect: Mist Ball
         
@@ -2732,6 +2821,7 @@ move_effects:
       address:
         EU: 0x232C350
         NA: 0x232B8E4
+        JP: 0x232CD30
       description: |-
         Move effect: Calm Mind
         
@@ -2759,6 +2849,7 @@ move_effects:
       address:
         EU: 0x232C3AC
         NA: 0x232B940
+        JP: 0x232CD8C
       description: |-
         Move effect: Metal Claw
         
@@ -2840,6 +2931,7 @@ move_effects:
       address:
         EU: 0x232C734
         NA: 0x232BCC4
+        JP: 0x232D118
       description: |-
         Move effect: Dream Eater
         
@@ -2891,6 +2983,7 @@ move_effects:
       address:
         EU: 0x232C9F8
         NA: 0x232BF88
+        JP: 0x232D3D4
       description: |-
         Move effect: Dragon Rage
         
@@ -3009,6 +3102,7 @@ move_effects:
       address:
         EU: 0x232CFA8
         NA: 0x232C538
+        JP: 0x232D97C
       description: |-
         Move effect: Switches the user's position with positions of other monsters in the room.
         Relevant moves: Baton Pass, Switcher (item effect)
@@ -3048,6 +3142,7 @@ move_effects:
       address:
         EU: 0x232D124
         NA: 0x232C6B4
+        JP: 0x232DAFC
       description: |-
         Move effect: Siesta (item effect)
         
@@ -3297,6 +3392,7 @@ move_effects:
       address:
         EU: 0x232D8EC
         NA: 0x232CE7C
+        JP: 0x232E2C4
       description: |-
         Move effect: Reviver (item effect)
         
@@ -3544,6 +3640,7 @@ move_effects:
       address:
         EU: 0x232DDE8
         NA: 0x232D378
+        JP: 0x232E7BC
       description: |-
         Move effect: Guard Swap
         
@@ -3726,6 +3823,7 @@ move_effects:
       address:
         EU: 0x232E37C
         NA: 0x232D90C
+        JP: 0x232ED50
       description: |-
         Move effect: Stealth Rock
         
@@ -3751,6 +3849,7 @@ move_effects:
       address:
         EU: 0x232E454
         NA: 0x232D9E4
+        JP: 0x232EE18
       description: |-
         Move effect: Deals damage, and eats any beneficial items the defender is holding.
         Relevant moves: Pluck, Bug Bite
@@ -3790,6 +3889,7 @@ move_effects:
       address:
         EU: 0x232E6A4
         NA: 0x232DC64
+        JP: 0x232F07C
       description: |-
         Move effect: Toxic Spikes
         
@@ -3828,6 +3928,7 @@ move_effects:
       address:
         EU: 0x232E7EC
         NA: 0x232DDAC
+        JP: 0x232F1B4
       description: |-
         Move effect: Worry Seed
         
@@ -3880,6 +3981,7 @@ move_effects:
       address:
         EU: 0x232EAC4
         NA: 0x232E084
+        JP: 0x232F484
       description: |-
         Move effect: Power Swap
         
@@ -3931,6 +4033,7 @@ move_effects:
       address:
         EU: 0x232ECB4
         NA: 0x232E274
+        JP: 0x232F674
       description: |-
         Move effect: Defend Order
         
@@ -4076,6 +4179,7 @@ move_effects:
       address:
         EU: 0x232F154
         NA: 0x232E714
+        JP: 0x232FB10
       description: |-
         Move effect: Nasty Plot
         
@@ -4088,6 +4192,7 @@ move_effects:
       address:
         EU: 0x232F174
         NA: 0x232E734
+        JP: 0x232FB30
       description: |-
         Move effect: MOVE_TAG_0x1AB
         

--- a/symbols/overlay30.yml
+++ b/symbols/overlay30.yml
@@ -17,7 +17,7 @@ overlay30:
       address:
         EU: 0x2383868
         NA: 0x2382C68
-        JP: 0x2383EDC
+        JP: 0x2383ED8
       description: |-
         Function responsible for writing dungeon data when quicksaving.
         

--- a/symbols/overlay31.yml
+++ b/symbols/overlay31.yml
@@ -592,7 +592,7 @@ overlay31:
       address:
         EU: 0x238AE80
         NA: 0x238A260
-        JP: 0x238B528
+        JP: 0x238B520
       length:
         NA: 0x4
         JP: 0x4
@@ -600,7 +600,7 @@ overlay31:
     - name: OVERLAY31_UNKNOWN_VALUE__NA_238A264
       address:
         NA: 0x238A264
-        JP: 0x238B52C
+        JP: 0x238B524
       length:
         NA: 0x4
         JP: 0x4
@@ -609,7 +609,7 @@ overlay31:
       address:
         EU: 0x238AE88
         NA: 0x238A268
-        JP: 0x238B530
+        JP: 0x238B528
       length:
         NA: 0x4
         JP: 0x4
@@ -618,7 +618,7 @@ overlay31:
       address:
         EU: 0x238AE8C
         NA: 0x238A26C
-        JP: 0x238B534
+        JP: 0x238B52C
       length:
         NA: 0x4
         JP: 0x4
@@ -627,7 +627,7 @@ overlay31:
       address:
         EU: 0x238AE90
         NA: 0x238A270
-        JP: 0x238B538
+        JP: 0x238B530
       length:
         NA: 0x4
         JP: 0x4

--- a/symbols/overlay34.yml
+++ b/symbols/overlay34.yml
@@ -20,6 +20,7 @@ overlay34:
       address:
         EU: 0x22DCB80
         NA: 0x22DC240
+        JP: 0x22DD8E0
       description: |-
         The main function for Explorers of Sky.
         
@@ -32,6 +33,7 @@ overlay34:
       address:
         EU: 0x22DD8BC
         NA: 0x22DD014
+        JP: 0x22DE618
       length:
         NA: 0x10
       description: |-
@@ -42,7 +44,7 @@ overlay34:
       address:
         EU: 0x22DD8CC
         NA: 0x22DD024
-        JP: 0x22DE62C
+        JP: 0x22DE628
       length:
         EU: 0x18
         NA: 0x18
@@ -51,6 +53,7 @@ overlay34:
       address:
         EU: 0x22DD8E4
         NA: 0x22DD03C
+        JP: 0x22DE640
       length:
         NA: 0x10
       description: |-
@@ -61,7 +64,7 @@ overlay34:
       address:
         EU: 0x22DD8F4
         NA: 0x22DD04C
-        JP: 0x22DE654
+        JP: 0x22DE650
       length:
         EU: 0x28
         NA: 0x28
@@ -76,6 +79,7 @@ overlay34:
       address:
         EU: 0x22DD920
         NA: 0x22DD080
+        JP: 0x22DE680
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -83,6 +87,7 @@ overlay34:
       address:
         EU: 0x22DD924
         NA: 0x22DD084
+        JP: 0x22DE684
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"
@@ -96,6 +101,7 @@ overlay34:
       address:
         EU: 0x22DD92C
         NA: 0x22DD08C
+        JP: 0x22DE68C
       length:
         NA: 0x4
       description: "Note: unverified, ported from Irdkwia's notes"

--- a/symbols/ram.yml
+++ b/symbols/ram.yml
@@ -475,10 +475,12 @@ ram:
       address:
         EU: 0x22B7C70
         NA: 0x22B7330
+        JP: 0x22B8AE8
     - name: DISP_MODE
       address:
         EU: 0x22B9EC8
         NA: 0x22B9588
+        JP: 0x22BAD40
       length:
         EU: 0x2
         NA: 0x2
@@ -486,6 +488,7 @@ ram:
       address:
         EU: 0x22B9ECA
         NA: 0x22B958A
+        JP: 0x22BAD42
       length:
         EU: 0x2
         NA: 0x2
@@ -493,6 +496,7 @@ ram:
       address:
         EU: 0x22B9ECC
         NA: 0x22B958C
+        JP: 0x22BAD44
       length:
         EU: 0x2
         NA: 0x2
@@ -504,6 +508,7 @@ ram:
       address:
         EU: 0x22B9EE8
         NA: 0x22B95A8
+        JP: 0x22BAD60
       length:
         EU: 0x4
         NA: 0x4
@@ -511,6 +516,7 @@ ram:
       address:
         EU: 0x22B9F04
         NA: 0x22B95C4
+        JP: 0x22BAD7C
       length:
         EU: 0x4
         NA: 0x4


### PR DESCRIPTION
The decomp now produces a matching JP build, which allows determining all JP symbol addresses in the ROM.