### PR TITLE
LICK_PARALYZE_CHANCE Corrections

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - check-headers
       - check-symbol-header-sync
     env:
-      RELEASE_VERSION: '0.10.4'
+      RELEASE_VERSION: '0.10.5'
       OUTPUT_DIR: out
       RELEASE_INSTALL_DIR: release-install
       RELEASE_ASSETS_DIR: release-assets

--- a/headers/functions/overlay29/move_effects.h
+++ b/headers/functions/overlay29/move_effects.h
@@ -188,7 +188,7 @@ bool DoMoveEarthquake(struct entity* attacker, struct entity* defender, struct m
 enum nature_power_variant GetNaturePowerVariant(void);
 bool DoMoveNaturePower(struct entity* attacker, struct entity* defender, struct move* move,
                        enum item_id item_id);
-bool DoMoveDamageParalyze10(struct entity* attacker, struct entity* defender, struct move* move,
+bool DoMoveDamageParalyze15(struct entity* attacker, struct entity* defender, struct move* move,
                             enum item_id item_id);
 bool DoMoveSelfdestruct(struct entity* attacker, struct entity* defender, struct move* move,
                         enum item_id item_id);

--- a/symbols/overlay10.yml
+++ b/symbols/overlay10.yml
@@ -918,7 +918,7 @@ overlay10:
         EU: 0x2
         NA: 0x2
         JP: 0x2
-      description: "The chance of Lick (and others, see DoMoveDamageParalyze10) paralyzing, as a percentage (10%)."
+      description: "The chance of Lick (and others, see DoMoveDamageParalyze15) paralyzing, as a percentage (15%)."
     - name: THUNDER_FANG_PARALYZE_CHANCE
       address:
         EU: 0x22C4E84

--- a/symbols/overlay29/move_effects.yml
+++ b/symbols/overlay29/move_effects.yml
@@ -1301,13 +1301,13 @@ move_effects:
         r2: move (unused)
         r3: item ID
         return: whether the move was successfully used
-    - name: DoMoveDamageParalyze10
+    - name: DoMoveDamageParalyze15
       address:
         EU: 0x2328BD8
         NA: 0x232816C
         JP: 0x23295F4
       description: |-
-        Move effect: Deal damage with a 10% chance (LICK_PARALZYE_CHANCE) of paralyzing the defender.
+        Move effect: Deal damage with a 15% chance (LICK_PARALZYE_CHANCE) of paralyzing the defender.
         Relevant moves: Lick, Spark, Body Slam, DragonBreath
         
         r0: attacker pointer

--- a/symbols/overlay29/move_effects.yml
+++ b/symbols/overlay29/move_effects.yml
@@ -1900,8 +1900,6 @@ move_effects:
       description: |-
         Move effect: Thundershock
         
-        This is identical to DoMoveDamageParalyze10, except it uses a different data symbol for the paralysis chance (but it's still 10%).
-        
         r0: attacker pointer
         r1: defender pointer
         r2: move


### PR DESCRIPTION
Changed LICK_PARALYZE_CHANCE's description to reflect its actual value of 15%, as well as edited the description and name of DoMoveDamageParalyze10 (now DoMoveDamageParalyze15) to match.