### PR TITLE
Add dungeon sprite buffer size

### DIFF
--- a/headers/data/literals.h
+++ b/headers/data/literals.h
@@ -13,6 +13,7 @@ extern const struct data_processing_instruction TOP_MENU_MUSIC_ID;
 
 // Overlay 29
 extern const struct data_processing_instruction NECTAR_IQ_BOOST;
+extern const struct data_processing_instruction COMPRESSED_SPRITE_BUFFER_SIZE;
 
 // Overlay 9
 extern const struct data_processing_instruction TOP_MENU_RETURN_MUSIC_ID;

--- a/headers/data/overlay29.h
+++ b/headers/data/overlay29.h
@@ -9,6 +9,7 @@ extern uint32_t OFFSET_OF_DUNGEON_FLOOR_PROPERTIES;
 extern int32_t SPAWN_RAND_MAX;
 extern uint32_t DUNGEON_PRNG_LCG_MULTIPLIER;
 extern uint32_t DUNGEON_PRNG_LCG_INCREMENT_SECONDARY;
+extern int32_t ATTACK_SPRITE_BUFFER_SIZE;
 extern enum monster_id KECLEON_FEMALE_ID;
 extern enum monster_id KECLEON_MALE_ID;
 extern int32_t MSG_ID_SLOW_START;

--- a/symbols/literals.yml
+++ b/symbols/literals.yml
@@ -121,6 +121,12 @@ overlay29:
         NA: 0x231C384
         JP: 0x231D850
       description: IQ boost from ingesting Nectar.
+    - name: COMPRESSED_SPRITE_BUFFER_SIZE
+      address:
+        EU: 0x234CB6C
+        NA: 0x234BF6C
+        JP: 0x234D1D0
+      description: Size of the buffer to store the current sprite to decompress.
 overlay34:
   versions:
     - EU

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -8569,6 +8569,16 @@ overlay29:
         EU: 0x4
         NA: 0x4
       description: "The increment for the dungeon PRNG's secondary LCGs, 2531011 (0x269EC3). This happens to be the same increment that the Microsoft Visual C++ runtime library uses in its implementation of the rand() function."
+    - name: ATTACK_SPRITE_BUFFER_SIZE
+      address:
+        EU: 0x22F7890
+        NA: 0x22F6ED8
+        JP: 0x22F84A8
+      length:
+        EU: 0x4
+        NA: 0x4
+        JP: 0x4
+      description: "Size of the buffer used to store the current attack sprite file."
     - name: KECLEON_FEMALE_ID
       address:
         EU: 0x22F7DBC

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -8578,7 +8578,7 @@ overlay29:
         EU: 0x4
         NA: 0x4
         JP: 0x4
-      description: "Size of the buffer used to store the current attack sprite file."
+      description: Size of the buffer used to store the current attack sprite file.
     - name: KECLEON_FEMALE_ID
       address:
         EU: 0x22F7DBC


### PR DESCRIPTION
Adds two symbols related to dungeon sprite buffer size, which controls how many bytes are used in the main heap to store sprite file data in dungeon mode.