### PR TITLE
Correct input of CreateMonsterSummaryFromEntity

### DIFF
--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -200,8 +200,8 @@ void EuFaintCheck(bool non_team_member_fainted, bool set_unk_byte);
 void HandleFaint(struct entity* fainted_entity, union damage_source damage_source,
                  struct entity* killer);
 void MoveMonsterToPos(struct entity* entity, int x_pos, int y_pos, undefined param_4);
-void CreateMonsterSummaryFromMonster(struct monster_summary* monster_summary,
-                                     struct monster* monster);
+void CreateMonsterSummaryFromEntity(struct monster_summary* monster_summary,
+                                    struct entity* monster_entity);
 void UpdateAiTargetPos(struct entity* monster);
 void SetMonsterTypeAndAbility(struct entity* target);
 void TryActivateSlowStart(void);

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -2191,7 +2191,9 @@ overlay29:
         r1: X target position
         r2: Y target position
         r3: ?
-    - name: CreateMonsterSummaryFromMonster
+    - name: CreateMonsterSummaryFromEntity
+      aliases:
+        - CreateMonsterSummaryFromMonster
       address:
         EU: 0x22F93D8
         NA: 0x22F89CC
@@ -2200,7 +2202,7 @@ overlay29:
         Creates a snapshot of the condition of a monster struct in a monster_summary struct.
         
         r0: [output] monster_summary
-        r1: monster
+        r1: monster_entity
     - name: UpdateAiTargetPos
       address:
         EU: 0x22F9B50


### PR DESCRIPTION
While the function is only intended to be used on monsters, it takes an entity pointer as input, and the function handles getting the monster struct.