### PR TITLE
Use signed char for int8_t

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - check-headers
       - check-symbol-header-sync
     env:
-      RELEASE_VERSION: '0.10.0'
+      RELEASE_VERSION: '0.10.1'
       OUTPUT_DIR: out
       RELEASE_INSTALL_DIR: release-install
       RELEASE_ASSETS_DIR: release-assets

--- a/headers/pmdsky.h
+++ b/headers/pmdsky.h
@@ -43,7 +43,7 @@ typedef unsigned char uint8_t;
 typedef unsigned short uint16_t;
 typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef char int8_t;
+typedef signed char int8_t;
 typedef short int16_t;
 typedef int int32_t;
 typedef long long int64_t;


### PR DESCRIPTION
The char type is special in that the C spec allows it to be either signed or unsigned depending on the target platform. Explicitly use signed char to defined int8_t instead, for portability.

See https://www.open-std.org/JTC1/SC22/WG14/www/docs/n1256.pdf, section 6.2.5/15