### PR TITLE
Two-Turn Invincibility Symbol

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -37,6 +37,7 @@ other parts of the project, feel free to add yourself to this file!
 - happylappy
 - Chesyon
 - Xaklor
+- Caitemis
 - The rest of the contributors to Project Pokémon's technical documentation
   for the NDS Mystery Dungeon games, which can be found here:
   https://projectpokemon.org/home/docs/mystery-dungeon-nds/

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -620,7 +620,7 @@ bool TryInflictEmbargoStatus(struct entity* user, struct entity* target, bool lo
 bool TryInflictMiracleEyeStatus(struct entity* user, struct entity* target, bool check_only);
 void TryInflictMagnetRiseStatus(struct entity* user, struct entity* target);
 bool IsFloating(struct entity* entity);
-void SetTwoTurnInvincibility(struct entity* defender, enum two_turn_invincibility);
+void SetTwoTurnInvincibility(struct entity* target, enum two_turn_invincibility);
 void SetReflectStatus(struct entity* user, struct entity* target, enum status_reflect_id status);
 void TryInflictSafeguardStatus(struct entity* user, struct entity* target);
 void TryInflictMistStatus(struct entity* user, struct entity* target);

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -620,6 +620,7 @@ bool TryInflictEmbargoStatus(struct entity* user, struct entity* target, bool lo
 bool TryInflictMiracleEyeStatus(struct entity* user, struct entity* target, bool check_only);
 void TryInflictMagnetRiseStatus(struct entity* user, struct entity* target);
 bool IsFloating(struct entity* entity);
+void SetTwoTurnInvincibility(struct entity* defender, enum two_turn_invincibility);
 void SetReflectStatus(struct entity* user, struct entity* target, enum status_reflect_id status);
 void TryInflictSafeguardStatus(struct entity* user, struct entity* target);
 void TryInflictMistStatus(struct entity* user, struct entity* target);

--- a/headers/functions/overlay29.h
+++ b/headers/functions/overlay29.h
@@ -620,7 +620,7 @@ bool TryInflictEmbargoStatus(struct entity* user, struct entity* target, bool lo
 bool TryInflictMiracleEyeStatus(struct entity* user, struct entity* target, bool check_only);
 void TryInflictMagnetRiseStatus(struct entity* user, struct entity* target);
 bool IsFloating(struct entity* entity);
-void SetTwoTurnInvincibility(struct entity* target, enum two_turn_invincibility);
+void SetTwoTurnInvincibility(struct entity* target, enum two_turn_invincibility value);
 void SetReflectStatus(struct entity* user, struct entity* target, enum status_reflect_id status);
 void TryInflictSafeguardStatus(struct entity* user, struct entity* target);
 void TryInflictMistStatus(struct entity* user, struct entity* target);

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -1480,4 +1480,14 @@ enum damage_visual {
 ENUM_8_BIT(damage_visual);
 #pragma pack(pop)
 
+enum two_turn_invincibility {
+    TWO_TURN_NONE = 0,
+    TWO_TURN_FLYING = 1, // For Fly, Bounce, Seismic Toss
+    TWO_TURN_OTHER = 2, // For other two-turn invincibility moves (Shadow Force, Dig, etc.)
+};
+
+#pragma pack(push, 1)
+ENUM_8_BIT(two_turn_invincibility);
+#pragma pack(pop)
+
 #endif

--- a/headers/types/dungeon_mode/enums.h
+++ b/headers/types/dungeon_mode/enums.h
@@ -1480,10 +1480,11 @@ enum damage_visual {
 ENUM_8_BIT(damage_visual);
 #pragma pack(pop)
 
+// Two-turn invincibility status and visuals
 enum two_turn_invincibility {
     TWO_TURN_NONE = 0,
     TWO_TURN_FLYING = 1, // For Fly, Bounce, Seismic Toss
-    TWO_TURN_OTHER = 2, // For other two-turn invincibility moves (Shadow Force, Dig, etc.)
+    TWO_TURN_OTHER = 2,  // For other two-turn invincibility moves (Shadow Force, Dig, etc.)
 };
 
 #pragma pack(push, 1)

--- a/symbols/overlay29.yml
+++ b/symbols/overlay29.yml
@@ -6147,6 +6147,16 @@ overlay29:
         
         r0: entity pointer
         return: bool
+    - name: SetTwoTurnInvincibility
+      address:
+        NA: 0x2318A90
+      description: |-
+        Sets two-turn invincibility to a specified value on a target monster entity.
+        
+        Used for the "flying up/down" effects (similar to Fly/Bounce) in Seismic Toss' animation.
+        
+        r0: target entity pointer
+        r1: two_turn_move_invincible value
     - name: SetReflectStatus
       address:
         EU: 0x23197F8


### PR DESCRIPTION
Documented the function at 2318A90 which turned out to set two-turn invincibility specifically in the Seismic Toss animation.