### PR TITLE
Clarify monster weight value

### DIFF
--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -914,7 +914,7 @@ enum mobility_type GetMobilityType(enum monster_id monster_id);
 int GetRegenSpeed(enum monster_id monster_id);
 bool GetCanMoveFlag(enum monster_id monster_id);
 int GetChanceAsleep(enum monster_id monster_id);
-fx32_8 GetLowKickMultiplier(enum monster_id monster_id);
+fx32_8 GetWeightMultiplier(enum monster_id monster_id);
 int GetSize(enum monster_id monster_id);
 int GetBaseHp(enum monster_id monster_id);
 bool CanThrowItems(enum monster_id monster_id);

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -8739,16 +8739,18 @@ arm9:
         
         r0: id
         return: chance asleep
-    - name: GetLowKickMultiplier
+    - name: GetWeightMultiplier
+      aliases:
+        - GetLowKickMultiplier
       address:
         EU: 0x2052C34
         NA: 0x20528FC
         JP: 0x2052C34
       description: |-
-        Gets the Low Kick (and Grass Knot) damage multiplier (i.e., weight) for the given species.
+        Gets the weight multiplier value for the given species. This value is passed as the damage_mult_fp parameter to DealDamage when calculating the damage dealt by Low Kick and Grass Knot.
         
         r0: monster ID
-        return: multiplier as a binary fixed-point number with 8 fraction bits.
+        return: Monster weight multiplier, as a binary fixed-point number with 8 fraction bits.
     - name: GetSize
       address:
         EU: 0x2052C50


### PR DESCRIPTION
Renames `GetLowKickMultiplier` to `GetWeightMultiplier` so it's a bit more consistent with the name that is usually given to this field in monster data ("weight").

I had no idea this value was a fixed-point number. Everyone has been treating it as an integer so far.