### PR TITLE
Add a few functions previously documented only in CoT

### DIFF
--- a/headers/functions/arm9.h
+++ b/headers/functions/arm9.h
@@ -715,7 +715,8 @@ void InitInventoryMenuInput(struct inventory_menu_input_ctx* input_ctx, struct w
                             struct window_extra_info* window_extra_info,
                             struct window_rectangle* rect, int n_items, int n_items_per_page,
                             undefined param_7);
-int ShowKeyboard(int string_id, char* buffer1, int param_3, char* buffer2);
+int SetupAndShowKeyboard(int menu_type, char* buffer1, char* buffer2);
+int ShowKeyboard(int menu_type, char* buffer1, int param_3, char* buffer2);
 int GetKeyboardStatus(void);
 int GetKeyboardStringResult(void);
 char* TeamSelectionMenuGetItem(char* buffer, int member_idx);
@@ -954,6 +955,7 @@ int GetFamilyIndex(enum monster_id monster_id);
 void LoadM2nAndN2m(void);
 void GuestMonsterToGroundMonster(struct ground_monster* ground_monster,
                                  struct guest_monster* guest_monster);
+void SetBaseStatsMovesGroundMonster(struct ground_monster* ground_monster);
 bool StrcmpMonsterName(char* string, enum monster_id monster_id);
 void GetLvlUpEntry(struct level_up_entry* level_up_entry, enum monster_id monster_id, int level);
 uint8_t* GetEncodedHalfword(uint8_t* data_ptr, uint16_t* result);
@@ -971,6 +973,7 @@ void SetMonsterId(struct monster_spawn_entry* monster_spawn, enum monster_id mon
 void SetMonsterLevelAndId(struct monster_spawn_entry* monster_spawn, int level,
                           enum monster_id monster_id);
 uint8_t GetMonsterLevelFromSpawnEntry(struct monster_spawn_entry* entry);
+void ApplyLevelUpBoostsToGroundMonster(struct ground_monster* ground_monster, int level, bool flag);
 enum monster_gender GetMonsterGenderVeneer(enum monster_id monster_id);
 bool IsMonsterValid(enum monster_id monster_id);
 bool IsUnown(enum monster_id monster_id);

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -11,7 +11,7 @@ void FuncThatCallsRunNextOpcode(struct script_routine* routine);
 int16_t RunNextOpcode(struct script_routine* routine);
 char* GetSsbString(struct ssb_runtime_info* ssb_info, int idx);
 void HandleUnlocks(void);
-uint16_t* ScriptCaseProcess(struct script_routine* routine, int case);
+uint16_t* ScriptCaseProcess(struct script_routine* routine, int case_id);
 void LoadFileFromRomVeneer(struct iovec* iov, const char* filepath, uint32_t flags);
 void SsbLoad2(void);
 int16_t ScriptParamToInt(uint16_t parameter);

--- a/headers/functions/overlay11.h
+++ b/headers/functions/overlay11.h
@@ -11,6 +11,7 @@ void FuncThatCallsRunNextOpcode(struct script_routine* routine);
 int16_t RunNextOpcode(struct script_routine* routine);
 char* GetSsbString(struct ssb_runtime_info* ssb_info, int idx);
 void HandleUnlocks(void);
+uint16_t* ScriptCaseProcess(struct script_routine* routine, int case);
 void LoadFileFromRomVeneer(struct iovec* iov, const char* filepath, uint32_t flags);
 void SsbLoad2(void);
 int16_t ScriptParamToInt(uint16_t parameter);

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -6735,6 +6735,18 @@ arm9:
         stack[0]: total number of selectable items
         stack[1]: number of selectable items per page
         stack[2]: ?
+    - name: SetupAndShowKeyboard
+      address:
+        EU: 0x2036AA8
+        NA: 0x20367B4
+        JP: 0x2036ACC
+      description: |-
+        Calls a function that seems to sets up info for the keyboard menu before ending with a call to ShowKeyboard.
+        
+        r0: menu type
+        r1: buffer1
+        r2: buffer2
+        return: ?
     - name: ShowKeyboard
       address:
         EU: 0x2036AE4
@@ -6743,7 +6755,7 @@ arm9:
       description: |-
         Note: unverified, ported from Irdkwia's notes
         
-        r0: string ID
+        r0: menu type
         r1: buffer1
         r2: ???
         r3: buffer2
@@ -9132,6 +9144,15 @@ arm9:
         
         r0: [output] ground_monster struct to init
         r1: guest_monster struct to use
+    - name: SetBaseStatsMovesGroundMonster
+      address:
+        EU: 0x2053278
+        NA: 0x2052EFC
+        JP: 0x2053234
+      description: |-
+        Sets a ground monster to have the base stats and Level 1 moves of its species, along with 1 IQ.
+        
+        r0: ground monster pointer
     - name: StrcmpMonsterName
       address:
         EU: 0x205332C
@@ -9299,6 +9320,17 @@ arm9:
         
         r0: pointer to the monster spawn entry
         return: uint8_t
+    - name: ApplyLevelUpBoostsToGroundMonster
+      address:
+        EU: 0x2054844
+        NA: 0x20544C8
+        JP: 0x2054800
+      description: |-
+        Applies the level up boosts to stats and moves (until moveset is full) to a target monster.
+        
+        r0: ground monster pointer
+        r1: level
+        r2: flag that enables further editing of the monster
     - name: GetMonsterGenderVeneer
       address:
         EU: 0x2054ADC

--- a/symbols/arm9.yml
+++ b/symbols/arm9.yml
@@ -6741,7 +6741,7 @@ arm9:
         NA: 0x20367B4
         JP: 0x2036ACC
       description: |-
-        Calls a function that seems to sets up info for the keyboard menu before ending with a call to ShowKeyboard.
+        Calls a function that seems to set up info for the keyboard menu before ending with a call to ShowKeyboard.
         
         r0: menu type
         r1: buffer1

--- a/symbols/overlay11.yml
+++ b/symbols/overlay11.yml
@@ -111,6 +111,17 @@ overlay11:
         If the global unlock flag is not set, returns immediately. If it is, the function loops LOCK_NOTIFY_ARRAY, checking for true values. If it finds one, resets it back to 0 and handles the unlock.
         
         No params.
+    - name: ScriptCaseProcess
+      address:
+        EU: 0x22E4D28
+        NA: 0x22E43E8
+        JP: 0x22E5A14
+      description: |-
+        Calculates the next opcode address for a script routine as the result of a switch-statement.
+        
+        r0: script routine pointer
+        r1: case id
+        return: Next opcode address for the routine to execute
     - name: LoadFileFromRomVeneer
       address:
         EU: 0x22E501C


### PR DESCRIPTION
Adds a few functions that were [only documented in CoT](https://github.com/SkyTemple/c-of-time/blob/8a1af65e4fc8d672ce458e690ab42b88c738403b/src/menus.c#L9-L13), mainly to then follow up by editing CoT to rely on the pmdsky-debug names.
~~`ScriptCaseProcess` isn't yet in CoT, but I was planning on using it for adding more custom ground instruction support, so why not get it out of the way now~~