### PR TITLE
Sync entity pixel pos funcs from decomp

### DIFF
--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -24,6 +24,8 @@ struct trap* GetTrapInfo(struct entity* trap_entity);
 struct item* GetItemInfo(struct entity* item_entity);
 struct tile* GetTileAtEntity(struct entity* entity);
 void UpdateEntityPixelPos(struct entity* entity, struct pixel_position* pixel_pos);
+void SetEntityPixelPosXY(struct entity* entity, uint32_t x, uint32_t y);
+void IncrementEntityPixelPosXY(struct entity* entity, uint32_t x, uint32_t y);
 struct entity* CreateEnemyEntity(enum monster_id monster_id);
 struct entity* SpawnTrap(enum trap_id trap_id, struct position* position, uint8_t team,
                          uint8_t flags);

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -4807,6 +4807,8 @@ arm9:
     - name: GetRankString
       address:
         EU: 0x2024D88
+        NA: 0x2024AF4
+        JP: 0x2024B44
       description: |-
         Gets the string corresponding to the player's current explorer rank.
         
@@ -5223,6 +5225,8 @@ arm9:
     - name: PrintBadgeMark
       address:
         EU: 0x202A728
+        NA: 0x202A434
+        JP: 0x202A78C
       description: |-
         Prints the specified badge mark on the screen.
         
@@ -5235,6 +5239,8 @@ arm9:
     - name: PrintMark
       address:
         EU: 0x202A750
+        NA: 0x202A45C
+        JP: 0x202A7B4
       description: |-
         Prints a mark from one of the .w16 files in FONT.
         

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -381,6 +381,24 @@ overlay29:
         
         r0: Entity pointer
         r1: Pixel position to use, or null to use the entity's own position
+    - name: SetEntityPixelPosXY
+      address:
+        EU: 0x22E23C4
+        NA: 0x22E1A84
+        JP: 0x22E3114
+      description: |-
+        r0: Entity pointer
+        r1: x
+        r2: y
+    - name: IncrementEntityPixelPosXY
+      address:
+        EU: 0x22E23D0
+        NA: 0x22E1A90
+        JP: 0x22E3120
+      description: |-
+        r0: Entity pointer
+        r1: x
+        r2: y
     - name: CreateEnemyEntity
       address:
         EU: 0x22E2A00


### PR DESCRIPTION
New functions were labeled in the decomp by chordtoll.

Also filled in region addresses for the new badge/rank symbols.